### PR TITLE
sbomnix: fixes from manual sbom verification

### DIFF
--- a/sbomnix/utils.py
+++ b/sbomnix/utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -96,7 +96,7 @@ def setup_logging(verbosity=1):
     project_logger.setLevel(level)
 
 
-def exec_cmd(cmd):
+def exec_cmd(cmd, raise_on_error=True):
     """Run shell command cmd"""
     command_str = " ".join(cmd)
     logging.getLogger(LOGGER_NAME).debug("Running: %s", command_str)
@@ -104,13 +104,15 @@ def exec_cmd(cmd):
         ret = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=True)
         return ret.stdout
     except subprocess.CalledProcessError as error:
-        logging.getLogger(LOGGER_NAME).fatal(
+        logging.getLogger(LOGGER_NAME).debug(
             "Error running shell command:\n cmd:   '%s'\n stdout: %s\n stderr: %s",
             command_str,
             error.stdout,
             error.stderr,
         )
-        raise error
+        if raise_on_error:
+            raise error
+        return None
 
 
 def regex_match(regex, string):


### PR DESCRIPTION
- `sbomdb.py`: fix regex that matches dependency source paths: this fix impacts dependencies-section in the output cdx. Also, expand the comment that explains why some dependencies might get dropped based on manually analyzing such instances.

- `nix.py`: get rid of the lambda in `_find_outputs` and replace it with a function instead. Let `_find_deriver` handle the missing deriver, instead of handling that in the labmda (now a function) before calling `_find_deriver`

- `nix.py`: change `_find_deriver` function so that it can return `None` in case no derivation was found

- `utils.py`: add `raise_on_error` parameter to `exec_cmd` to allow executing shell commands that might err out, without raising exceptions when that happens