### PR TITLE
enhancement: make sbomnix flake runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Table of Contents
 `sbomnix` requires common [nix](https://nixos.org/download.html) tools like `nix` and `nix-store`. These tools are expected to be in `$PATH`.
 `nixgraph` requires [graphviz](https://graphviz.org/download/).
 
+
 ### Running without installation
 `sbomnix` requires python3 and packages specified in [requirements.txt](./requirements.txt). You can install the required packages with:
 ```bash
@@ -46,6 +47,12 @@ After requirements have been installed, you can run sbomnix without installation
 $ source scripts/env.sh
 $ python3 sbomnix/main.py
 usage: main.py [-h] [--version] [--verbose VERBOSE] [--meta [META]] [--type {runtime,buildtime,both}] [--csv [CSV]] [--cdx [CDX]] NIX_PATH
+```
+
+### Running with nix flakes
+`sbomnix` can as a nix flake like so:
+```bash
+nix run github:tiiuae/sbomnix/main /nix/store/1kd6cas7lxhccf7bv1v37wvwmknahfrj-wget-1.21.3.drv
 ```
 
 ### Installation

--- a/flake.nix
+++ b/flake.nix
@@ -20,12 +20,16 @@
         pkgs = nixpkgs.legacyPackages.${system};
         mach = mach-nix.lib.${system};
 
+        sbomnix_app = import (./default.nix) { inherit pkgs; };
         pythonEnv = mach.mkPython {
           python = pythonVersion;
           requirements = builtins.readFile ./requirements.txt;
         };
       in
       {
+        packages = {
+          default = sbomnix_app;
+        };
         devShells.default = pkgs.mkShellNoCC {
           packages = [ pythonEnv ];
 


### PR DESCRIPTION
Hey there!

Caught wind of this, and wanted to add a quick flake tweak so `sbomnix` is runnable for for outside folks. This would make so anyone could more easily scan their own nix builds without explicit installation.

This would make it so folks could:
```sh
nix run github:tiiuae/sbomnix/main <your-nix-build>
```

You can test this today as
```sh
nix run github:emattiza/sbomnix/chore/add-package-to-flake <your-nix-build>
```
until it is merged if you want to try for yourself.
