### PR TITLE
vulnxscan: add initial pytests for vulnxscan

### DIFF
--- a/.github/workflows/test_sbomnix.yml
+++ b/.github/workflows/test_sbomnix.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Test nix-build
         run: nix-build '<nixpkgs>' -A hello
       - name: Run tests
-        run: make pre-push
+        run: make test-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ install:
   # Install python requirements:
   - pip3 install -r requirements.txt
 script:
-  # Ensure 'pre-push' targets pass:
-  - make pre-push
+  # Ensure 'test-ci' targets pass:
+  - make test-ci

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[pytest]
+markers =
+    skip_in_ci: indicates test should not be run in ci.

--- a/scripts/vulnxscan/README.md
+++ b/scripts/vulnxscan/README.md
@@ -20,7 +20,7 @@ Table of Contents
    * [Running Vulnxscan as Flake](#running-vulnxscan-as-flake)
    * [Find Vulnerabilities Impacting Runtime Dependencies](#find-vulnerabilities-impacting-runtime-dependencies)
    * [Find Vulnerabilities Given SBOM as Input](#find-vulnerabilities-given-sbom-as-input)
-   * [Find Vulnerabilities Impacting Vuildtime and Runtime Dependencies](#find-vulnerabilities-impacting-vuildtime-and-runtime-dependencies)
+   * [Find Vulnerabilities Impacting Buildtime and Runtime Dependencies](#find-vulnerabilities-impacting-buildtime-and-runtime-dependencies)
 * [Footnotes and Future Work](#footnotes-and-future-work)
 
 ## Getting Started
@@ -213,7 +213,7 @@ INFO     Wrote: vulns.csv
 Notice that `vulnxscan` drops the Vulnix scan when the input is SBOM. This is due to the Vulnix not supporting SBOM input at the time of writing.
 
 
-### Find Vulnerabilities Impacting Vuildtime and Runtime Dependencies
+### Find Vulnerabilities Impacting Buildtime and Runtime Dependencies
 By default, `vulnxscan` scans the given target for vulnerabilities that impact its runtime-only dependencies. This example shows how to use `vulnxscan` to include also buildtime dependencies to the scan.
 
 ```bash

--- a/tests/test_sbomnix.py
+++ b/tests/test_sbomnix.py
@@ -20,6 +20,7 @@ import pytest
 MYDIR = Path(os.path.dirname(os.path.realpath(__file__)))
 TEST_WORK_DIR = MYDIR / "sbomnix_test_data"
 TEST_NIX_RESULT = TEST_WORK_DIR / "result"
+REPOROOT = MYDIR / ".."
 SBOMNIX = MYDIR / ".." / "sbomnix" / "main.py"
 NIXGRAPH = MYDIR / ".." / "nixgraph" / "main.py"
 COMPARE_DEPS = MYDIR / "compare_deps.py"
@@ -51,6 +52,15 @@ def test_sbomnix_help():
     Test sbomnix command line argument: '-h'
     """
     cmd = [SBOMNIX, "-h"]
+    assert subprocess.run(cmd, check=True).returncode == 0
+
+
+def test_sbomnix_help_flake():
+    """
+    Test sbomnix command line argument: '-h' running sbomnix as flake
+    """
+
+    cmd = ["nix", "run", f"{REPOROOT}#sbomnix", "--", "-h"]
     assert subprocess.run(cmd, check=True).returncode == 0
 
 
@@ -125,6 +135,15 @@ def test_nixgraph_help():
     Test nixgraph command line argument: '-h'
     """
     cmd = [NIXGRAPH, "-h"]
+    assert subprocess.run(cmd, check=True).returncode == 0
+
+
+def test_nixgraph_help_flake():
+    """
+    Test nixgraph command line argument: '-h' running nixgraph as flake
+    """
+
+    cmd = ["nix", "run", f"{REPOROOT}#nixgraph", "--", "-h"]
     assert subprocess.run(cmd, check=True).returncode == 0
 
 
@@ -322,6 +341,64 @@ def test_compare_sboms():
         COMPARE_SBOMS,
         out_path_cdx_1,
         out_path_cdx_2,
+    ]
+    assert subprocess.run(cmd, check=True).returncode == 0
+
+
+################################################################################
+
+
+def test_vulnxscan_help_flake():
+    """
+    Test vulnxscan command line argument: '-h' running vulnxscan as flake
+    """
+
+    cmd = ["nix", "run", f"{REPOROOT}#vulnxscan", "--", "-h"]
+    assert subprocess.run(cmd, check=True).returncode == 0
+
+
+@pytest.mark.skip_in_ci
+def test_vulnxscan_scan_nix_result():
+    """
+    Test vulnxscan scan with TEST_NIX_RESULT as input
+    """
+
+    cmd = [
+        "nix",
+        "run",
+        f"{REPOROOT}#vulnxscan",
+        "--",
+        TEST_NIX_RESULT.as_posix(),
+    ]
+    assert subprocess.run(cmd, check=True).returncode == 0
+
+
+@pytest.mark.skip_in_ci
+def test_vulnxscan_scan_sbom():
+    """
+    Test vulnxscan scan with SBOM as input
+    """
+
+    out_path_cdx = TEST_WORK_DIR / "sbom_cdx_test.json"
+    cmd = [
+        "nix",
+        "run",
+        f"{REPOROOT}#sbomnix",
+        "--",
+        TEST_NIX_RESULT,
+        "--cdx",
+        out_path_cdx,
+    ]
+    assert subprocess.run(cmd, check=True).returncode == 0
+    assert out_path_cdx.exists()
+
+    cmd = [
+        "nix",
+        "run",
+        f"{REPOROOT}#vulnxscan",
+        "--",
+        "--sbom",
+        out_path_cdx.as_posix(),
     ]
     assert subprocess.run(cmd, check=True).returncode == 0
 


### PR DESCRIPTION
- Add pytests for vulnxscan
- Add initial tests for sbomnix and nixgraph testing running them as flake
- Make pylint tests execute faster by running the tests with a single command as opposed to invoking pylint separately for each target file
- Allow skipping pytests in CI runs with '@pytest.mark.skip_in_ci'. For now, use this mark to skip vulnxscan scan tests in CI due to grype run failing in github actions test run
- Fix a typo in vulnxscan readme

Signed-off-by: Henri Rosten <henri.rosten@unikie.com>