### PR TITLE
vulnscan: initial commit

### DIFF
--- a/sbomnix/utils.py
+++ b/sbomnix/utils.py
@@ -96,7 +96,7 @@ def setup_logging(verbosity=1):
     project_logger.setLevel(level)
 
 
-def exec_cmd(cmd, raise_on_error=True):
+def exec_cmd(cmd, raise_on_error=True, return_error=False):
     """Run shell command cmd"""
     command_str = " ".join(cmd)
     logging.getLogger(LOGGER_NAME).debug("Running: %s", command_str)
@@ -112,6 +112,8 @@ def exec_cmd(cmd, raise_on_error=True):
         )
         if raise_on_error:
             raise error
+        if return_error:
+            return error
         return None
 
 

--- a/scripts/vulnscan/osv.py
+++ b/scripts/vulnscan/osv.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=import-error
+
+""" Demonstrate querying OSV db for vulnerabilities based on cdx SBOM """
+
+import argparse
+import logging
+import os
+import sys
+import pathlib
+import json
+import requests
+import pandas as pd
+from sbomnix.utils import (
+    setup_logging,
+    LOGGER_NAME,
+    LOG_SPAM,
+    df_to_csv_file,
+)
+
+###############################################################################
+
+_LOG = logging.getLogger(LOGGER_NAME)
+
+###############################################################################
+
+
+def getargs():
+    """Parse command line arguments"""
+    desc = "Scan CycloneDX SBOM components for OSV vulnerabilities"
+    epil = f"Example: ./{os.path.basename(__file__)} /path/to/sbom.json"
+    parser = argparse.ArgumentParser(description=desc, epilog=epil)
+    helps = "Set the debug verbosity level between 0-3 (default: --verbose=1)"
+    parser.add_argument("--verbose", help=helps, type=int, default=1)
+    helps = "Path to CycloneDX SBOM json file"
+    parser.add_argument("SBOM", help=helps, type=pathlib.Path)
+    helps = "Path to output file (default: ./osv.csv)"
+    parser.add_argument("--out", nargs="?", help=helps, default="osv.csv")
+    return parser.parse_args()
+
+
+################################################################################
+
+
+def _parse_sbom(path):
+    _LOG.info("Parsing sbom: %s", path)
+    with path.open(encoding="utf-8") as inf:
+        json_dict = json.loads(inf.read())
+        components = json_dict["components"] + [json_dict["metadata"]["component"]]
+        components_dict = {}
+        setcol = components_dict.setdefault
+        for cmp in components:
+            setcol("name", []).append(cmp["name"])
+            setcol("version", []).append(cmp["version"])
+        df_components = pd.DataFrame(components_dict)
+        df_components.fillna("", inplace=True)
+        df_components = df_components.astype(str)
+        df_components.sort_values("name", inplace=True, key=lambda col: col.str.lower())
+        df_components.reset_index(drop=True, inplace=True)
+        return df_components
+
+
+################################################################################
+
+
+class OSV:
+    """Query and parse OSV vulnerability data"""
+
+    def __init__(self):
+        self.vulns_dict = {}
+
+    def _parse_vulns(self, package, vulns):
+        setcol = self.vulns_dict.setdefault
+        for vuln in vulns["vulns"]:
+            setcol("vuln_id", []).append(vuln["id"])
+            setcol("modified", []).append(vuln["modified"])
+            setcol("package", []).append(package["package"]["name"])
+            setcol("version", []).append(package["version"])
+
+    def _parse_batch_response(self, query, resp):
+        for package, vulns in zip(query["queries"], resp["results"]):
+            if not package or not vulns:
+                continue
+            _LOG.debug("package: %s", package)
+            _LOG.debug("vulns: %s", vulns)
+            self._parse_vulns(package, vulns)
+
+    def _post_batch_query(self, query):
+        _LOG.log(LOG_SPAM, "query: %s", query)
+        url = "https://api.osv.dev/v1/querybatch"
+        _LOG.log(LOG_SPAM, "sending request to '%s'", url)
+        resp = requests.post(url, json=query, timeout=30)
+        _LOG.debug("resp.status_code: %s", resp.status_code)
+        _LOG.log(LOG_SPAM, "resp.json: %s", resp.json())
+        resp.raise_for_status()
+        self._parse_batch_response(query, resp.json())
+
+    def query_vulns(self, df_sbom):
+        """Query each package in df_sbom for OSV vulnerabilities"""
+        _LOG.info("Querying vulnerabilities")
+        # See the API description at: https://osv.dev/docs/#tag/api.
+        # The limit of max 1000 packages per single query is stated in the
+        # api documentation at the time of writing.
+        max_queries = 1000
+        batchquery = {}
+        batchquery["queries"] = []
+        for drv in df_sbom.itertuples():
+            query = {}
+            query["version"] = drv.version
+            query["package"] = {}
+            query["package"]["name"] = drv.name
+            batchquery["queries"].append(query)
+            if len(batchquery["queries"]) >= max_queries:
+                self._post_batch_query(batchquery)
+                batchquery["queries"] = []
+        if batchquery["queries"]:
+            self._post_batch_query(batchquery)
+
+    def to_dataframe(self):
+        """Return found vulnerabilities as pandas dataframe"""
+        return pd.DataFrame.from_dict(self.vulns_dict)
+
+
+################################################################################
+
+
+def main():
+    """main entry point"""
+    args = getargs()
+    setup_logging(args.verbose)
+    if not args.SBOM.exists():
+        _LOG.fatal("Invalid path: '%s'", args.SBOM)
+        sys.exit(1)
+    df_sbom = _parse_sbom(args.SBOM)
+    osv = OSV()
+    osv.query_vulns(df_sbom)
+    df_vulns = osv.to_dataframe()
+    df_to_csv_file(df_vulns, args.out)
+
+
+################################################################################
+
+if __name__ == "__main__":
+    main()
+
+################################################################################

--- a/scripts/vulnscan/vulnscan.py
+++ b/scripts/vulnscan/vulnscan.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=invalid-name, import-error
+
+""" Demonstrate vulnerability scan with vulnix, grype, and osv.py"""
+
+import argparse
+import logging
+import os
+import sys
+import pathlib
+import json
+import re
+import pandas as pd
+import numpy as np
+from tabulate import tabulate
+from sbomnix.utils import (
+    setup_logging,
+    exec_cmd,
+    LOGGER_NAME,
+    LOG_SPAM,
+    df_from_csv_file,
+    df_to_csv_file,
+)
+
+###############################################################################
+
+_LOG = logging.getLogger(LOGGER_NAME)
+
+###############################################################################
+
+
+def getargs():
+    """Parse command line arguments"""
+    desc = "Scan nix artifact for vulnerabilities with vulnix, grype, and osv.py"
+    epil = f"Example: ./{os.path.basename(__file__)} /path/to/sbom.json"
+    parser = argparse.ArgumentParser(description=desc, epilog=epil)
+    helps = "Target derivation path or nix out path"
+    parser.add_argument("TARGET", help=helps, type=pathlib.Path)
+    helps = "Set the debug verbosity level between 0-3 (default: --verbose=1)"
+    parser.add_argument("--verbose", help=helps, type=int, default=1)
+    helps = "Path to output file (default: ./vulns.csv)"
+    parser.add_argument("--out", nargs="?", help=helps, default="vulns.csv")
+    helps = (
+        "Include target's buildtime dependencies to the scan."
+        "By default, only runtime dependencies are scanned."
+    )
+    parser.add_argument("--buildtime", help=helps, action="store_true")
+    return parser.parse_args()
+
+
+################################################################################
+
+
+class VulnScan:
+    """Run vulnerability scans, generate reports"""
+
+    def __init__(self):
+        self.df_vulnix = None
+        self.df_grype = None
+        self.df_osv = None
+        self.df_report = None
+
+    def _parse_vulnix(self, json_str):
+        vulnerable_packages = json.loads(json_str)
+        vulnix_vulns_dict = {}
+        setcol = vulnix_vulns_dict.setdefault
+        for package in vulnerable_packages:
+            for cve in package["affected_by"]:
+                setcol("package", []).append(package["pname"])
+                setcol("version", []).append(package["version"])
+                setcol("vuln_id", []).append(cve)
+                setcol("scanner", []).append("vulnix")
+        self.df_vulnix = pd.DataFrame.from_dict(vulnix_vulns_dict)
+        if not self.df_vulnix.empty:
+            _LOG.debug("Vulnix found vulnerabilities")
+            self.df_vulnix.replace(np.nan, "", regex=True, inplace=True)
+            self.df_vulnix.drop_duplicates(keep="first", inplace=True)
+            if _LOG.level <= logging.DEBUG:
+                df_to_csv_file(self.df_vulnix, "df_vulnix.csv")
+
+    def scan_vulnix(self, target_path, buildtime=False):
+        """Run vulnix scan for nix artifact at target_path"""
+        _LOG.info("Running vulnix scan")
+        # We use vulnix from 'https://github.com/henrirosten/vulnix' to get
+        # vulnix support for runtime-only scan ('-C' command-line option)
+        # which is currently not available in released version of vulnix.
+        # To manually test this on command-line, try something like:
+        # nix-shell \
+        #   --packages 'callPackage (fetchGit { url = URL; ref = "master"; } ) {}' \
+        #   --run "vulnix PATH_TO_TARGET -C --json"
+        url = "https://github.com/henrirosten/vulnix"
+        ref = '"master"'
+        packages = f"callPackage (fetchGit {{ url = {url}; ref = {ref}; }} ) {{}}"
+        extra_opts = "-C --json"
+        if buildtime:
+            extra_opts = "--json"
+        run_vulnix = f"vulnix {target_path} {extra_opts}"
+        cmd = ["nix-shell", "--packages", packages, "--run", run_vulnix]
+        # vulnix exit status is non-zero if it found vulnerabilities,
+        # therefore, we need to se the raise_on_error=False and
+        # return_error=True to be able to read the command's stdout on
+        # failure
+        ret = exec_cmd(cmd, raise_on_error=False, return_error=True)
+        if ret and hasattr(ret, "stdout") and ret.stdout:
+            self._parse_vulnix(ret.stdout)
+
+    def _parse_grype(self, json_str):
+        vulnerabilities = json.loads(json_str)
+        _LOG.log(LOG_SPAM, json.dumps(vulnerabilities, indent=2))
+        grype_vulns_dict = {}
+        setcol = grype_vulns_dict.setdefault
+        for vuln in vulnerabilities["matches"]:
+            if not vuln["artifact"]["version"]:
+                _LOG.log(
+                    LOG_SPAM,
+                    "'%s' missing version information: skipping",
+                    vuln["artifact"]["name"],
+                )
+                continue
+            setcol("package", []).append(vuln["artifact"]["name"])
+            setcol("version", []).append(vuln["artifact"]["version"])
+            setcol("vuln_id", []).append(vuln["vulnerability"]["id"])
+            setcol("scanner", []).append("grype")
+        self.df_grype = pd.DataFrame.from_dict(grype_vulns_dict)
+        if not self.df_grype.empty:
+            _LOG.debug("Grype found vulnerabilities")
+            self.df_grype.replace(np.nan, "", regex=True, inplace=True)
+            self.df_grype.drop_duplicates(keep="first", inplace=True)
+            if _LOG.level <= logging.DEBUG:
+                df_to_csv_file(self.df_grype, "df_grype.csv")
+
+    def scan_grype(self, sbom_path):
+        """Run grype scan using the SBOM at sbom_path as input"""
+        _LOG.info("Running grype scan")
+        # To manually test this on command-line, try something like:
+        # nix-shell \
+        #   --packages grype \
+        #   --run "grype sbom:PATH_TO_SBOM --add-cpes-if-none --output json"
+        packages = "grype"
+        extra_opts = "--add-cpes-if-none --output json"
+        run_grype = f"grype sbom:{sbom_path} {extra_opts}"
+        cmd = ["nix-shell", "--packages", packages, "--run", run_grype]
+        ret = exec_cmd(cmd)
+        if ret:
+            self._parse_grype(ret)
+
+    def _parse_osv(self, osv_out_path):
+        self.df_osv = df_from_csv_file(osv_out_path)
+        if not self.df_osv.empty:
+            self.df_osv["scanner"] = "osv"
+            self.df_osv.replace(np.nan, "", regex=True, inplace=True)
+            self.df_osv.drop_duplicates(keep="first", inplace=True)
+            self.df_osv["modified"] = pd.to_datetime(self.df_osv["modified"])
+            _LOG.log(LOG_SPAM, "osv data:\n%s", self.df_osv.to_markdown())
+            _LOG.debug("OSV scan found vulnerabilities")
+            if _LOG.level <= logging.DEBUG:
+                df_to_csv_file(self.df_osv, "df_osv.csv")
+
+    def scan_osv(self, sbom_path):
+        """Run osv scan using the SBOM at sbom_path as input"""
+        _LOG.info("Running OSV scan")
+        osv_scanner = pathlib.Path(__file__).parents[0] / "osv.py"
+        osv_out = pathlib.Path("osv_vulns.csv")
+        cmd = f"{osv_scanner.as_posix()} " f"--out {osv_out.as_posix()} " f"{sbom_path}"
+        exec_cmd(cmd.split(), raise_on_error=True)
+        if _valid_csv(osv_out):
+            self._parse_osv(osv_out.as_posix())
+
+    def _generate_report(self):
+        # Concatenate vulnerability data from different scanners
+        df = pd.concat([self.df_vulnix, self.df_grype, self.df_osv], ignore_index=True)
+        if df.empty:
+            _LOG.debug("No scanners reported any findings")
+            return
+        # Add column 'sortcol'
+        df["sortcol"] = df.apply(_vuln_sortcol, axis=1)
+        if _LOG.level <= logging.DEBUG:
+            df_to_csv_file(df, "df_report_raw.csv")
+
+        # Following steps summarize the raw data to produce df_report
+
+        # We'll use the following column to aggregate values in the pivot table
+        df["count"] = 1
+        # Group by the following columns making "scanner" values new columns
+        group_cols = ["vuln_id", "package", "version", "sortcol"]
+        df = df.pivot_table(index=group_cols, columns="scanner", values="count")
+        # Pivot creates a multilevel index, we'll get rid of it:
+        df.reset_index(drop=False, inplace=True)
+        scanners = ["grype", "osv", "vulnix"]
+        df.reindex(group_cols + scanners, axis=1)
+        for scanner_col in scanners:
+            if scanner_col not in df:
+                df[scanner_col] = 0
+        # Add 'sum' column
+        df["sum"] = df[scanners].sum(axis=1).astype(int)
+        # Reformat values in 'scanner' columns
+        df["grype"] = df.apply(lambda row: _reformat_scanner(row.grype), axis=1)
+        df["osv"] = df.apply(lambda row: _reformat_scanner(row.osv), axis=1)
+        df["vulnix"] = df.apply(lambda row: _reformat_scanner(row.vulnix), axis=1)
+        # Add column 'url'
+        df["url"] = df.apply(_vuln_url, axis=1)
+        # Sort the data based on the following columns
+        sort_cols = ["sortcol", "package", "version"]
+        df.sort_values(by=sort_cols, ascending=False, inplace=True)
+        # Re-order columns
+        report_cols = (
+            ["vuln_id", "url", "package", "version"] + scanners + ["sum", "sortcol"]
+        )
+        self.df_report = df[report_cols]
+
+    def report(self, name, target, buildtime):
+        """Generate the vulnerability report: csv file and a table to console"""
+        self._generate_report()
+        if self.df_report is None or self.df_report.empty:
+            _LOG.info("No vulnerabilities found")
+            return
+        _LOG.info("Writing report")
+
+        # Console report
+        # Copy the df to only make changes to the console report
+        df = self.df_report.copy()
+        # Don't print the "sortcol"
+        df = df.drop("sortcol", axis=1)
+        # Truncate
+        df["version"] = df["version"].str.slice(0, 16)
+        table = tabulate(
+            df, headers="keys", tablefmt="orgtbl", numalign="center", showindex=False
+        )
+        dtype = "runtime or buildtime" if buildtime else "runtime"
+        header = (
+            f"Potential vulnerabilities impacting '{target}' or some of its "
+            f"{dtype} dependencies:"
+        )
+        _LOG.info("Console report:\n\n%s\n\n%s\n", header, table)
+
+        # File report
+        df_to_csv_file(self.df_report, name)
+
+
+################################################################################
+
+
+def _reformat_scanner(val):
+    if val and not pd.isnull(val):
+        return "1"
+    return "0"
+
+
+def _vuln_sortcol(row):
+    # Return a string that should make the vulns we want to see high
+    # on the report list to bubble up when sorted in ascending order based
+    # on the returned string
+    match = re.match(r".*[A-Za-z][-_]([1-2][0-9]{3})[-_]([0-9]+).*", row.vuln_id)
+    if match:
+        year = match.group(1)
+        number = str(match.group(2)).zfill(10)
+        return f"{year}A{number}"
+    if row.modified and not pd.isnull(row.modified):
+        return f"{row.modified.year}A{int(row.modified.timestamp())}"
+    return str(row.vuln_id)
+
+
+def _vuln_url(row):
+    osv_url = "https://osv.dev/"
+    nvd_url = "https://nvd.nist.gov/vuln/detail/"
+    if "cve" in row.vuln_id.lower():
+        return f"{nvd_url}{row.vuln_id}"
+    if row.osv:
+        return f"{osv_url}{row.vuln_id}"
+    return ""
+
+
+def _valid_csv(path):
+    try:
+        pd.read_csv(path, nrows=1)
+        _LOG.debug("True")
+        return True
+    except (FileNotFoundError, pd.errors.EmptyDataError, pd.errors.ParserError):
+        _LOG.debug("False")
+        return False
+
+
+def _check_nix():
+    _LOG.info("Checking nix installation")
+    # Try running nix-info to check that nix tools are available
+    cmd = "nix-shell -p nix-info --run 'nix-info'"
+    ret = exec_cmd(cmd.split(), raise_on_error=True)
+    _LOG.debug(ret.strip())
+
+
+def _generate_sbom(target_path, buildtime=False):
+    _LOG.info("Generating SBOM for target '%s'", target_path)
+    sbomnix = pathlib.Path(__file__).parents[2] / "sbomnix" / "main.py"
+    sbomtype = "runtime"
+    cdx = pathlib.Path("sbom_cdx.json")
+    if buildtime:
+        sbomtype = "both"
+    cmd = f"{sbomnix.as_posix()} --type {sbomtype} {target_path} --cdx={cdx.as_posix()}"
+    ret = exec_cmd(cmd.split(), raise_on_error=True)
+    _LOG.debug(ret.strip())
+    if not cdx.exists():
+        _LOG.fatal("Failed generating SBOM")
+        sys.exit(1)
+    return cdx.as_posix()
+
+
+################################################################################
+
+
+def main():
+    """main entry point"""
+    args = getargs()
+    setup_logging(args.verbose)
+    if not args.TARGET.exists():
+        _LOG.fatal("Invalid path: '%s'", args.sbom)
+        sys.exit(1)
+    _check_nix()
+    target_path = args.TARGET.as_posix()
+    sbom_path = _generate_sbom(target_path, args.buildtime)
+
+    scanner = VulnScan()
+    scanner.scan_vulnix(target_path, args.buildtime)
+    scanner.scan_grype(sbom_path)
+    scanner.scan_osv(sbom_path)
+    scanner.report(args.out, target_path, args.buildtime)
+
+
+################################################################################
+
+if __name__ == "__main__":
+    main()
+
+################################################################################


### PR DESCRIPTION
This commit adds the following scripts:

- ´osv.py´: demonstrates querying OSV data given CycloneDX SBOM as input.
  OSV database currently does not support nix ecosystem, so queries that
  specify nix as ecosystem would fail. ´osv.py´ sends queries to OSV
  API without specifying the ecosystem, only the package name
  and version. Currently, such queries return vulnerabilities
  that match the given package and version across all ecosystems.
  This tool thus demonstrates using OSV with nix SBOMs.

- ´vulnscan.py´: demonstrates running vulnerability scans with vulnix,
  grype, and osv.py given a target nix artifact. The tool generates a
  report that summarizes the vulnerabilities found for the given target
  with the three scanners.
  
Example output from scanning both buildtime and runtime dependencies of package 'wget-1.21.3':
```
$ scripts/vulnscan/vulnscan.py /nix/store/1kd6cas7lxhccf7bv1v37wvwmknahfrj-wget-1.21.3.drv --buildtime
INFO     Checking nix installation
INFO     Generating SBOM for target '/nix/store/1kd6cas7lxhccf7bv1v37wvwmknahfrj-wget-1.21.3.drv'
INFO     Running vulnix scan
INFO     Running grype scan
INFO     Running OSV scan
INFO     Writing report
INFO     Console report:

Potential vulnerabilities impacting '/nix/store/1kd6cas7lxhccf7bv1v37wvwmknahfrj-wget-1.21.3.drv' or some of its runtime or buildtime dependencies:

| vuln_id          | url                                               | package   | version   |  grype  |  osv  |  vulnix  |  sum  |
|------------------+---------------------------------------------------+-----------+-----------+---------+-------+----------+-------|
| CVE-2022-46908   | https://nvd.nist.gov/vuln/detail/CVE-2022-46908   | sqlite    | 3.39.4    |    1    |   0   |    1     |   2   |
| CVE-2022-43551   | https://nvd.nist.gov/vuln/detail/CVE-2022-43551   | curl      | 7.86.0    |    0    |   0   |    1     |   1   |
| CVE-2022-38533   | https://nvd.nist.gov/vuln/detail/CVE-2022-38533   | binutils  | 2.39      |    1    |   1   |    1     |   3   |
| CVE-2022-37454   | https://nvd.nist.gov/vuln/detail/CVE-2022-37454   | python3   | 3.10.8    |    0    |   1   |    0     |   1   |
| CVE-2022-28321   | https://nvd.nist.gov/vuln/detail/CVE-2022-28321   | linux-pam | 1.5.2     |    0    |   0   |    1     |   1   |
| CVE-2022-3996    | https://nvd.nist.gov/vuln/detail/CVE-2022-3996    | openssl   | 3.0.7     |    1    |   0   |    1     |   2   |
| CVE-2022-3715    | https://nvd.nist.gov/vuln/detail/CVE-2022-3715    | bash      | 5.1-p16   |    0    |   0   |    1     |   1   |
| CVE-2022-0530    | https://nvd.nist.gov/vuln/detail/CVE-2022-0530    | unzip     | 6.0       |    0    |   1   |    1     |   2   |
| CVE-2022-0529    | https://nvd.nist.gov/vuln/detail/CVE-2022-0529    | unzip     | 6.0       |    0    |   1   |    1     |   2   |
| CVE-2021-35331   | https://nvd.nist.gov/vuln/detail/CVE-2021-35331   | tcl       | 8.6.11    |    1    |   0   |    1     |   2   |
| CVE-2021-4217    | https://nvd.nist.gov/vuln/detail/CVE-2021-4217    | unzip     | 6.0       |    0    |   1   |    1     |   2   |
| OSV-2021-777     | https://osv.dev/OSV-2021-777                      | libxml2   | 2.10.3    |    0    |   1   |    0     |   1   |
| CVE-2019-20633   | https://nvd.nist.gov/vuln/detail/CVE-2019-20633   | patch     | 2.7.6     |    1    |   0   |    1     |   2   |
| CVE-2019-13638   | https://nvd.nist.gov/vuln/detail/CVE-2019-13638   | patch     | 2.7.6     |    1    |   0   |    0     |   1   |
| CVE-2019-13636   | https://nvd.nist.gov/vuln/detail/CVE-2019-13636   | patch     | 2.7.6     |    1    |   0   |    0     |   1   |
| CVE-2019-6293    | https://nvd.nist.gov/vuln/detail/CVE-2019-6293    | flex      | 2.6.4     |    0    |   0   |    1     |   1   |
| CVE-2018-1000156 | https://nvd.nist.gov/vuln/detail/CVE-2018-1000156 | patch     | 2.7.6     |    1    |   0   |    0     |   1   |
| CVE-2018-20969   | https://nvd.nist.gov/vuln/detail/CVE-2018-20969   | patch     | 2.7.6     |    1    |   0   |    0     |   1   |
| CVE-2018-16395   | https://nvd.nist.gov/vuln/detail/CVE-2018-16395   | openssl   | 1.1.1s    |    0    |   0   |    1     |   1   |
| CVE-2018-6952    | https://nvd.nist.gov/vuln/detail/CVE-2018-6952    | patch     | 2.7.6     |    1    |   0   |    0     |   1   |
| CVE-2018-6951    | https://nvd.nist.gov/vuln/detail/CVE-2018-6951    | patch     | 2.7.6     |    1    |   0   |    0     |   1   |
| CVE-2016-2781    | https://nvd.nist.gov/vuln/detail/CVE-2016-2781    | coreutils | 9.1       |    1    |   0   |    0     |   1   |

INFO     Wrote: vulns.csv
``` 