### PR TITLE
sbomnix: nixgraph: miscellaneous fixes

### DIFF
--- a/sbomnix/cpe.py
+++ b/sbomnix/cpe.py
@@ -16,7 +16,7 @@ from sbomnix.utils import (
     LOGGER_NAME,
     LOG_SPAM,
     df_from_csv_file,
-    print_df,
+    df_log,
     exec_cmd,
 )
 
@@ -100,13 +100,12 @@ class _CPE:
             _LOG.log(LOG_SPAM, "no matches for product '%s'", product)
             return None
         if len(df) != 1:
-            # If there are more than one product with the same name,
+            # If there is more than one product with the same name,
             # we cannot determine which vendor name should be used for the CPE.
             # Therefore, if more than one product names match, treat it the
             # same way as if there were no matches (returning None).
-            if _LOG.level <= LOG_SPAM:
-                _LOG.log(LOG_SPAM, "more than one match for product '%s':", product)
-                print_df(df)
+            _LOG.log(LOG_SPAM, "more than one match for product '%s':", product)
+            df_log(df, LOG_SPAM)
             return None
 
         vendor = df["vendor"].values[0]

--- a/sbomnix/derivation.py
+++ b/sbomnix/derivation.py
@@ -162,7 +162,7 @@ class Derive:
         self.version = envVars.get("version", "")
         self.patches = patches or envVars.get("patches", "")
         self.system = envVars.get("system", "")
-        self.out = envVars.get("out", "")
+        self.out = [envVars.get("out", "")]
         self.cpe = CPE().generate(self.pname, self.version)
         self.purl = str(PackageURL(type="nix", name=self.pname, version=self.version))
 
@@ -190,6 +190,11 @@ class Derive:
         if self.pname < other.pname:
             return False
         return compare_versions(self.version, other.version) == 1
+
+    def add_outpath(self, path):
+        """Add an outpath to derivation"""
+        _LOG.debug("adding outpath to %s:%s", self, path)
+        self.out.append(path)
 
     def to_dict(self):
         """Return derivation as dictionary"""

--- a/sbomnix/nix.py
+++ b/sbomnix/nix.py
@@ -7,12 +7,14 @@
 """ Nix store, originally from https://github.com/flyingcircusio/vulnix """
 
 import os
+import sys
 import logging
 import json
 import pandas as pd
 
 from sbomnix.utils import (
     LOGGER_NAME,
+    LOG_SPAM,
     exec_cmd,
 )
 
@@ -35,61 +37,64 @@ class Store:
         self.buildtime = buildtime
         self.derivations = {}
 
-    def _update(self, drv_path, in_path=None):
+    def _add_cached(self, path, drv):
+        assert path is not None, f"invalid path: {drv}"
+        if path:
+            _LOG.log(LOG_SPAM, "caching path - %s:%s", path, drv)
+            self.derivations[path] = drv
+
+    def _is_cached(self, path):
+        cached = path in self.derivations
+        _LOG.log(LOG_SPAM, "is cached %s:%s", path, cached)
+        return path in self.derivations
+
+    def _update(self, drv_path, nixpath=None):
         _LOG.debug("drv_path=%s", drv_path)
-        if drv_path in self.derivations:
+        if self._is_cached(drv_path):
             _LOG.debug("Skipping redundant path '%s'", drv_path)
             return
         if not drv_path.endswith(".drv"):
             _LOG.debug("Not a derivation, skipping: '%s'", drv_path)
-            self.derivations[drv_path] = None
+            self._add_cached(drv_path, drv=None)
             return
         try:
             drv_obj = load(drv_path)
         except SkipDrv:
             _LOG.debug("Skipping derivation: '%s'", drv_path)
-            self.derivations[drv_path] = None
+            self._add_cached(drv_path, drv=None)
             return
-        if in_path and in_path != drv_obj.store_path and in_path != drv_obj.out:
-            # We end up here if the nix artifact read from 'in_path' does
-            # not have it's own deriver, but it's produced by another
-            # deriver. As an example, 'util-linux-minimal-2.38.1-lib' deriver
-            # is 'util-linux-minimal-2.38.1', so whenever a component depends
-            # on 'util-linux-minimal-2.38.1-lib' the dependency in sbom will
-            # be replaced with dependency to 'util-linux-minimal-2.38.1' because
-            # that's the deriver for 'util-linux-minimal-2.38.1-lib'.
-            # To make the sbomdb dependency lookup find the dependencies for
-            # such cases correctly, we need to fix the drv path so that it points
-            # to the store path of util-linux-minimal-2.38.1-lib, not the path of
-            # util-linux-minimal-2.38.1:
-            if in_path.endswith(".drv"):
-                _LOG.debug("Fix store_path: %s ==> %s", drv_obj.store_path, in_path)
-                drv_obj.store_path = in_path
-            else:
-                _LOG.debug("Fix out path: %s ==> %s", drv_obj.out, in_path)
-                drv_obj.out = in_path
-        self.derivations[drv_obj.store_path] = drv_obj
-        self.derivations[drv_obj.out] = drv_obj
+        if drv_obj.store_path != drv_path:
+            _LOG.fatal("store_path:'%s' != drv_path:'%s'", drv_obj.store_path, drv_path)
+            sys.exit(1)
+        if nixpath and nixpath != drv_obj.store_path and nixpath not in drv_obj.out:
+            # We end up here if the nix artifact read from out path 'nixpath'
+            # does not have it's own deriver, but it's produced by another
+            # deriver. This happens because 'drv_obj' is associated to more
+            # than one 'out' path:
+            drv_obj.add_outpath(nixpath)
+        self._add_cached(drv_path, drv=drv_obj)
+        if nixpath:
+            self._add_cached(nixpath, drv=drv_obj)
 
-    def add_path(self, path):
-        """Add the the derivation referenced by a store path"""
-        _LOG.debug(path)
-        if path in self.derivations:
-            _LOG.debug("Skipping redundant path '%s'", path)
+    def add_path(self, nixpath):
+        """Add the the derivation referenced by a store path (nixpath)"""
+        _LOG.debug(nixpath)
+        if self._is_cached(nixpath):
+            _LOG.debug("Skipping redundant path '%s'", nixpath)
             return
-        if not os.path.exists(path):
+        if not os.path.exists(nixpath):
             raise RuntimeError(
-                f"path `{path}` does not exist - cannot load "
+                f"path `{nixpath}` does not exist - cannot load "
                 "derivations referenced from it"
             )
-        deriver = find_deriver(path)
-        if not deriver:
-            _LOG.debug("No deriver found for: '%s", path)
-            self.derivations[path] = None
+        drv_path = find_deriver(nixpath)
+        if not drv_path:
+            _LOG.debug("No deriver found for: '%s", nixpath)
+            self._add_cached(nixpath, drv=None)
             return
-        self._update(deriver, path)
+        self._update(drv_path, nixpath)
         if self.buildtime:
-            for candidate in exec_cmd(["nix-store", "-qR", deriver]).splitlines():
+            for candidate in exec_cmd(["nix-store", "-qR", drv_path]).splitlines():
                 self._update(candidate)
 
     def to_dataframe(self):

--- a/sbomnix/utils.py
+++ b/sbomnix/utils.py
@@ -50,17 +50,16 @@ def df_regex_filter(df, column, regex):
     return df[df[column].str.contains(regex, regex=True, na=False)]
 
 
-def print_df(df, tablefmt="presto"):
-    """Pretty-print dataframe to stdout"""
-    if df.empty:
-        return
-    df = df.fillna("")
-    print(
-        tabulate(
+def df_log(df, loglevel, tablefmt="presto"):
+    """Log dataframe with given loglevel and tablefmt"""
+    if logging.getLogger(LOGGER_NAME).level <= loglevel:
+        if df.empty:
+            return
+        df = df.fillna("")
+        table = tabulate(
             df, headers="keys", tablefmt=tablefmt, stralign="left", showindex=False
         )
-    )
-    print("")
+        logging.getLogger(LOGGER_NAME).log(loglevel, "\n%s\n", table)
 
 
 def setup_logging(verbosity=1):


### PR DESCRIPTION
- sbomnix: allow multiple out paths per derivation
- sbomnix: simplify store derivation caching
- sbomnix: output valid SBOM also in case the given target has no dependencies
- nixgraph: gracefully handle the case when the given target has no dependencies, simply opt to not draw anything
- utils: make the utils function that can be used to pretty-print a dataframe to use logging instead of directly printing to stdout

Signed-off-by: Henri Rosten <henri.rosten@unikie.com>