### PR TITLE
Explicit pip user install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -24,18 +24,18 @@ help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?##.*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install sbomnix
-	pip3 install .
+	pip3 install --user .
 	$(call try_run_sbomnix,$@)
 	$(call target_success,$@)
 
 install-dev: uninstall install-dev-requirements ## Install for development
-	pip3 install -e .
+	pip3 install --user --editable .
 	$(call try_run_sbomnix,$@)
 	$(call target_success,$@)
 
 uninstall: ## Uninstall sbomnix
-	pip3 uninstall -y sbomnix 
 	find . -name '*.egg-info' -exec rm -fr {} +
+	pip3 uninstall -y sbomnix 
 	$(call target_success,$@)
 
 install-dev-requirements: ## Install all requirements

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 # sbomnix
 
 `sbomnix` is a utility that generates SBOMs for [nix](https://nixos.org/) packages.
+
 In addition to `sbomnix` this repository is a home to [nixgraph](./doc/nixgraph.md), a python library and command line utility for querying and visualizing dependency graphs for [nix](https://nixos.org/) packages.
 
 `sbomnix` originates from the [Ghaf](https://github.com/tiiuae/ghaf) project.
@@ -28,7 +29,7 @@ Table of Contents
 * [Acknowledgements](#acknowledgements)
 
 ## Getting Started
-`sbomnix` requires common Nix tools like `nix` and `nix-store`. These tools are expected to be in `$PATH`.
+`sbomnix` requires common [nix](https://nixos.org/download.html) tools like `nix` and `nix-store`. These tools are expected to be in `$PATH`.
 `nixgraph` requires [graphviz](https://graphviz.org/download/).
 
 ### Running without installation
@@ -36,9 +37,9 @@ Table of Contents
 ```bash
 $ git clone https://github.com/tiiuae/sbomnix
 $ cd sbomnix
-$ pip3 install -r requirements.txt
+$ pip3 install --user -r requirements.txt
 ```
-After requirements have been installed, you can run sbomnix as follows:
+After requirements have been installed, you can run sbomnix without installation as follows:
 ```bash
 $ source scripts/env.sh
 $ python3 sbomnix/main.py
@@ -50,7 +51,7 @@ Examples in this README.md assume you have installed `sbomnix` on your system an
 ```bash
 $ git clone https://github.com/tiiuae/sbomnix
 $ cd sbomnix
-$ pip3 install .
+$ pip3 install --user .
 ```
 
 ## Usage examples

--- a/doc/nixgraph.md
+++ b/doc/nixgraph.md
@@ -102,7 +102,7 @@ The output now becomes:
 <img src="img/git_r2_col_inv.svg">
 <br /><br />
 
-The output graph shows that there are three dependency paths from git to `openssl-3.0.7` and one dependency path that leads to `sqlite-3.39.4`.
+The output graph shows that there are three dependency paths from `git` to `openssl-3.0.7` and one dependency path that leads to `sqlite-3.39.4`.
 
 #### Example: package buildtime dependencies
 ```bash


### PR DESCRIPTION
- Change documentation to instruct pip 'user' install
- Change relevant Makefile targets to also state user install

Signed-off-by: Henri Rosten <henri.rosten@unikie.com>