### PR TITLE
sbomnix: add githash to cdx tool version string

### DIFF
--- a/nixgraph/main.py
+++ b/nixgraph/main.py
@@ -6,10 +6,9 @@
 
 """ Python script to query and visualize nix package dependencies """
 
-import os
 import argparse
 from nixgraph.graph import NixDependencies
-from sbomnix.utils import setup_logging
+from sbomnix.utils import setup_logging, get_version
 
 ###############################################################################
 
@@ -24,12 +23,13 @@ def check_positive(val):
 
 def getargs():
     """Parse command line arguments"""
-    desc = "Visualize nix package dependencies"
-    epil = f"Example: ./{os.path.basename(__file__)} /path/to/derivation.drv "
+    desc = "Visualize nix artifact dependencies"
+    epil = "Example: nixgraph /path/to/derivation.drv "
     parser = argparse.ArgumentParser(description=desc, epilog=epil)
 
     helps = "Path to nix artifact, e.g.: derivation file or nix output path"
     parser.add_argument("NIX_PATH", nargs=1, help=helps)
+    parser.add_argument("--version", action="version", version=get_version())
 
     helps = "Scan buildtime dependencies instead of runtime dependencies"
     parser.add_argument("--buildtime", help=helps, action="store_true")

--- a/sbomnix/main.py
+++ b/sbomnix/main.py
@@ -7,11 +7,11 @@
 """ Python script that generates SBOMs from nix packages """
 
 import argparse
-import os
 import logging
 from sbomnix.sbomdb import SbomDb
 from sbomnix.utils import (
     setup_logging,
+    get_version,
     LOGGER_NAME,
 )
 
@@ -30,13 +30,13 @@ def getargs():
         "writes SBOM file(s) as specified in output arguments."
     )
     epil = (
-        f"Example: ./{os.path.basename(__file__)} /path/to/derivation.drv "
-        "--meta /path/to/meta.json --runtime"
+        "Example: sbomnix /path/to/derivation.drv --meta /path/to/meta.json --runtime"
     )
     parser = argparse.ArgumentParser(description=desc, epilog=epil)
 
     helps = "Path to nix artifact, e.g.: derivation file or nix output path"
     parser.add_argument("NIX_PATH", nargs=1, help=helps)
+    parser.add_argument("--version", action="version", version=get_version())
 
     helps = "Set the debug verbosity level between 0-3 (default: --verbose=1)"
     parser.add_argument("--verbose", help=helps, type=int, default=1)

--- a/sbomnix/sbomdb.py
+++ b/sbomnix/sbomdb.py
@@ -21,6 +21,7 @@ from sbomnix.nix import Store
 from sbomnix.utils import (
     LOGGER_NAME,
     df_to_csv_file,
+    get_version,
 )
 
 ###############################################################################
@@ -162,7 +163,7 @@ class SbomDb:
         tool = {}
         tool["vendor"] = "TII"
         tool["name"] = "sbomnix"
-        tool["version"] = "0.1.0"
+        tool["version"] = get_version()
         cdx["metadata"]["tools"] = []
         cdx["metadata"]["tools"].append(tool)
         cdx["components"] = []

--- a/sbomnix/utils.py
+++ b/sbomnix/utils.py
@@ -11,8 +11,8 @@ import sys
 import csv
 import logging
 import subprocess
+from importlib.metadata import version, PackageNotFoundError
 from tabulate import tabulate
-
 from colorlog import ColoredFormatter, default_log_colors
 import pandas as pd
 
@@ -118,6 +118,16 @@ def regex_match(regex, string):
     if not regex or not string:
         return False
     return re.match(regex, string) is not None
+
+
+def get_version(package="sbomnix"):
+    """Return package version string"""
+    versionstr = ""
+    try:
+        versionstr = version(package)
+    except PackageNotFoundError:
+        versionstr = "0.0.0"
+    return versionstr
 
 
 ################################################################################

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ requires = [
 
 setuptools.setup(
     name="sbomnix",
-    version="0.1.0",
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
     description="Utility that generates SBOMs from nix packages",
     url="https://github.com/tiiuae/sbomnix",
     author="TII",


### PR DESCRIPTION
- Use https://github.com/pypa/setuptools_scm/#setuptools_scm to extract the program's version string. The new version string format is specified in: https://github.com/pypa/setuptools_scm/#default-versioning-scheme. 
As an example "`0.1.dev45+g13df478.d20230116110627`" means:
    - `0.1`:               next version
    - `dev45`:             dev version, 45 revisions from lastest tag
    - `g`:                 scm letter, g for git
    - `13df478`:           git revision hash
    - `d`:                 datetime letter
    - `20230116110627`:    revision datetime stamp in format `YYYYMMDDHHMMSS`
- Use the new version string in cdx sbom tool section
- Add command line argument to print out the program version

Signed-off-by: Henri Rosten <henri.rosten@unikie.com>