### PR TITLE
sbomnix: rework nix flakes support

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@
 
 pythonPackages.buildPythonPackage rec {
   pname = "sbomnix";
-  version = "1.0.0";
+  version = "1.1.0";
   format = "setuptools";
 
   src = ./.;

--- a/flake.lock
+++ b/flake.lock
@@ -1,107 +1,24 @@
 {
   "nodes": {
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1642700792,
-        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "mach-nix": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs",
-        "pypi-deps-db": "pypi-deps-db"
-      },
-      "locked": {
-        "lastModified": 1672487114,
-        "narHash": "sha256-YIcQtXNQSofFSRDO8Y/uCtXAMguc8HqpY83TstgkH+k=",
-        "owner": "davhau",
-        "repo": "mach-nix",
-        "rev": "68a85753555ed67ff53f0d0320e5ac3c725c7400",
-        "type": "github"
-      },
-      "original": {
-        "owner": "davhau",
-        "repo": "mach-nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643805626,
-        "narHash": "sha256-AXLDVMG+UaAGsGSpOtQHPIKB+IZ0KSd9WS77aanGzgc=",
+        "lastModified": 1675545634,
+        "narHash": "sha256-TbQeQcM5TA/wIho6xtzG+inUfiGzUXi8ewwttiQWYJE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "554d2d8aa25b6e583575459c297ec23750adb6cb",
+        "rev": "0591d6b57bfeb55dfeec99a671843337bc2c3323",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-unstable",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1673315479,
-        "narHash": "sha256-GNCFRtDHjTygXGJp/H+f2XQPMGxpYSmNiibIqYzihtM=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "c07552f6f7d4eead7806645ec03f7f1eb71ba6bd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "pypi-deps-db": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1661155889,
-        "narHash": "sha256-t00mBTZhmZBT4jteO6pJbU0wyRS6/ep4pKmQNeztEms=",
-        "owner": "DavHau",
-        "repo": "pypi-deps-db",
-        "rev": "49c620f3de2b557c9d5c44f58a00fee59f27d1b0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "DavHau",
-        "repo": "pypi-deps-db",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "mach-nix": "mach-nix",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/scripts/vulnscan/README.md
+++ b/scripts/vulnscan/README.md
@@ -22,13 +22,7 @@ To get started, follow the [Getting Started](../../README.md#getting-started) se
 In the below examples, we use nix package `git` as an example target.
 To install nix `git` package and print out its out-path on your local system, try something like:
 ```bash
-PTRGT="git";\
-OUTP=$(\
-nix-shell \
-  --packages $PTRGT \
-  --run "nix-env -q -a --out-path ${PTRGT} | sed -r 's|.*[ ;](/nix/store.*)|\1|'"\
-);\
-echo -e "\n==> out-path: $OUTP"
+nix-shell -p git --run exit && nix eval -f '<nixpkgs>' 'git.outPath'
 ```
 Which outputs the example target out-path on your local system:
 ```

--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,7 @@
 }:
 
 pkgs.mkShell {
-  pname = "sbomnix-dev";
+  name = "sbomnix-dev-shell";
 
   buildInputs = [ 
     pkgs.reuse


### PR DESCRIPTION
- Make flakes.nix import default.nix or shell.nix depending on target
- Update flake.lock
- Update relevant documentation
- Update sbomnix version to 1.1.0

Signed-off-by: Henri Rosten <henri.rosten@unikie.com>