### PR TITLE
Improve vulnscan demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
 
 In addition to `sbomnix` this repository is a home to [nixgraph](./doc/nixgraph.md), a python library and command line utility for querying and visualizing dependency graphs for [nix](https://nixos.org/) packages.
 
-For a demonstration of how to use `sbomnix` generated SBOM in automating vulnerability scans see: [vulnscan](scripts/vulnscan/README.md#example-automating-nix-vulnerability-scans).
+For a demonstration of how to use `sbomnix` generated SBOM in automating vulnerability scans see: [vulnxscan](scripts/vulnxscan/README.md#example-automating-nix-vulnerability-scans).
 
 `sbomnix` and other tools in this repository originate from the [Ghaf](https://github.com/tiiuae/ghaf) project.
 

--- a/default.nix
+++ b/default.nix
@@ -27,6 +27,7 @@ pythonPackages.buildPythonPackage rec {
     pythonPackages.tabulate
     pythonPackages.wheel
     pythonPackages.packageurl-python
+    pythonPackages.requests
     pythonPackages.graphviz
   ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
         inherit sbomnix;
         default = sbomnix;
       };
-      
+
       # nix run .#sbomnix
       apps.x86_64-linux.sbomnix = {
         type = "app";
@@ -30,7 +30,13 @@
         type = "app";
         program = "${self.packages.x86_64-linux.sbomnix}/bin/nixgraph";
       };
-      
+
+      # nix run .#vulnxscan
+      apps.x86_64-linux.vulnxscan = {
+        type = "app";
+        program = "${self.packages.x86_64-linux.sbomnix}/bin/vulnxscan";
+      };
+
       # nix develop
       devShells.x86_64-linux.default = sbomnix-shell;
     };

--- a/sbomnix/derivation.py
+++ b/sbomnix/derivation.py
@@ -194,7 +194,7 @@ class Derive:
 
     def add_outpath(self, path):
         """Add an outpath to derivation"""
-        if path not in self.out:
+        if path not in self.out and path != self.store_path:
             _LOG.debug("adding outpath to %s:%s", self, path)
             bisect.insort(self.out, path)
 

--- a/sbomnix/sbomdb.py
+++ b/sbomnix/sbomdb.py
@@ -138,7 +138,7 @@ class SbomDb:
             return [uid for uid in dep_uids if uid != self_uid]
         return None
 
-    def to_cdx(self, cdx_path):
+    def to_cdx(self, cdx_path, printinfo=True):
         """Export sbomdb to cyclonedx json file"""
         cdx = {}
         cdx["bomFormat"] = "CycloneDX"
@@ -179,7 +179,8 @@ class SbomDb:
         with open(cdx_path, "w", encoding="utf-8") as outfile:
             json_string = json.dumps(cdx, indent=2)
             outfile.write(json_string)
-            _LOG.info("Wrote: %s", outfile.name)
+            if printinfo:
+                _LOG.info("Wrote: %s", outfile.name)
 
     def to_csv(self, csv_path):
         """Export sbomdb to csv file"""

--- a/scripts/vulnxscan/README.md
+++ b/scripts/vulnxscan/README.md
@@ -4,9 +4,9 @@ SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# vulnscan
+# vulnxscan
 
-`vulnscan` is a command line utility that demonstrates automating vulnerability scanning for nix targets.
+`vulnxscan` is a command line utility that demonstrates automating vulnerability scanning for nix targets.
 
 Table of Contents
 =================
@@ -43,7 +43,7 @@ Since we specified `--type=both`, `sbomnix` created SBOM that includes both buil
 
 To scan the components listed in `sbom.cdx.json` for [OSV](https://osv.dev/list?ecosystem=) vulnerabilities, run `osv.py` specifying the `sbom.cdx.json` as its input:
 ```bash
-$ scripts/vulnscan/osv.py sbom.cdx.json 
+$ scripts/vulnxscan/osv.py sbom.cdx.json 
 INFO     Parsing sbom: sbom.cdx.json
 INFO     Querying vulnerabilities
 INFO     Wrote: osv.csv
@@ -71,11 +71,11 @@ $ cat osv.csv | csvlook
 *Note (2)*: `osv.py`: demonstrates querying OSV data given CycloneDX SBOM as input. [OSV](https://osv.dev/list?ecosystem=) database [currently does not support nix ecosystem](https://ossf.github.io/osv-schema/#affectedpackage-field), so queries that specify nix as ecosystem would not return any matches. Therefore, for demonstration, `osv.py` sends queries to [OSV API](https://osv.dev/docs/) without specifying the ecosystem, only the package name and version. At the time of writing, such queries return vulnerabilities that match the given package and version across all ecosystems, although, this feature seems to be undocumented in the [API specification](https://osv.dev/docs/#tag/api/operation/OSV_QueryAffected). As a result, the returned vulnerabilities are inaccurate and might not be valid for the nix ecosystem.
 
 #### Example: automating nix vulnerability scans
-This example shows how to use `vulnscan.py` to summarize vulnerabilities for the given target with different scanners.
+This example shows how to use `vulnxscan.py` to summarize vulnerabilities for the given target with different scanners.
 
-To find vulnerabilities that potentially impact 'git-2.39.0' or some of its runtime or buildtime dependencies, run `vulnscan.py` as follows:
+To find vulnerabilities that potentially impact 'git-2.39.0' or some of its runtime or buildtime dependencies, run `vulnxscan.py` as follows:
 ```bash
-$ scripts/vulnscan/vulnscan.py /nix/store/5207hz4f779nz4z62zaa5gdjqzqz1l4g-git-2.39.0 --buildtime
+$ scripts/vulnxscan/vulnxscan.py /nix/store/5207hz4f779nz4z62zaa5gdjqzqz1l4g-git-2.39.0 --buildtime
 INFO     Checking nix installation
 INFO     Generating SBOM for target '/nix/store/5207hz4f779nz4z62zaa5gdjqzqz1l4g-git-2.39.0'
 INFO     Running vulnix scan
@@ -146,11 +146,11 @@ Potential vulnerabilities impacting '/nix/store/5207hz4f779nz4z62zaa5gdjqzqz1l4g
 INFO     Wrote: vulns.csv
 ```
 
-As printed in the console output, `vulnscan.py` first creates an SBOM, then feeds the SBOM or target path as input to different vulnerability scanners: [vulnix](https://github.com/flyingcircusio/vulnix) (for reference), [grype](https://github.com/anchore/grype), and [osv.py](https://github.com/tiiuae/sbomnix/blob/main/scripts/vulnscan/osv.py) and creates a summary report. The summary report lists the newest vulnerabilities on top, with the `sum` column indicating how many scanners agreed with the exact same finding. In addition to the console output, `vulnscan.py` writes the report to csv-file to allow easier post-processing of the output.
+As printed in the console output, `vulnxscan.py` first creates an SBOM, then feeds the SBOM or target path as input to different vulnerability scanners: [vulnix](https://github.com/flyingcircusio/vulnix) (for reference), [grype](https://github.com/anchore/grype), and [osv.py](https://github.com/tiiuae/sbomnix/blob/main/scripts/vulnxscan/osv.py) and creates a summary report. The summary report lists the newest vulnerabilities on top, with the `sum` column indicating how many scanners agreed with the exact same finding. In addition to the console output, `vulnxscan.py` writes the report to csv-file to allow easier post-processing of the output.
 
 *Note (1)*: the above example specified '`--buildtime`' argument, so the output includes vulnerabilities that impact any of the buildtime or runtime dependencies. To get a list of vulnerabilities that impact only runtime dependencies, simply leave out the '`--buildtime`' argument.
 
-*Note (2)*: for now, consider `vulnscan.py` as a demonstration. The list of reported vulnerabilities is inaccurate for various reasons:
+*Note (2)*: for now, consider `vulnxscan.py` as a demonstration. The list of reported vulnerabilities is inaccurate for various reasons:
  - `sbomnix` currently does not include the information about applied patches to the CycloneDX SBOM. `sbomnix` collects the list of patches applied on top of each package and outputs the collected data in its csv output, but it does not add the information to the cdx SBOM. CycloneDX apparently would support such information via the [pedigree](https://cyclonedx.org/use-cases/#pedigree) attribute.
  - Vulnerability scanners lack support for parsing the patch data: even if `sbomnix` added the patch data to the output SBOM, we suspect not many vulnerability scanners would read the information. As an example, the following discussion touches this topic on DependencyTrack: https://github.com/DependencyTrack/dependency-track/issues/919.
  - Identifying packages is hard as pointed out in https://discourse.nixos.org/t/the-future-of-the-vulnerability-roundups/22424/5. As an example, CPEs are inaccurate which causes issues in matching vulnerabilities: https://github.com/DependencyTrack/dependency-track/discussions/2290.

--- a/scripts/vulnxscan/__init__.py
+++ b/scripts/vulnxscan/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/setup.py
+++ b/setup.py
@@ -39,12 +39,13 @@ setuptools.setup(
         "Programming Language :: Python :: 3 :: Only",
     ],
     keywords="SBOM",
-    packages=setuptools.find_packages(include=["sbomnix", "nixgraph"]),
-    scripts=["scripts/update-cpedict.sh"],
+    packages=["sbomnix", "nixgraph", "scripts.vulnxscan"],
+    scripts=["scripts/update-cpedict.sh", "scripts/vulnxscan/osv.py"],
     entry_points={
         "console_scripts": [
-            "sbomnix = sbomnix.main:main",
-            "nixgraph= nixgraph.main:main",
+            "sbomnix  = sbomnix.main:main",
+            "nixgraph = nixgraph.main:main",
+            "vulnxscan= scripts.vulnxscan.vulnxscan:main",
         ]
     },
 )


### PR DESCRIPTION
Improve vulnscan demo:
- Rename vulnscan to vulnxscan
- setup.py: install entry point for vulnxscan
- Add flake target for vulnxscan
- vulnxscan.py: allow using SBOM as input

In addition, this PR adds the following fix:
- derivaiton.py: do not add drv store path as outpath
