### PR TITLE
sbomnix: fix issue in finding drv out-paths

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@
 
 pythonPackages.buildPythonPackage rec {
   pname = "sbomnix";
-  version = "1.1.0";
+  version = "1.2.0";
   format = "setuptools";
 
   src = ./.;

--- a/doc/nixgraph.md
+++ b/doc/nixgraph.md
@@ -90,7 +90,7 @@ As an example, consider the following graph for `git`:
 
 To find out what are all the runtime dependency paths from `git` to the highlighted nodes `openssl` or `sqlite` in the above graph, run the following command:
 ```bash
-# --depth=100: make sure the output graph includes "long enough" dependency chanins
+# --depth=100: make sure the output graph includes "long enough" dependency chains
 # --inverse="openssl-3|sqlite-3": draw the graph backwards starting from nodes that
 #                                 match the specified reqular expression
 # --colorize="openssl-3|sqlite-3": colorize the matching nodes

--- a/sbomnix/derivation.py
+++ b/sbomnix/derivation.py
@@ -14,6 +14,7 @@ import functools
 import json
 import logging
 import itertools
+import bisect
 from packageurl import PackageURL
 from sbomnix.cpe import CPE
 
@@ -193,8 +194,9 @@ class Derive:
 
     def add_outpath(self, path):
         """Add an outpath to derivation"""
-        _LOG.debug("adding outpath to %s:%s", self, path)
-        self.out.append(path)
+        if path not in self.out:
+            _LOG.debug("adding outpath to %s:%s", self, path)
+            bisect.insort(self.out, path)
 
     def to_dict(self):
         """Return derivation as dictionary"""

--- a/sbomnix/sbomdb.py
+++ b/sbomnix/sbomdb.py
@@ -132,7 +132,10 @@ class SbomDb:
         # dependencies as specified by the requested values (uid)
         if dfr is not None or dfb is not None:
             df = pd.concat([dfr, dfb], ignore_index=True)
-            return df[uid].unique().tolist()
+            dep_uids = df[uid].unique().tolist()
+            # Filter out dependencies to drv itself
+            self_uid = getattr(drv, uid)
+            return [uid for uid in dep_uids if uid != self_uid]
         return None
 
     def to_cdx(self, cdx_path):

--- a/tests/test_sbomnix.py
+++ b/tests/test_sbomnix.py
@@ -301,7 +301,7 @@ def test_compare_sboms():
         "--cdx",
         out_path_cdx_1.as_posix(),
         "--type",
-        "buildtime",
+        "both",
     ]
     assert subprocess.run(cmd, check=True).returncode == 0
     assert out_path_cdx_1.exists()
@@ -313,7 +313,7 @@ def test_compare_sboms():
         "--cdx",
         out_path_cdx_2.as_posix(),
         "--type",
-        "buildtime",
+        "both",
     ]
     assert subprocess.run(cmd, check=True).returncode == 0
     assert out_path_cdx_2.exists()


### PR DESCRIPTION
- Fix an issue in finding drv runtime dependencies which could have
  caused not finding all out-paths associated to deriver
- Sort outpaths under the SBOM component properties in a predictable order
  to allow comparing SBOMs produced for the same target in different
  invocations of sbomnix
- Fix compare_deps.py to make it work with SBOMs that include components
  that have more than one out-paths
- Make the pytest that compares SBOMs for the same target use SBOMs that
  include both buildtime and runtime dependencies to include more
  components to the compared SBOMs, thus, hopefully catching more errors
- Fix some spelling errors in documentation
- Up the version to 1.2.0