### PR TITLE
Upload sbomnix sbom to github release artifacts

### DIFF
--- a/.github/workflows/release_sbomnix.yml
+++ b/.github/workflows/release_sbomnix.yml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Upload Release Asset
+
+on:
+  push:
+    # Run on push events where tags match v*, e.g. v1.3.0
+    tags:
+      - 'v*'
+
+jobs:
+  build: 
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ts-graphviz/setup-graphviz@v1
+      - uses: cachix/install-nix-action@v18
+        with:
+          nix_path: nixpkgs=channel:nixpkgs-unstable
+      - name: Test nix-build
+        run: nix-build '<nixpkgs>' -A hello
+      - name: Build release asset
+        run: make release-asset
+      - name: Upload release asset
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: build/sbom*
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true

--- a/.github/workflows/test_sbomnix.yml
+++ b/.github/workflows/test_sbomnix.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ uninstall: ## Uninstall sbomnix
 	pip3 uninstall -y sbomnix 
 	$(call target_success,$@)
 
-install-dev-requirements: ## Install all requirements
+install-dev-requirements: clean ## Install all requirements
 	pip3 install -q -r requirements.txt --no-cache-dir
 	$(call target_success,$@)
 
@@ -71,6 +71,20 @@ pylint: clean ## Check with pylint
 
 reuse-lint: clean ## Check with reuse lint
 	reuse lint
+	$(call target_success,$@)
+
+release-asset: clean install-dev-requirements ## Build release asset
+	nix build
+	mkdir -p build/
+	nix run .#sbomnix -- result --type=runtime \
+        --cdx=./build/sbom.runtime.cdx.json \
+        --csv=./build/sbom.runtime.csv
+	nix run .#sbomnix -- result --type=buildtime \
+        --cdx=./build/sbom.buildtime.cdx.json \
+        --csv=./build/sbom.buildtime.csv
+	@echo ""
+	@echo "Build release asset:"
+	ls -la build
 	$(call target_success,$@)
 
 clean: ## Remove build artifacts

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ In addition to `sbomnix` this repository is home to [nixgraph](./doc/nixgraph.md
 
 For a demonstration of how to use `sbomnix` generated SBOM in automating vulnerability scans, see: [vulnxscan](scripts/vulnxscan/README.md).
 
+The CycloneDX SBOM for each release of `sbomnix` itself is available in the [release assets](https://github.com/tiiuae/sbomnix/releases/latest).
+
 `sbomnix` and other tools in this repository originate from [Ghaf Framework](https://github.com/tiiuae/ghaf).
 
 Table of Contents

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@
 
 pythonPackages.buildPythonPackage rec {
   pname = "sbomnix";
-  version = "1.2.0";
+  version = "1.3.0";
   format = "setuptools";
 
   src = ./.;


### PR DESCRIPTION
- Upload runtime and buildtime SBOMs from sbomnix itself to release artifacts on every push of a new release tag
- Up the sbomnix version to v1.3.0

Signed-off-by: Henri Rosten <henri.rosten@unikie.com>