### PR TITLE
sbomnix: add dependencies to sbom

### DIFF
--- a/nixgraph/graph.py
+++ b/nixgraph/graph.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2022 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -305,7 +305,8 @@ class NixDependencies:
         edge = NixDependency(src_path, src_pname, target_path, target_pname)
         self.dependencies.add(edge)
 
-    def _to_dataframe(self):
+    def to_dataframe(self):
+        """Return the dependencies as pandas dataframe"""
         deps = [dep.to_dict() for dep in self.dependencies]
         df = pd.DataFrame.from_records(deps)
         if _LOG.level <= logging.DEBUG:
@@ -314,7 +315,7 @@ class NixDependencies:
 
     def graph(self, args):
         """Draw the dependencies as directed graph"""
-        digraph = NixDependencyGraph(self._to_dataframe())
+        digraph = NixDependencyGraph(self.to_dataframe())
         digraph.draw(self.start_path, args)
 
 

--- a/nixgraph/graph.py
+++ b/nixgraph/graph.py
@@ -310,7 +310,7 @@ class NixDependencies:
         deps = [dep.to_dict() for dep in self.dependencies]
         df = pd.DataFrame.from_records(deps)
         if _LOG.level <= logging.DEBUG:
-            df_to_csv_file(df, f"deps_{self.dtype}.csv")
+            df_to_csv_file(df, f"nixgraph_deps_{self.dtype}.csv")
         return df
 
     def graph(self, args):

--- a/sbomnix/cpe.py
+++ b/sbomnix/cpe.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sbomnix/cpe.py
+++ b/sbomnix/cpe.py
@@ -59,6 +59,7 @@ class _CPE:
         week_ago = datetime.datetime.now() - datetime.timedelta(days=7)
         if cpe_updated < week_ago:
             # Try updating cpe dictionary if it wasn't recently updated
+            _LOG.debug("Attempting periodic update of cpe dictionary")
             if not self._update_cpedict():
                 _LOG.warning(
                     "CPE data is not up-to-date: CPE identifiers will be inaccurate"

--- a/sbomnix/derivation.py
+++ b/sbomnix/derivation.py
@@ -6,6 +6,7 @@
 
 # pylint: disable=unnecessary-pass, too-many-return-statements
 # pylint: disable=invalid-name, eval-used, unidiomatic-typecheck
+# pylint: disable=too-many-instance-attributes
 
 """ Nix derivation, originally from https://github.com/flyingcircusio/vulnix """
 
@@ -14,6 +15,7 @@ import json
 import logging
 import re
 import itertools
+from packageurl import PackageURL
 from sbomnix.cpe import CPE
 
 from sbomnix.utils import (
@@ -192,11 +194,14 @@ class Derive:
 
         self.pname, self.version = split_name(self.name)
         if not self.version:
-            raise SkipDrv()
+            _LOG.debug("missing version information: '%s'", self.pname)
+            self.version = ""
+            # raise SkipDrv()
         self.patches = patches or envVars.get("patches", "")
         self.system = envVars.get("system", "")
         self.out = envVars.get("out", "")
         self.cpe = CPE().generate(self.pname, self.version)
+        self.purl = str(PackageURL(type="nix", name=self.pname, version=self.version))
 
     def __repr__(self):
         return f"<Derive({repr(self.name)})>"

--- a/sbomnix/derivation.py
+++ b/sbomnix/derivation.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # SPDX-FileCopyrightText: Flying Circus Internet Operations GmbH
 
-# SPDX-FileCopyrightText: 2022 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
 
 # pylint: disable=unnecessary-pass, too-many-return-statements
 # pylint: disable=invalid-name, eval-used, unidiomatic-typecheck

--- a/sbomnix/derivation.py
+++ b/sbomnix/derivation.py
@@ -14,6 +14,7 @@ import json
 import logging
 import re
 import itertools
+from sbomnix.cpe import CPE
 
 from sbomnix.utils import (
     LOGGER_NAME,
@@ -195,6 +196,7 @@ class Derive:
         self.patches = patches or envVars.get("patches", "")
         self.system = envVars.get("system", "")
         self.out = envVars.get("out", "")
+        self.cpe = CPE().generate(self.pname, self.version)
 
     def __repr__(self):
         return f"<Derive({repr(self.name)})>"

--- a/sbomnix/derivation.py
+++ b/sbomnix/derivation.py
@@ -142,7 +142,7 @@ def destructure(env):
     return json.loads(env["__json"])
 
 
-IGNORE_EXT = {
+IGNORE_NAMES = {
     ".tar.gz",
     ".tar.bz2",
     ".tar.xz",
@@ -154,6 +154,8 @@ IGNORE_EXT = {
     ".patch.gz",
     ".patch.xz",
     ".diff",
+    "?id=",
+    "?p=",
 }
 
 
@@ -188,15 +190,14 @@ class Derive:
         self.name = name or envVars.get("name")
         if not self.name:
             self.name = destructure(envVars)["name"]
-        for e in IGNORE_EXT:
-            if self.name.endswith(e):
+        for e in IGNORE_NAMES:
+            if e in self.name:
                 raise SkipDrv()
 
         self.pname, self.version = split_name(self.name)
         if not self.version:
             _LOG.debug("missing version information: '%s'", self.pname)
             self.version = ""
-            # raise SkipDrv()
         self.patches = patches or envVars.get("patches", "")
         self.system = envVars.get("system", "")
         self.out = envVars.get("out", "")

--- a/sbomnix/main.py
+++ b/sbomnix/main.py
@@ -18,7 +18,6 @@ import pandas as pd
 import numpy as np
 from packageurl import PackageURL
 
-from sbomnix.cpe import CPE
 from sbomnix.utils import (
     setup_logging,
     LOGGER_NAME,
@@ -170,7 +169,7 @@ def df_row_to_cdx_component(row):
     component["version"] = row.version
     purl = PackageURL(type="nix", name=row.pname, version=row.version)
     component["purl"] = str(purl)
-    component["cpe"] = CPE().generate(row.pname, row.version)
+    component["cpe"] = row.cpe
     cdx_component_add_licenses(component, row)
     return component
 

--- a/sbomnix/main.py
+++ b/sbomnix/main.py
@@ -1,31 +1,18 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2022 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
 #
 # SPDX-License-Identifier: Apache-2.0
-
-# pylint: disable=fixme
 
 """ Python script that generates SBOMs from nix packages """
 
 import argparse
 import os
-import uuid
 import logging
-import json
-
-import pandas as pd
-import numpy as np
-from packageurl import PackageURL
-
+from sbomnix.sbomdb import SbomDb
 from sbomnix.utils import (
     setup_logging,
     LOGGER_NAME,
-    df_to_csv_file,
-)
-
-from sbomnix.nix import (
-    Store,
 )
 
 ###############################################################################
@@ -78,183 +65,21 @@ def getargs():
 ################################################################################
 
 
-def parse_meta_entry(meta, key):
-    """Parse the given key from the metadata entry"""
-    if isinstance(meta, dict):
-        ret = [meta.get(key, "")]
-    elif isinstance(meta, list):
-        ret = [x.get(key, "") if isinstance(x, dict) else x for x in meta]
-    else:
-        ret = [meta]
-    return list(filter(None, ret))
-
-
-def parse_json_metadata(json_filename):
-    """Parse package metadata from the specified json file"""
-
-    with open(json_filename, "r", encoding="utf-8") as inf:
-        _LOG.info('Loading meta info from "%s"', json_filename)
-        json_dict = json.loads(inf.read())
-
-        dict_selected = {}
-        setcol = dict_selected.setdefault
-        for nixpkg_name, pkg in json_dict.items():
-            # generic package info
-            setcol("nixpkgs", []).append(nixpkg_name)
-            setcol("name", []).append(pkg.get("name", ""))
-            setcol("pname", []).append(pkg.get("pname", ""))
-            setcol("version", []).append(pkg.get("version", ""))
-            # meta
-            meta = pkg.get("meta", {})
-            setcol("meta_homepage", []).append(meta.get("homepage", ""))
-            setcol("meta_position", []).append(meta.get("position", ""))
-            # meta.license
-            meta_license = meta.get("license", {})
-            license_short = parse_meta_entry(meta_license, key="shortName")
-            setcol("meta_license_short", []).append(";".join(license_short))
-            license_spdx = parse_meta_entry(meta_license, key="spdxId")
-            setcol("meta_license_spdxid", []).append(";".join(license_spdx))
-            # meta.maintainers
-            meta_maintainers = meta.get("maintainers", {})
-            emails = parse_meta_entry(meta_maintainers, key="email")
-            setcol("meta_maintainers_email", []).append(";".join(emails))
-
-        return pd.DataFrame(dict_selected)
-
-
-################################################################################
-
-
-def licenses_entry_from_row(row, column_name, cdx_license_type):
-    """Parse license entries of type cdx_license_type from column_name"""
-    licenses = []
-    if column_name not in row._asdict():
-        # Return empty list if column name is not in row
-        return licenses
-    license_str = getattr(row, column_name)
-    if not license_str:
-        # Return empty list if license string is empty
-        return licenses
-    # Parse the ";" separated licenses to cdx license format
-    license_strings = license_str.split(";")
-    for license_string in license_strings:
-        license_dict = {"license": {cdx_license_type: license_string}}
-        licenses.append(license_dict)
-    return licenses
-
-
-def cdx_component_add_licenses(component, row):
-    """Add licenses array to cdx component (if any)"""
-    licenses = []
-    # First, try reading the license in spdxid-format
-    # TODO: spdxid license data from meta in many cases is not spdxids
-    # but something else, therefore, skipping this for now:
-    # licenses = licenses_entry_from_row(row, "meta_license_spdxid", "id")
-    # If it fails, try reading the license short name
-    if not licenses:
-        licenses = licenses_entry_from_row(row, "meta_license_short", "name")
-    # Give up if pacakge does not have license information associated
-    if not licenses:
-        return
-    # Otherwise, add the licenses entry
-    component["licenses"] = licenses
-
-
-def df_row_to_cdx_component(row):
-    """Convert one entry from df_sbomdb (row) to cdx component"""
-    component = {}
-    component["type"] = "application"
-    component["bom-ref"] = row.store_path
-    component["name"] = row.pname
-    component["version"] = row.version
-    purl = PackageURL(type="nix", name=row.pname, version=row.version)
-    component["purl"] = str(purl)
-    component["cpe"] = row.cpe
-    cdx_component_add_licenses(component, row)
-    return component
-
-
-def sbomdb_to_cdx(df_sbomdb, cdx_path, target_path):
-    """Export sbomdb dataframe to cyclonedx json file"""
-    # TODO: use a library for this, for instance:
-    # https://github.com/CycloneDX/cyclonedx-python-lib
-
-    cdx = {}
-    cdx["bomFormat"] = "CycloneDX"
-    cdx["specVersion"] = "1.3"
-    cdx["version"] = 1
-    cdx["serialNumber"] = f"urn:uuid:{uuid.uuid4()}"
-    cdx["metadata"] = {}
-    tool = {}
-    tool["vendor"] = "TII"
-    tool["name"] = "sbomnix"
-    tool["version"] = "0.1.0"
-    cdx["metadata"]["tools"] = []
-    cdx["metadata"]["tools"].append(tool)
-    cdx["components"] = []
-    for row in df_sbomdb.itertuples():
-        component = df_row_to_cdx_component(row)
-        if row.store_path == target_path:
-            cdx["metadata"]["component"] = component
-        else:
-            cdx["components"].append(component)
-
-    with open(cdx_path, "w", encoding="utf-8") as outfile:
-        json_string = json.dumps(cdx, indent=2)
-        outfile.write(json_string)
-        _LOG.info("Wrote: %s", outfile.name)
-
-
-################################################################################
-
-
-def sbomdb_df(store, meta_json_path=None):
-    """Export sbomdb to pandas dataframe"""
-
-    # Convert the store object to dataframe
-    df_store = store.to_dataframe()
-    df_sbomdb = df_store
-
-    # Add meta information (licenses, maintainers) if file path to
-    # meta json was specified
-    if meta_json_path is not None:
-        df_meta = parse_json_metadata(meta_json_path)
-        if _LOG.level <= logging.DEBUG:
-            df_to_csv_file(df_meta, "meta.csv")
-        # Join based on package name including the version number
-        df_sbomdb = df_store.merge(
-            df_meta,
-            how="left",
-            left_on=["name"],
-            right_on=["name"],
-            suffixes=["", "_meta"],
-        )
-
-    df_sbom = df_sbomdb.replace(np.nan, "", regex=True)
-    return df_sbom.drop_duplicates(subset="store_path", keep="first")
-
-
-################################################################################
-
-
 def main():
     """main entry point"""
     args = getargs()
     setup_logging(args.verbose)
-    store = Store(args.NIX_PATH[0], args.runtime)
-    target_drv = store.get_target_drv_path()
+    target_path = args.NIX_PATH[0]
     if not args.meta:
         _LOG.warning(
             "Command line argument '--meta' missing: SBOM will not include "
             "license information (see '--help' for more details)"
         )
-
-    df_sbomdb = sbomdb_df(store, args.meta)
-
+    sbomdb = SbomDb(target_path, args.runtime, args.meta)
     if args.cdx:
-        sbomdb_to_cdx(df_sbomdb, args.cdx, target_drv)
+        sbomdb.to_cdx(args.cdx)
     if args.csv:
-        df_to_csv_file(df_sbomdb, args.csv)
+        sbomdb.to_csv(args.csv)
 
 
 ################################################################################

--- a/sbomnix/sbomdb.py
+++ b/sbomnix/sbomdb.py
@@ -132,7 +132,7 @@ class SbomDb:
                 suffixes=["", "_meta"],
             )
         df_sbom = df_sbomdb.replace(np.nan, "", regex=True)
-        return df_sbom.drop_duplicates(subset="store_path", keep="first")
+        return df_sbom.drop_duplicates(subset=["purl"], keep="first")
 
     def to_cdx(self, cdx_path):
         """Export sbomdb to cyclonedx json file"""
@@ -216,7 +216,7 @@ def _df_row_to_cdx_component(row):
     """Convert one entry from df_sbomdb (row) to cdx component"""
     component = {}
     component["type"] = "application"
-    component["bom-ref"] = row.store_path
+    component["bom-ref"] = row.purl
     component["name"] = row.pname
     component["version"] = row.version
     component["purl"] = row.purl

--- a/sbomnix/sbomdb.py
+++ b/sbomnix/sbomdb.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=fixme
+
+""" Module for generating SBOMs in various formats """
+
+import uuid
+import logging
+import json
+
+import pandas as pd
+import numpy as np
+from packageurl import PackageURL
+from sbomnix.nix import Store
+from sbomnix.utils import (
+    LOGGER_NAME,
+    df_to_csv_file,
+)
+
+# from nixgraph.graph import NixDependencies
+
+
+###############################################################################
+
+_LOG = logging.getLogger(LOGGER_NAME)
+
+###############################################################################
+
+
+class SbomDb:
+    """SbomDb allows generating SBOMs in various formats"""
+
+    def __init__(self, nix_path, runtime=False, meta_path=None):
+        _LOG.debug("")
+        self.store = Store(nix_path, runtime)
+        self.df_sbomdb = self._generate_sbomdb(meta_path)
+
+    def _generate_sbomdb(self, meta_path):
+        _LOG.debug("")
+        df_store = self.store.to_dataframe()
+        df_sbomdb = df_store
+        if meta_path is not None:
+            df_meta = _parse_json_metadata(meta_path)
+            if _LOG.level <= logging.DEBUG:
+                df_to_csv_file(df_meta, "meta.csv")
+            # Join based on package name including the version number
+            df_sbomdb = df_store.merge(
+                df_meta,
+                how="left",
+                left_on=["name"],
+                right_on=["name"],
+                suffixes=["", "_meta"],
+            )
+        df_sbom = df_sbomdb.replace(np.nan, "", regex=True)
+        return df_sbom.drop_duplicates(subset="store_path", keep="first")
+
+    def to_cdx(self, cdx_path):
+        """Export sbomdb to cyclonedx json file"""
+        target_path = self.store.get_target_drv_path()
+        cdx = {}
+        cdx["bomFormat"] = "CycloneDX"
+        cdx["specVersion"] = "1.3"
+        cdx["version"] = 1
+        cdx["serialNumber"] = f"urn:uuid:{uuid.uuid4()}"
+        cdx["metadata"] = {}
+        tool = {}
+        tool["vendor"] = "TII"
+        tool["name"] = "sbomnix"
+        tool["version"] = "0.1.0"
+        cdx["metadata"]["tools"] = []
+        cdx["metadata"]["tools"].append(tool)
+        cdx["components"] = []
+        for row in self.df_sbomdb.itertuples():
+            component = _df_row_to_cdx_component(row)
+            if row.store_path == target_path:
+                cdx["metadata"]["component"] = component
+            else:
+                cdx["components"].append(component)
+
+        with open(cdx_path, "w", encoding="utf-8") as outfile:
+            json_string = json.dumps(cdx, indent=2)
+            outfile.write(json_string)
+            _LOG.info("Wrote: %s", outfile.name)
+
+    def to_csv(self, csv_path):
+        """Export sbomdb to csv file"""
+        df_to_csv_file(self.df_sbomdb, csv_path)
+
+
+################################################################################
+
+# CycloneDX
+
+
+def _licenses_entry_from_row(row, column_name, cdx_license_type):
+    """Parse license entries of type cdx_license_type from column_name"""
+    licenses = []
+    if column_name not in row._asdict():
+        # Return empty list if column name is not in row
+        return licenses
+    license_str = getattr(row, column_name)
+    if not license_str:
+        # Return empty list if license string is empty
+        return licenses
+    # Parse the ";" separated licenses to cdx license format
+    license_strings = license_str.split(";")
+    for license_string in license_strings:
+        license_dict = {"license": {cdx_license_type: license_string}}
+        licenses.append(license_dict)
+    return licenses
+
+
+def _cdx_component_add_licenses(component, row):
+    """Add licenses array to cdx component (if any)"""
+    licenses = []
+    # First, try reading the license in spdxid-format
+    # TODO: spdxid license data from meta in many cases is not spdxids
+    # but something else, therefore, skipping this for now:
+    # licenses = licenses_entry_from_row(row, "meta_license_spdxid", "id")
+    # If it fails, try reading the license short name
+    if not licenses:
+        licenses = _licenses_entry_from_row(row, "meta_license_short", "name")
+    # Give up if pacakge does not have license information associated
+    if not licenses:
+        return
+    # Otherwise, add the licenses entry
+    component["licenses"] = licenses
+
+
+def _df_row_to_cdx_component(row):
+    """Convert one entry from df_sbomdb (row) to cdx component"""
+    component = {}
+    component["type"] = "application"
+    component["bom-ref"] = row.store_path
+    component["name"] = row.pname
+    component["version"] = row.version
+    purl = PackageURL(type="nix", name=row.pname, version=row.version)
+    component["purl"] = str(purl)
+    component["cpe"] = row.cpe
+    _cdx_component_add_licenses(component, row)
+    return component
+
+
+###############################################################################
+
+# Nix package metadata
+
+
+def _parse_meta_entry(meta, key):
+    """Parse the given key from the metadata entry"""
+    if isinstance(meta, dict):
+        ret = [meta.get(key, "")]
+    elif isinstance(meta, list):
+        ret = [x.get(key, "") if isinstance(x, dict) else x for x in meta]
+    else:
+        ret = [meta]
+    return list(filter(None, ret))
+
+
+def _parse_json_metadata(json_filename):
+    """Parse package metadata from the specified json file"""
+
+    with open(json_filename, "r", encoding="utf-8") as inf:
+        _LOG.info('Loading meta info from "%s"', json_filename)
+        json_dict = json.loads(inf.read())
+
+        dict_selected = {}
+        setcol = dict_selected.setdefault
+        for nixpkg_name, pkg in json_dict.items():
+            # generic package info
+            setcol("nixpkgs", []).append(nixpkg_name)
+            setcol("name", []).append(pkg.get("name", ""))
+            setcol("pname", []).append(pkg.get("pname", ""))
+            setcol("version", []).append(pkg.get("version", ""))
+            # meta
+            meta = pkg.get("meta", {})
+            setcol("meta_homepage", []).append(meta.get("homepage", ""))
+            setcol("meta_position", []).append(meta.get("position", ""))
+            # meta.license
+            meta_license = meta.get("license", {})
+            license_short = _parse_meta_entry(meta_license, key="shortName")
+            setcol("meta_license_short", []).append(";".join(license_short))
+            license_spdx = _parse_meta_entry(meta_license, key="spdxId")
+            setcol("meta_license_spdxid", []).append(";".join(license_spdx))
+            # meta.maintainers
+            meta_maintainers = meta.get("maintainers", {})
+            emails = _parse_meta_entry(meta_maintainers, key="email")
+            setcol("meta_maintainers_email", []).append(";".join(emails))
+
+        return pd.DataFrame(dict_selected)
+
+
+################################################################################


### PR DESCRIPTION
This PR adds 'dependencies' section to SBOM:
- Read package dependencies using nixgraph
- Start using purl as bom-ref: purl is also used to reference packages in the 'dependencies' section

Other, smaller improvements:
- Move sbomdb to its own module
- Move cpe generation to derivation.py
- Change the derivation.py so that so that derivations without version information are no longer skipped

Signed-off-by: Henri Rosten <henri.rosten@unikie.com>