### PR TITLE
nixgraph: command line argument to draw inverse graphs

### DIFF
--- a/.github/workflows/test_sbomnix.yml
+++ b/.github/workflows/test_sbomnix.yml
@@ -8,12 +8,16 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: ts-graphviz/setup-graphviz@v1
       - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@
 
 language: python
 dist: focal
+addons:
+  apt:
+    packages:
+      - graphviz
 python:
   - 3.8
 install:

--- a/nixgraph/main.py
+++ b/nixgraph/main.py
@@ -38,11 +38,20 @@ def getargs():
     parser.add_argument("--depth", help=helps, type=check_positive, default=1)
 
     helps = (
+        "Draw inverse graph starting from nodes that match the specified "
+        "regular expression"
+    )
+    parser.add_argument("--inverse", help=helps)
+
+    helps = (
         "Set the output file name, default is 'graph.png'. "
         "The output filename extension determines the output format. "
         "Common supported formats include: png, jpg, pdf, and dot. "
         "For a full list of supported output formats, see: "
-        "https://graphviz.org/doc/info/output.html."
+        "https://graphviz.org/doc/info/output.html. In addition to graphviz "
+        "supported output formats, the tool supports output in csv to "
+        "allow post-processing the output data. Specify output file with "
+        ".csv extension to output the query result in textual csv format."
     )
     parser.add_argument("--out", nargs="?", help=helps, default="graph.png")
 

--- a/sbomnix/utils.py
+++ b/sbomnix/utils.py
@@ -44,6 +44,12 @@ def df_from_csv_file(name):
         sys.exit(1)
 
 
+def df_regex_filter(df, column, regex):
+    """Return rows where column 'column' values match the given regex"""
+    logging.getLogger(LOGGER_NAME).debug("column:'%s', regex:'%s'", column, regex)
+    return df[df[column].str.contains(regex, regex=True, na=False)]
+
+
 def print_df(df, tablefmt="presto"):
     """Pretty-print dataframe to stdout"""
     if df.empty:


### PR DESCRIPTION
This PR makes the following changes to nixgraph:
- Add a command line argument 'inverse' to allow drawing inverse graphs starting from specified nodes
- Add support for csv output format
- Add pytest tests for nixgraph

Signed-off-by: Henri Rosten <henri.rosten@unikie.com>