### PR TITLE
Enable CI testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+export PYTHONPATH := $(PYTHONPATH):$(shell pwd)
+
 define target_success
 	@printf "\033[32m==> Target \"$(1)\" passed\033[0m\n\n"
 endef

--- a/sbomnix/nix.py
+++ b/sbomnix/nix.py
@@ -106,7 +106,19 @@ class Store:
                     )
                     if p.get("deriver") is not None
                     else None,
-                    json.loads(exec_cmd(["nix", "path-info", "-r", "--json", output])),
+                    json.loads(
+                        exec_cmd(
+                            [
+                                "nix",
+                                "--extra-experimental-features",
+                                "nix-command",
+                                "path-info",
+                                "-r",
+                                "--json",
+                                output,
+                            ]
+                        )
+                    ),
                 ):
                     if candidate is not None:
                         self._update(candidate)


### PR DESCRIPTION
This change, together with the previous commit: b0160de428522efd8b4c96b6c99a18bbdd053976 enable CI testing with travis.

Signed-off-by: Henri Rosten <henri.rosten@unikie.com>