### PR TITLE
sbomnix: add support for sbom output in spdx json format

### DIFF
--- a/LICENSES/CC-BY-3.0.txt
+++ b/LICENSES/CC-BY-3.0.txt
@@ -1,0 +1,93 @@
+Creative Commons Attribution 3.0 Unported
+
+ CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS LICENSE DOES NOT CREATE AN ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE INFORMATION PROVIDED, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM ITS USE.
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE TO BE BOUND BY THE TERMS OF THIS LICENSE. TO THE EXTENT THIS LICENSE MAY BE CONSIDERED TO BE A CONTRACT, THE LICENSOR GRANTS YOU THE RIGHTS CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND CONDITIONS.
+
+1. Definitions
+
+     a. "Adaptation" means a work based upon the Work, or upon the Work and other pre-existing works, such as a translation, adaptation, derivative work, arrangement of music or other alterations of a literary or artistic work, or phonogram or performance and includes cinematographic adaptations or any other form in which the Work may be recast, transformed, or adapted including in any form recognizably derived from the original, except that a work that constitutes a Collection will not be considered an Adaptation for the purpose of this License. For the avoidance of doubt, where the Work is a musical work, performance or phonogram, the synchronization of the Work in timed-relation with a moving image ("synching") will be considered an Adaptation for the purpose of this License.
+
+     b. "Collection" means a collection of literary or artistic works, such as encyclopedias and anthologies, or performances, phonograms or broadcasts, or other works or subject matter other than works listed in Section 1(f) below, which, by reason of the selection and arrangement of their contents, constitute intellectual creations, in which the Work is included in its entirety in unmodified form along with one or more other contributions, each constituting separate and independent works in themselves, which together are assembled into a collective whole. A work that constitutes a Collection will not be considered an Adaptation (as defined above) for the purposes of this License.
+
+     c. "Distribute" means to make available to the public the original and copies of the Work or Adaptation, as appropriate, through sale or other transfer of ownership.
+
+     d. "Licensor" means the individual, individuals, entity or entities that offer(s) the Work under the terms of this License.
+
+     e. "Original Author" means, in the case of a literary or artistic work, the individual, individuals, entity or entities who created the Work or if no individual or entity can be identified, the publisher; and in addition (i) in the case of a performance the actors, singers, musicians, dancers, and other persons who act, sing, deliver, declaim, play in, interpret or otherwise perform literary or artistic works or expressions of folklore; (ii) in the case of a phonogram the producer being the person or legal entity who first fixes the sounds of a performance or other sounds; and, (iii) in the case of broadcasts, the organization that transmits the broadcast.
+
+     f. "Work" means the literary and/or artistic work offered under the terms of this License including without limitation any production in the literary, scientific and artistic domain, whatever may be the mode or form of its expression including digital form, such as a book, pamphlet and other writing; a lecture, address, sermon or other work of the same nature; a dramatic or dramatico-musical work; a choreographic work or entertainment in dumb show; a musical composition with or without words; a cinematographic work to which are assimilated works expressed by a process analogous to cinematography; a work of drawing, painting, architecture, sculpture, engraving or lithography; a photographic work to which are assimilated works expressed by a process analogous to photography; a work of applied art; an illustration, map, plan, sketch or three-dimensional work relative to geography, topography, architecture or science; a performance; a broadcast; a phonogram; a compilation of data to the extent it is protected as a copyrightable work; or a work performed by a variety or circus performer to the extent it is not otherwise considered a literary or artistic work.
+
+     g. "You" means an individual or entity exercising rights under this License who has not previously violated the terms of this License with respect to the Work, or who has received express permission from the Licensor to exercise rights under this License despite a previous violation.
+
+     h. "Publicly Perform" means to perform public recitations of the Work and to communicate to the public those public recitations, by any means or process, including by wire or wireless means or public digital performances; to make available to the public Works in such a way that members of the public may access these Works from a place and at a place individually chosen by them; to perform the Work to the public by any means or process and the communication to the public of the performances of the Work, including by public digital performance; to broadcast and rebroadcast the Work by any means including signs, sounds or images.
+
+     i. "Reproduce" means to make copies of the Work by any means including without limitation by sound or visual recordings and the right of fixation and reproducing fixations of the Work, including storage of a protected performance or phonogram in digital form or other electronic medium.
+
+2. Fair Dealing Rights. Nothing in this License is intended to reduce, limit, or restrict any uses free from copyright or rights arising from limitations or exceptions that are provided for in connection with the copyright protection under copyright law or other applicable laws.
+
+3. License Grant. Subject to the terms and conditions of this License, Licensor hereby grants You a worldwide, royalty-free, non-exclusive, perpetual (for the duration of the applicable copyright) license to exercise the rights in the Work as stated below:
+
+     a. to Reproduce the Work, to incorporate the Work into one or more Collections, and to Reproduce the Work as incorporated in the Collections;
+
+     b. to create and Reproduce Adaptations provided that any such Adaptation, including any translation in any medium, takes reasonable steps to clearly label, demarcate or otherwise identify that changes were made to the original Work. For example, a translation could be marked "The original work was translated from English to Spanish," or a modification could indicate "The original work has been modified.";
+
+     c. to Distribute and Publicly Perform the Work including as incorporated in Collections; and,
+
+     d. to Distribute and Publicly Perform Adaptations.
+
+     e. For the avoidance of doubt:
+
+          i. Non-waivable Compulsory License Schemes. In those jurisdictions in which the right to collect royalties through any statutory or compulsory licensing scheme cannot be waived, the Licensor reserves the exclusive right to collect such royalties for any exercise by You of the rights granted under this License;
+
+          ii. Waivable Compulsory License Schemes. In those jurisdictions in which the right to collect royalties through any statutory or compulsory licensing scheme can be waived, the Licensor waives the exclusive right to collect such royalties for any exercise by You of the rights granted under this License; and,
+
+          iii. Voluntary License Schemes. The Licensor waives the right to collect royalties, whether individually or, in the event that the Licensor is a member of a collecting society that administers voluntary licensing schemes, via that society, from any exercise by You of the rights granted under this License.
+
+The above rights may be exercised in all media and formats whether now known or hereafter devised. The above rights include the right to make such modifications as are technically necessary to exercise the rights in other media and formats. Subject to Section 8(f), all rights not expressly granted by Licensor are hereby reserved.
+
+4. Restrictions. The license granted in Section 3 above is expressly made subject to and limited by the following restrictions:
+
+     a. You may Distribute or Publicly Perform the Work only under the terms of this License. You must include a copy of, or the Uniform Resource Identifier (URI) for, this License with every copy of the Work You Distribute or Publicly Perform. You may not offer or impose any terms on the Work that restrict the terms of this License or the ability of the recipient of the Work to exercise the rights granted to that recipient under the terms of the License. You may not sublicense the Work. You must keep intact all notices that refer to this License and to the disclaimer of warranties with every copy of the Work You Distribute or Publicly Perform. When You Distribute or Publicly Perform the Work, You may not impose any effective technological measures on the Work that restrict the ability of a recipient of the Work from You to exercise the rights granted to that recipient under the terms of the License. This Section 4(a) applies to the Work as incorporated in a Collection, but this does not require the Collection apart from the Work itself to be made subject to the terms of this License. If You create a Collection, upon notice from any Licensor You must, to the extent practicable, remove from the Collection any credit as required by Section 4(b), as requested. If You create an Adaptation, upon notice from any Licensor You must, to the extent practicable, remove from the Adaptation any credit as required by Section 4(b), as requested.
+
+     b. If You Distribute, or Publicly Perform the Work or any Adaptations or Collections, You must, unless a request has been made pursuant to Section 4(a), keep intact all copyright notices for the Work and provide, reasonable to the medium or means You are utilizing: (i) the name of the Original Author (or pseudonym, if applicable) if supplied, and/or if the Original Author and/or Licensor designate another party or parties (e.g., a sponsor institute, publishing entity, journal) for attribution ("Attribution Parties") in Licensor's copyright notice, terms of service or by other reasonable means, the name of such party or parties; (ii) the title of the Work if supplied; (iii) to the extent reasonably practicable, the URI, if any, that Licensor specifies to be associated with the Work, unless such URI does not refer to the copyright notice or licensing information for the Work; and (iv) , consistent with Section 3(b), in the case of an Adaptation, a credit identifying the use of the Work in the Adaptation (e.g., "French translation of the Work by Original Author," or "Screenplay based on original Work by Original Author"). The credit required by this Section 4 (b) may be implemented in any reasonable manner; provided, however, that in the case of a Adaptation or Collection, at a minimum such credit will appear, if a credit for all contributing authors of the Adaptation or Collection appears, then as part of these credits and in a manner at least as prominent as the credits for the other contributing authors. For the avoidance of doubt, You may only use the credit required by this Section for the purpose of attribution in the manner set out above and, by exercising Your rights under this License, You may not implicitly or explicitly assert or imply any connection with, sponsorship or endorsement by the Original Author, Licensor and/or Attribution Parties, as appropriate, of You or Your use of the Work, without the separate, express prior written permission of the Original Author, Licensor and/or Attribution Parties.
+
+     c. Except as otherwise agreed in writing by the Licensor or as may be otherwise permitted by applicable law, if You Reproduce, Distribute or Publicly Perform the Work either by itself or as part of any Adaptations or Collections, You must not distort, mutilate, modify or take other derogatory action in relation to the Work which would be prejudicial to the Original Author's honor or reputation. Licensor agrees that in those jurisdictions (e.g. Japan), in which any exercise of the right granted in Section 3(b) of this License (the right to make Adaptations) would be deemed to be a distortion, mutilation, modification or other derogatory action prejudicial to the Original Author's honor and reputation, the Licensor will waive or not assert, as appropriate, this Section, to the fullest extent permitted by the applicable national law, to enable You to reasonably exercise Your right under Section 3(b) of this License (right to make Adaptations) but not otherwise.
+
+5. Representations, Warranties and Disclaimer
+
+UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, LICENSOR OFFERS THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND CONCERNING THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING, WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY, FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF LATENT OR OTHER DEFECTS, ACCURACY, OR THE PRESENCE OF ABSENCE OF ERRORS, WHETHER OR NOT DISCOVERABLE. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF IMPLIED WARRANTIES, SO SUCH EXCLUSION MAY NOT APPLY TO YOU.
+
+6. Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW, IN NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK, EVEN IF LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. Termination
+
+     a. This License and the rights granted hereunder will terminate automatically upon any breach by You of the terms of this License. Individuals or entities who have received Adaptations or Collections from You under this License, however, will not have their licenses terminated provided such individuals or entities remain in full compliance with those licenses. Sections 1, 2, 5, 6, 7, and 8 will survive any termination of this License.
+
+     b. Subject to the above terms and conditions, the license granted here is perpetual (for the duration of the applicable copyright in the Work). Notwithstanding the above, Licensor reserves the right to release the Work under different license terms or to stop distributing the Work at any time; provided, however that any such election will not serve to withdraw this License (or any other license that has been, or is required to be, granted under the terms of this License), and this License will continue in full force and effect unless terminated as stated above.
+
+8. Miscellaneous
+
+     a. Each time You Distribute or Publicly Perform the Work or a Collection, the Licensor offers to the recipient a license to the Work on the same terms and conditions as the license granted to You under this License.
+
+     b. Each time You Distribute or Publicly Perform an Adaptation, Licensor offers to the recipient a license to the original Work on the same terms and conditions as the license granted to You under this License.
+
+     c. If any provision of this License is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this License, and without further action by the parties to this agreement, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+
+     d. No term or provision of this License shall be deemed waived and no breach consented to unless such waiver or consent shall be in writing and signed by the party to be charged with such waiver or consent. This License constitutes the entire agreement between the parties with respect to the Work licensed here. There are no understandings, agreements or representations with respect to the Work not specified here. Licensor shall not be bound by any additional provisions that may appear in any communication from You.
+
+     e. This License may not be modified without the mutual written agreement of the Licensor and You.
+
+     f. The rights granted under, and the subject matter referenced, in this License were drafted utilizing the terminology of the Berne Convention for the Protection of Literary and Artistic Works (as amended on September 28, 1979), the Rome Convention of 1961, the WIPO Copyright Treaty of 1996, the WIPO Performances and Phonograms Treaty of 1996 and the Universal Copyright Convention (as revised on July 24, 1971). These rights and subject matter take effect in the relevant jurisdiction in which the License terms are sought to be enforced according to the corresponding provisions of the implementation of those treaty provisions in the applicable national law. If the standard suite of rights granted under applicable copyright law includes additional rights not granted under this License, such additional rights are deemed to be included in the License; this License is not intended to restrict the license of any rights under applicable law.
+
+Creative Commons Notice
+
+Creative Commons is not a party to this License, and makes no warranty whatsoever in connection with the Work. Creative Commons will not be liable to You or any party on any legal theory for any damages whatsoever, including without limitation any general, special, incidental or consequential damages arising in connection to this license. Notwithstanding the foregoing two (2) sentences, if Creative Commons has expressly identified itself as the Licensor hereunder, it shall have all rights and obligations of Licensor.
+
+Except for the limited purpose of indicating to the public that the Work is licensed under the CCPL, Creative Commons does not authorize the use by either party of the trademark "Creative Commons" or any related trademark or logo of Creative Commons without the prior written consent of Creative Commons. Any permitted use will be in compliance with Creative Commons' then-current trademark usage guidelines, as may be published on its website or otherwise made available upon request from time to time. For the avoidance of doubt, this trademark restriction does not form part of this License.
+
+Creative Commons may be contacted at http://creativecommons.org/.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 SHELL := bash
-PYTHON_TARGETS := $(shell find . -path ./venv -prune -false -o -name "*.py")
+PYTHON_TARGETS := $(shell find . -path ./venv -prune -o -path "*.eggs" -prune -o -name "*.py")
 
 define target_success
 	@printf "\033[32m==> Target \"$(1)\" passed\033[0m\n\n"
@@ -78,12 +78,14 @@ release-asset: clean install-dev-requirements ## Build release asset
 	mkdir -p build/
 	nix run .#sbomnix -- result --type=runtime \
         --cdx=./build/sbom.runtime.cdx.json \
+        --spdx=./build/sbom.runtime.spdx.json \
         --csv=./build/sbom.runtime.csv
 	nix run .#sbomnix -- result --type=buildtime \
         --cdx=./build/sbom.buildtime.cdx.json \
+        --spdx=./build/sbom.buildtime.spdx.json \
         --csv=./build/sbom.buildtime.csv
 	@echo ""
-	@echo "Build release asset:"
+	@echo "Built release asset:"
 	ls -la build
 	$(call target_success,$@)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In addition to `sbomnix` this repository is home to [nixgraph](./doc/nixgraph.md
 
 For a demonstration of how to use `sbomnix` generated SBOM in automating vulnerability scans, see: [vulnxscan](scripts/vulnxscan/README.md).
 
-The CycloneDX SBOM for each release of `sbomnix` itself is available in the [release assets](https://github.com/tiiuae/sbomnix/releases/latest).
+The [CycloneDX](https://cyclonedx.org/) and [SPDX](https://spdx.github.io/spdx-spec/v2.3/) SBOMs for each release of `sbomnix` itself are available in the [release assets](https://github.com/tiiuae/sbomnix/releases/latest).
 
 `sbomnix` and other tools in this repository originate from [Ghaf Framework](https://github.com/tiiuae/ghaf).
 
@@ -93,9 +93,10 @@ By default `sbomnix` scans the given target and generates an SBOM including the 
 $ sbomnix /nix/store/8nbv1drmvh588pwiwsxa47iprzlgwx6j-wget-1.21.3
 ...
 INFO     Wrote: sbom.cdx.json
+INFO     Wrote: sbom.spdx.json
 INFO     Wrote: sbom.csv
 ```
-Main output is the SBOM json file (sbom.cdx.json) in [CycloneDX](https://cyclonedx.org/) format.
+Main output are the SBOM json files sbom.cdx.json and sbom.spdx.json in [CycloneDX](https://cyclonedx.org/) and [SPDX](https://spdx.github.io/spdx-spec/v2.3/) formats.
 
 #### Generate SBOM Including Meta Information
 To include license information to the SBOM, first generate package meta information with `nix-env`:

--- a/nixgraph/graph.py
+++ b/nixgraph/graph.py
@@ -254,7 +254,7 @@ class NixDependencies:
         else:
             self._parse_runtime_dependencies(nix_path)
         if len(self.dependencies) <= 0:
-            _LOG.info("No %s dependices", self.dtype)
+            _LOG.info("No %s dependencies", self.dtype)
 
     def _parse_runtime_dependencies(self, nix_path):
         # map nix_path to output path by calling nix path-info

--- a/sbomnix/main.py
+++ b/sbomnix/main.py
@@ -59,8 +59,10 @@ def getargs():
     group = parser.add_argument_group("output arguments")
     helps = "Path to csv output file (default: ./sbom.csv)"
     group.add_argument("--csv", nargs="?", help=helps, default="sbom.csv")
-    helps = "Path to cyclonedx output file (default: ./sbom.cdx.json)"
+    helps = "Path to cyclonedx json output file (default: ./sbom.cdx.json)"
     group.add_argument("--cdx", nargs="?", help=helps, default="sbom.cdx.json")
+    helps = "Path to spdx json output file (default: ./sbom.spdx.json)"
+    group.add_argument("--spdx", nargs="?", help=helps, default="sbom.spdx.json")
 
     return parser.parse_args()
 
@@ -87,6 +89,8 @@ def main():
     sbomdb = SbomDb(target_path, runtime, buildtime, args.meta)
     if args.cdx:
         sbomdb.to_cdx(args.cdx)
+    if args.spdx:
+        sbomdb.to_spdx(args.spdx)
     if args.csv:
         sbomdb.to_csv(args.csv)
 

--- a/tests/resources/README.md
+++ b/tests/resources/README.md
@@ -5,6 +5,11 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 # Test resources
-## CycloneDX 1.3 schema
+## CycloneDX 1.3 json schema
 - cdx_bom-1.3.schema.json
 - https://github.com/CycloneDX/specification/blob/9b04a94474dfcabafe7d3a9f8db6c7e5eb868adb/schema/bom-1.3.schema.json
+
+
+## SPDX 2.3 json schema
+- spdx_bom-2.3.schema.json
+- https://github.com/spdx/spdx-spec/blob/214f23d34ee287cb1db5b31c3d571af291e836f3/schemas/spdx-schema.json

--- a/tests/resources/spdx_bom-2.3.schema.json
+++ b/tests/resources/spdx_bom-2.3.schema.json
@@ -1,0 +1,740 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "$id" : "http://spdx.org/rdf/terms/2.3",
+  "title" : "SPDX 2.3",
+  "type" : "object",
+  "properties" : {
+    "SPDXID" : {
+      "type" : "string",
+      "description" : "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+    },
+    "annotations" : {
+      "description" : "Provide additional information about an SpdxElement.",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "annotationDate" : {
+            "description" : "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+            "type" : "string"
+          },
+          "annotationType" : {
+            "description" : "Type of the annotation.",
+            "type" : "string",
+            "enum" : [ "OTHER", "REVIEW" ]
+          },
+          "annotator" : {
+            "description" : "This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document.",
+            "type" : "string"
+          },
+          "comment" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "annotationDate", "annotationType", "annotator", "comment" ],
+        "additionalProperties" : false,
+        "description" : "An Annotation is a comment on an SpdxItem by an agent."
+      }
+    },
+    "comment" : {
+      "type" : "string"
+    },
+    "creationInfo" : {
+      "type" : "object",
+      "properties" : {
+        "comment" : {
+          "type" : "string"
+        },
+        "created" : {
+          "description" : "Identify when the SPDX document was originally created. The date is to be specified according to combined date and time in UTC format as specified in ISO 8601 standard.",
+          "type" : "string"
+        },
+        "creators" : {
+          "description" : "Identify who (or what, in the case of a tool) created the SPDX document. If the SPDX document was created by an individual, indicate the person's name. If the SPDX document was created on behalf of a company or organization, indicate the entity name. If the SPDX document was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate.",
+          "minItems" : 1,
+          "type" : "array",
+          "items" : {
+            "description" : "Identify who (or what, in the case of a tool) created the SPDX document. If the SPDX document was created by an individual, indicate the person's name. If the SPDX document was created on behalf of a company or organization, indicate the entity name. If the SPDX document was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate.",
+            "type" : "string"
+          }
+        },
+        "licenseListVersion" : {
+          "description" : "An optional field for creators of the SPDX file to provide the version of the SPDX License List used when the SPDX file was created.",
+          "type" : "string"
+        }
+      },
+      "required" : [ "created", "creators" ],
+      "additionalProperties" : false,
+      "description" : "One instance is required for each SPDX file produced. It provides the necessary information for forward and backward compatibility for processing tools."
+    },
+    "dataLicense" : {
+      "description" : "License expression for dataLicense. See SPDX Annex D for the license expression syntax.  Compliance with the SPDX specification includes populating the SPDX fields therein with data related to such fields (\"SPDX-Metadata\"). The SPDX specification contains numerous fields where an SPDX document creator may provide relevant explanatory text in SPDX-Metadata. Without opining on the lawfulness of \"database rights\" (in jurisdictions where applicable), such explanatory text is copyrightable subject matter in most Berne Convention countries. By using the SPDX specification, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license. For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you \"as-is\" and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.",
+      "type" : "string"
+    },
+    "externalDocumentRefs" : {
+      "description" : "Identify any external SPDX documents referenced within this SPDX document.",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "checksum" : {
+            "type" : "object",
+            "properties" : {
+              "algorithm" : {
+                "description" : "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                "type" : "string",
+                "enum" : [ "SHA1", "BLAKE3", "SHA3-384", "SHA256", "SHA384", "BLAKE2b-512", "BLAKE2b-256", "SHA3-512", "MD2", "ADLER32", "MD4", "SHA3-256", "BLAKE2b-384", "SHA512", "MD6", "MD5", "SHA224" ]
+              },
+              "checksumValue" : {
+                "description" : "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                "type" : "string"
+              }
+            },
+            "required" : [ "algorithm", "checksumValue" ],
+            "additionalProperties" : false,
+            "description" : "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+          },
+          "externalDocumentId" : {
+            "description" : "externalDocumentId is a string containing letters, numbers, ., - and/or + which uniquely identifies an external document within this document.",
+            "type" : "string"
+          },
+          "spdxDocument" : {
+            "description" : "SPDX ID for SpdxDocument.  A property containing an SPDX document.",
+            "type" : "string"
+          }
+        },
+        "required" : [ "checksum", "externalDocumentId", "spdxDocument" ],
+        "additionalProperties" : false,
+        "description" : "Information about an external SPDX document reference including the checksum. This allows for verification of the external references."
+      }
+    },
+    "hasExtractedLicensingInfos" : {
+      "description" : "Indicates that a particular ExtractedLicensingInfo was defined in the subject SpdxDocument.",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "comment" : {
+            "type" : "string"
+          },
+          "crossRefs" : {
+            "description" : "Cross Reference Detail for a license SeeAlso URL",
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "isLive" : {
+                  "description" : "Indicate a URL is still a live accessible location on the public internet",
+                  "type" : "boolean"
+                },
+                "isValid" : {
+                  "description" : "True if the URL is a valid well formed URL",
+                  "type" : "boolean"
+                },
+                "isWayBackLink" : {
+                  "description" : "True if the License SeeAlso URL points to a Wayback archive",
+                  "type" : "boolean"
+                },
+                "match" : {
+                  "description" : "Status of a License List SeeAlso URL reference if it refers to a website that matches the license text.",
+                  "type" : "string"
+                },
+                "order" : {
+                  "description" : "The ordinal order of this element within a list",
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "description" : "Timestamp",
+                  "type" : "string"
+                },
+                "url" : {
+                  "description" : "URL Reference",
+                  "type" : "string"
+                }
+              },
+              "required" : [ "url" ],
+              "additionalProperties" : false,
+              "description" : "Cross reference details for the a URL reference"
+            }
+          },
+          "extractedText" : {
+            "description" : "Provide a copy of the actual text of the license reference extracted from the package, file or snippet that is associated with the License Identifier to aid in future analysis.",
+            "type" : "string"
+          },
+          "licenseId" : {
+            "description" : "A human readable short form license identifier for a license. The license ID is either on the standard license list or the form \"LicenseRef-[idString]\" where [idString] is a unique string containing letters, numbers, \".\" or \"-\".  When used within a license expression, the license ID can optionally include a reference to an external document in the form \"DocumentRef-[docrefIdString]:LicenseRef-[idString]\" where docRefIdString is an ID for an external document reference.",
+            "type" : "string"
+          },
+          "name" : {
+            "description" : "Identify name of this SpdxElement.",
+            "type" : "string"
+          },
+          "seeAlsos" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        },
+        "required" : [ "extractedText", "licenseId" ],
+        "additionalProperties" : false,
+        "description" : "An ExtractedLicensingInfo represents a license or licensing notice that was found in a package, file or snippet. Any license text that is recognized as a license may be represented as a License rather than an ExtractedLicensingInfo."
+      }
+    },
+    "name" : {
+      "description" : "Identify name of this SpdxElement.",
+      "type" : "string"
+    },
+    "revieweds" : {
+      "description" : "Reviewed",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "comment" : {
+            "type" : "string"
+          },
+          "reviewDate" : {
+            "description" : "The date and time at which the SpdxDocument was reviewed. This value must be in UTC and have 'Z' as its timezone indicator.",
+            "type" : "string"
+          },
+          "reviewer" : {
+            "description" : "The name and, optionally, contact information of the person who performed the review. Values of this property must conform to the agent and tool syntax.  The reviewer property is deprecated in favor of Annotation with an annotationType review.",
+            "type" : "string"
+          }
+        },
+        "required" : [ "reviewDate" ],
+        "additionalProperties" : false,
+        "description" : "This class has been deprecated in favor of an Annotation with an Annotation type of review."
+      }
+    },
+    "spdxVersion" : {
+      "description" : "Provide a reference number that can be used to understand how to parse and interpret the rest of the file. It will enable both future changes to the specification and to support backward compatibility. The version number consists of a major and minor version indicator. The major field will be incremented when incompatible changes between versions are made (one or more sections are created, modified or deleted). The minor field will be incremented when backwards compatible changes are made.",
+      "type" : "string"
+    },
+    "documentNamespace" : {
+      "type" : "string",
+      "description" : "The URI provides an unambiguous mechanism for other SPDX documents to reference SPDX elements within this SPDX document."
+    },
+    "documentDescribes" : {
+      "description" : "Packages, files and/or Snippets described by this SPDX document",
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "description" : "SPDX ID for each Package, File, or Snippet."
+      }
+    },
+    "packages" : {
+      "description" : "Packages referenced in the SPDX document",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "SPDXID" : {
+            "type" : "string",
+            "description" : "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+          },
+          "annotations" : {
+            "description" : "Provide additional information about an SpdxElement.",
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "annotationDate" : {
+                  "description" : "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                  "type" : "string"
+                },
+                "annotationType" : {
+                  "description" : "Type of the annotation.",
+                  "type" : "string",
+                  "enum" : [ "OTHER", "REVIEW" ]
+                },
+                "annotator" : {
+                  "description" : "This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document.",
+                  "type" : "string"
+                },
+                "comment" : {
+                  "type" : "string"
+                }
+              },
+              "required" : [ "annotationDate", "annotationType", "annotator", "comment" ],
+              "additionalProperties" : false,
+              "description" : "An Annotation is a comment on an SpdxItem by an agent."
+            }
+          },
+          "attributionTexts" : {
+            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+            "type" : "array",
+            "items" : {
+              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+              "type" : "string"
+            }
+          },
+          "builtDate" : {
+            "description" : "This field provides a place for recording the actual date the package was built.",
+            "type" : "string"
+          },
+          "checksums" : {
+            "description" : "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.",
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "algorithm" : {
+                  "description" : "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                  "type" : "string",
+                  "enum" : [ "SHA1", "BLAKE3", "SHA3-384", "SHA256", "SHA384", "BLAKE2b-512", "BLAKE2b-256", "SHA3-512", "MD2", "ADLER32", "MD4", "SHA3-256", "BLAKE2b-384", "SHA512", "MD6", "MD5", "SHA224" ]
+                },
+                "checksumValue" : {
+                  "description" : "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                  "type" : "string"
+                }
+              },
+              "required" : [ "algorithm", "checksumValue" ],
+              "additionalProperties" : false,
+              "description" : "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+            }
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "copyrightText" : {
+            "description" : "The text of copyright declarations recited in the package, file or snippet.\n\nIf the copyrightText field is not present, it implies an equivalent meaning to NOASSERTION.",
+            "type" : "string"
+          },
+          "description" : {
+            "description" : "Provides a detailed description of the package.",
+            "type" : "string"
+          },
+          "downloadLocation" : {
+            "description" : "The URI at which this package is available for download. Private (i.e., not publicly reachable) URIs are acceptable as values of this property. The values http://spdx.org/rdf/terms#none and http://spdx.org/rdf/terms#noassertion may be used to specify that the package is not downloadable or that no attempt was made to determine its download location, respectively.",
+            "type" : "string"
+          },
+          "externalRefs" : {
+            "description" : "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package.",
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "comment" : {
+                  "type" : "string"
+                },
+                "referenceCategory" : {
+                  "description" : "Category for the external reference",
+                  "type" : "string",
+                  "enum" : [ "OTHER", "PERSISTENT-ID", "SECURITY", "PACKAGE-MANAGER" ]
+                },
+                "referenceLocator" : {
+                  "description" : "The unique string with no spaces necessary to access the package-specific information, metadata, or content within the target location. The format of the locator is subject to constraints defined by the <type>.",
+                  "type" : "string"
+                },
+                "referenceType" : {
+                  "description" : "Type of the external reference. These are definined in an appendix in the SPDX specification.",
+                  "type" : "string"
+                }
+              },
+              "required" : [ "referenceCategory", "referenceLocator", "referenceType" ],
+              "additionalProperties" : false,
+              "description" : "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package."
+            }
+          },
+          "filesAnalyzed" : {
+            "description" : "Indicates whether the file content of this package has been available for or subjected to analysis when creating the SPDX document. If false indicates packages that represent metadata or URI references to a project, product, artifact, distribution or a component. If set to false, the package must not contain any files.",
+            "type" : "boolean"
+          },
+          "hasFiles" : {
+            "description" : "Indicates that a particular file belongs to a package.",
+            "type" : "array",
+            "items" : {
+              "description" : "SPDX ID for File.  Indicates that a particular file belongs to a package.",
+              "type" : "string"
+            }
+          },
+          "homepage" : {
+            "type" : "string"
+          },
+          "licenseComments" : {
+            "description" : "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+            "type" : "string"
+          },
+          "licenseConcluded" : {
+            "description" : "License expression for licenseConcluded. See SPDX Annex D for the license expression syntax.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the SPDX Item.\n\nIf the licenseConcluded field is not present for an SPDX Item, it implies an equivalent meaning to NOASSERTION.",
+            "type" : "string"
+          },
+          "licenseDeclared" : {
+            "description" : "License expression for licenseDeclared. See SPDX Annex D for the license expression syntax.  The licensing that the creators of the software in the package, or the packager, have declared. Declarations by the original software creator should be preferred, if they exist.",
+            "type" : "string"
+          },
+          "licenseInfoFromFiles" : {
+            "description" : "The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.\n\nIf the licenseInfoFromFiles field is not present for a package and filesAnalyzed property for that same pacakge is true or omitted, it implies an equivalent meaning to NOASSERTION.",
+            "type" : "array",
+            "items" : {
+              "description" : "License expression for licenseInfoFromFiles. See SPDX Annex D for the license expression syntax.  The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.\n\nIf the licenseInfoFromFiles field is not present for a package and filesAnalyzed property for that same pacakge is true or omitted, it implies an equivalent meaning to NOASSERTION.",
+              "type" : "string"
+            }
+          },
+          "name" : {
+            "description" : "Identify name of this SpdxElement.",
+            "type" : "string"
+          },
+          "originator" : {
+            "description" : "The name and, optionally, contact information of the person or organization that originally created the package. Values of this property must conform to the agent and tool syntax.",
+            "type" : "string"
+          },
+          "packageFileName" : {
+            "description" : "The base name of the package file name. For example, zlib-1.2.5.tar.gz.",
+            "type" : "string"
+          },
+          "packageVerificationCode" : {
+            "type" : "object",
+            "properties" : {
+              "packageVerificationCodeExcludedFiles" : {
+                "description" : "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                "type" : "array",
+                "items" : {
+                  "description" : "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                  "type" : "string"
+                }
+              },
+              "packageVerificationCodeValue" : {
+                "description" : "The actual package verification code as a hex encoded value.",
+                "type" : "string"
+              }
+            },
+            "required" : [ "packageVerificationCodeValue" ],
+            "additionalProperties" : false,
+            "description" : "A manifest based verification code (the algorithm is defined in section 4.7 of the full specification) of the SPDX Item. This allows consumers of this data and/or database to determine if an SPDX item they have in hand is identical to the SPDX item from which the data was produced. This algorithm works even if the SPDX document is included in the SPDX item."
+          },
+          "primaryPackagePurpose" : {
+            "description" : "This field provides information about the primary purpose of the identified package. Package Purpose is intrinsic to how the package is being used rather than the content of the package.",
+            "type" : "string",
+            "enum" : [ "OTHER", "INSTALL", "ARCHIVE", "FIRMWARE", "APPLICATION", "FRAMEWORK", "LIBRARY", "CONTAINER", "SOURCE", "DEVICE", "OPERATING_SYSTEM", "FILE" ]
+          },
+          "releaseDate" : {
+            "description" : "This field provides a place for recording the date the package was released.",
+            "type" : "string"
+          },
+          "sourceInfo" : {
+            "description" : "Allows the producer(s) of the SPDX document to describe how the package was acquired and/or changed from the original source.",
+            "type" : "string"
+          },
+          "summary" : {
+            "description" : "Provides a short description of the package.",
+            "type" : "string"
+          },
+          "supplier" : {
+            "description" : "The name and, optionally, contact information of the person or organization who was the immediate supplier of this package to the recipient. The supplier may be different than originator when the software has been repackaged. Values of this property must conform to the agent and tool syntax.",
+            "type" : "string"
+          },
+          "validUntilDate" : {
+            "description" : "This field provides a place for recording the end of the support period for a package from the supplier.",
+            "type" : "string"
+          },
+          "versionInfo" : {
+            "description" : "Provides an indication of the version of the package that is described by this SpdxDocument.",
+            "type" : "string"
+          }
+        },
+        "required" : [ "SPDXID", "downloadLocation", "name" ],
+        "additionalProperties" : false
+      }
+    },
+    "files" : {
+      "description" : "Files referenced in the SPDX document",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "SPDXID" : {
+            "type" : "string",
+            "description" : "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+          },
+          "annotations" : {
+            "description" : "Provide additional information about an SpdxElement.",
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "annotationDate" : {
+                  "description" : "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                  "type" : "string"
+                },
+                "annotationType" : {
+                  "description" : "Type of the annotation.",
+                  "type" : "string",
+                  "enum" : [ "OTHER", "REVIEW" ]
+                },
+                "annotator" : {
+                  "description" : "This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document.",
+                  "type" : "string"
+                },
+                "comment" : {
+                  "type" : "string"
+                }
+              },
+              "required" : [ "annotationDate", "annotationType", "annotator", "comment" ],
+              "additionalProperties" : false,
+              "description" : "An Annotation is a comment on an SpdxItem by an agent."
+            }
+          },
+          "artifactOfs" : {
+            "description" : "Indicates the project in which the SpdxElement originated. Tools must preserve doap:homepage and doap:name properties and the URI (if one is known) of doap:Project resources that are values of this property. All other properties of doap:Projects are not directly supported by SPDX and may be dropped when translating to or from some SPDX formats.",
+            "type" : "array",
+            "items" : {
+              "type" : "object"
+            }
+          },
+          "attributionTexts" : {
+            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+            "type" : "array",
+            "items" : {
+              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+              "type" : "string"
+            }
+          },
+          "checksums" : {
+            "description" : "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.",
+            "minItems" : 1,
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "algorithm" : {
+                  "description" : "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                  "type" : "string",
+                  "enum" : [ "SHA1", "BLAKE3", "SHA3-384", "SHA256", "SHA384", "BLAKE2b-512", "BLAKE2b-256", "SHA3-512", "MD2", "ADLER32", "MD4", "SHA3-256", "BLAKE2b-384", "SHA512", "MD6", "MD5", "SHA224" ]
+                },
+                "checksumValue" : {
+                  "description" : "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                  "type" : "string"
+                }
+              },
+              "required" : [ "algorithm", "checksumValue" ],
+              "additionalProperties" : false,
+              "description" : "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+            }
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "copyrightText" : {
+            "description" : "The text of copyright declarations recited in the package, file or snippet.\n\nIf the copyrightText field is not present, it implies an equivalent meaning to NOASSERTION.",
+            "type" : "string"
+          },
+          "fileContributors" : {
+            "description" : "This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content.",
+            "type" : "array",
+            "items" : {
+              "description" : "This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content.",
+              "type" : "string"
+            }
+          },
+          "fileDependencies" : {
+            "description" : "This field is deprecated since SPDX 2.0 in favor of using Section 7 which provides more granularity about relationships.",
+            "type" : "array",
+            "items" : {
+              "description" : "SPDX ID for File.  This field is deprecated since SPDX 2.0 in favor of using Section 7 which provides more granularity about relationships.",
+              "type" : "string"
+            }
+          },
+          "fileName" : {
+            "description" : "The name of the file relative to the root of the package.",
+            "type" : "string"
+          },
+          "fileTypes" : {
+            "description" : "The type of the file.",
+            "type" : "array",
+            "items" : {
+              "description" : "The type of the file.",
+              "type" : "string",
+              "enum" : [ "OTHER", "DOCUMENTATION", "IMAGE", "VIDEO", "ARCHIVE", "SPDX", "APPLICATION", "SOURCE", "BINARY", "TEXT", "AUDIO" ]
+            }
+          },
+          "licenseComments" : {
+            "description" : "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+            "type" : "string"
+          },
+          "licenseConcluded" : {
+            "description" : "License expression for licenseConcluded. See SPDX Annex D for the license expression syntax.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the SPDX Item.\n\nIf the licenseConcluded field is not present for an SPDX Item, it implies an equivalent meaning to NOASSERTION.",
+            "type" : "string"
+          },
+          "licenseInfoInFiles" : {
+            "description" : "Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.\n\nIf the licenseInfoInFile field is not present for a file, it implies an equivalent meaning to NOASSERTION.",
+            "type" : "array",
+            "items" : {
+              "description" : "License expression for licenseInfoInFile. See SPDX Annex D for the license expression syntax.  Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.\n\nIf the licenseInfoInFile field is not present for a file, it implies an equivalent meaning to NOASSERTION.",
+              "type" : "string"
+            }
+          },
+          "noticeText" : {
+            "description" : "This field provides a place for the SPDX file creator to record potential legal notices found in the file. This may or may not include copyright statements.",
+            "type" : "string"
+          }
+        },
+        "required" : [ "SPDXID", "checksums", "fileName" ],
+        "additionalProperties" : false
+      }
+    },
+    "snippets" : {
+      "description" : "Snippets referenced in the SPDX document",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "SPDXID" : {
+            "type" : "string",
+            "description" : "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+          },
+          "annotations" : {
+            "description" : "Provide additional information about an SpdxElement.",
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "annotationDate" : {
+                  "description" : "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                  "type" : "string"
+                },
+                "annotationType" : {
+                  "description" : "Type of the annotation.",
+                  "type" : "string",
+                  "enum" : [ "OTHER", "REVIEW" ]
+                },
+                "annotator" : {
+                  "description" : "This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document.",
+                  "type" : "string"
+                },
+                "comment" : {
+                  "type" : "string"
+                }
+              },
+              "required" : [ "annotationDate", "annotationType", "annotator", "comment" ],
+              "additionalProperties" : false,
+              "description" : "An Annotation is a comment on an SpdxItem by an agent."
+            }
+          },
+          "attributionTexts" : {
+            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+            "type" : "array",
+            "items" : {
+              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+              "type" : "string"
+            }
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "copyrightText" : {
+            "description" : "The text of copyright declarations recited in the package, file or snippet.\n\nIf the copyrightText field is not present, it implies an equivalent meaning to NOASSERTION.",
+            "type" : "string"
+          },
+          "licenseComments" : {
+            "description" : "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+            "type" : "string"
+          },
+          "licenseConcluded" : {
+            "description" : "License expression for licenseConcluded. See SPDX Annex D for the license expression syntax.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the SPDX Item.\n\nIf the licenseConcluded field is not present for an SPDX Item, it implies an equivalent meaning to NOASSERTION.",
+            "type" : "string"
+          },
+          "licenseInfoInSnippets" : {
+            "description" : "Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.\n\nIf the licenseInfoInSnippet field is not present for a snippet, it implies an equivalent meaning to NOASSERTION.",
+            "type" : "array",
+            "items" : {
+              "description" : "License expression for licenseInfoInSnippet. See SPDX Annex D for the license expression syntax.  Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.\n\nIf the licenseInfoInSnippet field is not present for a snippet, it implies an equivalent meaning to NOASSERTION.",
+              "type" : "string"
+            }
+          },
+          "name" : {
+            "description" : "Identify name of this SpdxElement.",
+            "type" : "string"
+          },
+          "ranges" : {
+            "description" : "This field defines the byte range in the original host file (in X.2) that the snippet information applies to",
+            "minItems" : 1,
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "endPointer" : {
+                  "type" : "object",
+                  "properties" : {
+                    "reference" : {
+                      "description" : "SPDX ID for File",
+                      "type" : "string"
+                    },
+                    "offset" : {
+                      "type" : "integer",
+                      "description" : "Byte offset in the file"
+                    },
+                    "lineNumber" : {
+                      "type" : "integer",
+                      "description" : "line number offset in the file"
+                    }
+                  },
+                  "required" : [ "reference" ],
+                  "additionalProperties" : false
+                },
+                "startPointer" : {
+                  "type" : "object",
+                  "properties" : {
+                    "reference" : {
+                      "description" : "SPDX ID for File",
+                      "type" : "string"
+                    },
+                    "offset" : {
+                      "type" : "integer",
+                      "description" : "Byte offset in the file"
+                    },
+                    "lineNumber" : {
+                      "type" : "integer",
+                      "description" : "line number offset in the file"
+                    }
+                  },
+                  "required" : [ "reference" ],
+                  "additionalProperties" : false
+                }
+              },
+              "required" : [ "endPointer", "startPointer" ],
+              "additionalProperties" : false
+            }
+          },
+          "snippetFromFile" : {
+            "description" : "SPDX ID for File.  File containing the SPDX element (e.g. the file contaning a snippet).",
+            "type" : "string"
+          }
+        },
+        "required" : [ "SPDXID", "name", "ranges", "snippetFromFile" ],
+        "additionalProperties" : false
+      }
+    },
+    "relationships" : {
+      "description" : "Relationships referenced in the SPDX document",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "spdxElementId" : {
+            "type" : "string",
+            "description" : "Id to which the SPDX element is related"
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "relatedSpdxElement" : {
+            "description" : "SPDX ID for SpdxElement.  A related SpdxElement.",
+            "type" : "string"
+          },
+          "relationshipType" : {
+            "description" : "Describes the type of relationship between two SPDX elements.",
+            "type" : "string",
+            "enum" : [ "VARIANT_OF", "COPY_OF", "PATCH_FOR", "TEST_DEPENDENCY_OF", "CONTAINED_BY", "DATA_FILE_OF", "OPTIONAL_COMPONENT_OF", "ANCESTOR_OF", "GENERATES", "CONTAINS", "OPTIONAL_DEPENDENCY_OF", "FILE_ADDED", "REQUIREMENT_DESCRIPTION_FOR", "DEV_DEPENDENCY_OF", "DEPENDENCY_OF", "BUILD_DEPENDENCY_OF", "DESCRIBES", "PREREQUISITE_FOR", "HAS_PREREQUISITE", "PROVIDED_DEPENDENCY_OF", "DYNAMIC_LINK", "DESCRIBED_BY", "METAFILE_OF", "DEPENDENCY_MANIFEST_OF", "PATCH_APPLIED", "RUNTIME_DEPENDENCY_OF", "TEST_OF", "TEST_TOOL_OF", "DEPENDS_ON", "SPECIFICATION_FOR", "FILE_MODIFIED", "DISTRIBUTION_ARTIFACT", "AMENDS", "DOCUMENTATION_OF", "GENERATED_FROM", "STATIC_LINK", "OTHER", "BUILD_TOOL_OF", "TEST_CASE_OF", "PACKAGE_OF", "DESCENDANT_OF", "FILE_DELETED", "EXPANDED_FROM_ARCHIVE", "DEV_TOOL_OF", "EXAMPLE_OF" ]
+          }
+        },
+        "required" : [ "spdxElementId", "relatedSpdxElement", "relationshipType" ],
+        "additionalProperties" : false
+      }
+    }
+  },
+  "required" : [ "SPDXID", "creationInfo", "dataLicense", "name", "spdxVersion" ],
+  "additionalProperties" : false
+}

--- a/tests/resources/spdx_bom-2.3.schema.json.license
+++ b/tests/resources/spdx_bom-2.3.schema.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Linux Foundation and its Contributors
+
+SPDX-License-Identifier: CC-BY-3.0

--- a/tests/test_sbomnix.py
+++ b/tests/test_sbomnix.py
@@ -48,109 +48,109 @@ def set_up_test_data():
 
 
 def test_sbomnix_help():
-    """
-    Test sbomnix command line argument: '-h'
-    """
+    """Test sbomnix command line argument: '-h'"""
     cmd = [SBOMNIX, "-h"]
     assert subprocess.run(cmd, check=True).returncode == 0
 
 
 def test_sbomnix_help_flake():
-    """
-    Test sbomnix command line argument: '-h' running sbomnix as flake
-    """
-
+    """Test sbomnix command line argument: '-h' running sbomnix as flake"""
     cmd = ["nix", "run", f"{REPOROOT}#sbomnix", "--", "-h"]
     assert subprocess.run(cmd, check=True).returncode == 0
 
 
-def test_sbomnix_cdx_type_runtime():
-    """
-    Test sbomnix '--type=runtime' generates valid CycloneDX json
-    """
-
+def test_sbomnix_type_runtime():
+    """Test sbomnix '--type=runtime' generates valid CycloneDX json"""
     out_path_cdx = TEST_WORK_DIR / "sbom_cdx_test.json"
+    out_path_spdx = TEST_WORK_DIR / "sbom_spdx_test.json"
     cmd = [
         SBOMNIX,
         TEST_NIX_RESULT,
         "--cdx",
         out_path_cdx.as_posix(),
+        "--spdx",
+        out_path_spdx.as_posix(),
         "--type",
         "runtime",
     ]
     assert subprocess.run(cmd, check=True).returncode == 0
     assert out_path_cdx.exists()
-    schema_path = MYDIR / "resources" / "cdx_bom-1.3.schema.json"
-    assert schema_path.exists()
-    validate_json(out_path_cdx.as_posix(), schema_path)
+    assert out_path_spdx.exists()
+    cdx_schema_path = MYDIR / "resources" / "cdx_bom-1.3.schema.json"
+    assert cdx_schema_path.exists()
+    validate_json(out_path_cdx.as_posix(), cdx_schema_path)
+    spdx_schema_path = MYDIR / "resources" / "spdx_bom-2.3.schema.json"
+    assert spdx_schema_path.exists()
+    validate_json(out_path_spdx.as_posix(), spdx_schema_path)
 
 
-def test_sbomnix_cdx_type_buildtime():
-    """
-    Test sbomnix '--type=runtime' generates valid CycloneDX json
-    """
-
+def test_sbomnix_type_buildtime():
+    """Test sbomnix '--type=runtime' generates valid CycloneDX json"""
     out_path_cdx = TEST_WORK_DIR / "sbom_cdx_test.json"
+    out_path_spdx = TEST_WORK_DIR / "sbom_spdx_test.json"
     cmd = [
         SBOMNIX,
         TEST_NIX_RESULT,
         "--cdx",
         out_path_cdx.as_posix(),
+        "--spdx",
+        out_path_spdx.as_posix(),
         "--type",
         "buildtime",
     ]
     assert subprocess.run(cmd, check=True).returncode == 0
     assert out_path_cdx.exists()
-    schema_path = MYDIR / "resources" / "cdx_bom-1.3.schema.json"
-    assert schema_path.exists()
-    validate_json(out_path_cdx.as_posix(), schema_path)
+    assert out_path_spdx.exists()
+    cdx_schema_path = MYDIR / "resources" / "cdx_bom-1.3.schema.json"
+    assert cdx_schema_path.exists()
+    validate_json(out_path_cdx.as_posix(), cdx_schema_path)
+    spdx_schema_path = MYDIR / "resources" / "spdx_bom-2.3.schema.json"
+    assert spdx_schema_path.exists()
+    validate_json(out_path_spdx.as_posix(), spdx_schema_path)
 
 
 def test_sbomnix_cdx_type_both():
-    """
-    Test sbomnix '--type=both' generates valid CycloneDX json
-    """
-
+    """Test sbomnix '--type=both' generates valid CycloneDX json"""
     out_path_cdx = TEST_WORK_DIR / "sbom_cdx_test.json"
+    out_path_spdx = TEST_WORK_DIR / "sbom_spdx_test.json"
     cmd = [
         SBOMNIX,
         TEST_NIX_RESULT,
         "--cdx",
         out_path_cdx.as_posix(),
+        "--spdx",
+        out_path_spdx.as_posix(),
         "--type",
         "both",
     ]
     assert subprocess.run(cmd, check=True).returncode == 0
     assert out_path_cdx.exists()
-    schema_path = MYDIR / "resources" / "cdx_bom-1.3.schema.json"
-    assert schema_path.exists()
-    validate_json(out_path_cdx.as_posix(), schema_path)
+    assert out_path_spdx.exists()
+    cdx_schema_path = MYDIR / "resources" / "cdx_bom-1.3.schema.json"
+    assert cdx_schema_path.exists()
+    validate_json(out_path_cdx.as_posix(), cdx_schema_path)
+    spdx_schema_path = MYDIR / "resources" / "spdx_bom-2.3.schema.json"
+    assert spdx_schema_path.exists()
+    validate_json(out_path_spdx.as_posix(), spdx_schema_path)
 
 
 ################################################################################
 
 
 def test_nixgraph_help():
-    """
-    Test nixgraph command line argument: '-h'
-    """
+    """Test nixgraph command line argument: '-h'"""
     cmd = [NIXGRAPH, "-h"]
     assert subprocess.run(cmd, check=True).returncode == 0
 
 
 def test_nixgraph_help_flake():
-    """
-    Test nixgraph command line argument: '-h' running nixgraph as flake
-    """
-
+    """Test nixgraph command line argument: '-h' running nixgraph as flake"""
     cmd = ["nix", "run", f"{REPOROOT}#nixgraph", "--", "-h"]
     assert subprocess.run(cmd, check=True).returncode == 0
 
 
 def test_nixgraph_png():
-    """
-    Test nixgraph with png output generates valid png image
-    """
+    """Test nixgraph with png output generates valid png image"""
     png_out = TEST_WORK_DIR / "graph.png"
     cmd = [NIXGRAPH, TEST_NIX_RESULT, "--out", png_out, "--depth", "3"]
     assert subprocess.run(cmd, check=True).returncode == 0
@@ -160,9 +160,7 @@ def test_nixgraph_png():
 
 
 def test_nixgraph_csv():
-    """
-    Test nixgraph with csv output generates valid csv
-    """
+    """Test nixgraph with csv output generates valid csv"""
     csv_out = TEST_WORK_DIR / "graph.csv"
     cmd = [NIXGRAPH, TEST_NIX_RESULT, "--out", csv_out, "--depth", "3"]
     assert subprocess.run(cmd, check=True).returncode == 0
@@ -173,9 +171,7 @@ def test_nixgraph_csv():
 
 
 def test_nixgraph_csv_buildtime():
-    """
-    Test nixgraph with buildtime csv output generates valid csv
-    """
+    """Test nixgraph with buildtime csv output generates valid csv"""
     csv_out = TEST_WORK_DIR / "graph_buildtime.csv"
     cmd = [NIXGRAPH, TEST_NIX_RESULT, "--out", csv_out, "--buildtime"]
     assert subprocess.run(cmd, check=True).returncode == 0
@@ -186,9 +182,7 @@ def test_nixgraph_csv_buildtime():
 
 
 def test_nixgraph_csv_graph_inverse():
-    """
-    Test nixgraph with '--inverse' argument
-    """
+    """Test nixgraph with '--inverse' argument"""
     csv_out = TEST_WORK_DIR / "graph.csv"
     cmd = [
         NIXGRAPH,
@@ -235,9 +229,7 @@ def test_nixgraph_csv_graph_inverse():
 
 
 def test_compare_deps_runtime():
-    """
-    Compare nixgraph vs sbom runtime dependencies
-    """
+    """Compare nixgraph vs sbom runtime dependencies"""
     graph_csv_out = TEST_WORK_DIR / "graph.csv"
     cmd = [
         NIXGRAPH,
@@ -272,9 +264,7 @@ def test_compare_deps_runtime():
 
 
 def test_compare_deps_buildtime():
-    """
-    Compare nixgraph vs sbom buildtime dependencies
-    """
+    """Compare nixgraph vs sbom buildtime dependencies"""
     graph_csv_out = TEST_WORK_DIR / "graph.csv"
     cmd = [
         NIXGRAPH,
@@ -309,10 +299,8 @@ def test_compare_deps_buildtime():
     assert subprocess.run(cmd, check=True).returncode == 0
 
 
-def test_compare_sboms():
-    """
-    Compare two sbomnix runs with same target produce the same sbom
-    """
+def test_compare_subsequent_cdx_sboms():
+    """Compare two sbomnix runs with same target produce the same cdx sbom"""
     out_path_cdx_1 = TEST_WORK_DIR / "sbom_cdx_test_1.json"
     cmd = [
         SBOMNIX,
@@ -345,24 +333,78 @@ def test_compare_sboms():
     assert subprocess.run(cmd, check=True).returncode == 0
 
 
+def test_compare_subsequent_spdx_sboms():
+    """Compare two sbomnix runs with same target produce the same spdx sbom"""
+    out_path_spdx_1 = TEST_WORK_DIR / "sbom_spdx_test_1.json"
+    cmd = [
+        SBOMNIX,
+        TEST_NIX_RESULT,
+        "--spdx",
+        out_path_spdx_1.as_posix(),
+        "--type",
+        "both",
+    ]
+    assert subprocess.run(cmd, check=True).returncode == 0
+    assert out_path_spdx_1.exists()
+
+    out_path_spdx_2 = TEST_WORK_DIR / "sbom_spdx_test_2.json"
+    cmd = [
+        SBOMNIX,
+        TEST_NIX_RESULT,
+        "--spdx",
+        out_path_spdx_2.as_posix(),
+        "--type",
+        "both",
+    ]
+    assert subprocess.run(cmd, check=True).returncode == 0
+    assert out_path_spdx_2.exists()
+
+    cmd = [
+        COMPARE_SBOMS,
+        out_path_spdx_1,
+        out_path_spdx_2,
+    ]
+    assert subprocess.run(cmd, check=True).returncode == 0
+
+
+def test_compare_spdx_and_cdx_sboms():
+    """Compare spdx and cdx sboms from the same sbomnix invocation"""
+    out_path_spdx = TEST_WORK_DIR / "sbom_spdx_test.json"
+    out_path_cdx = TEST_WORK_DIR / "sbom_cdx_test.json"
+    cmd = [
+        SBOMNIX,
+        TEST_NIX_RESULT,
+        "--cdx",
+        out_path_cdx.as_posix(),
+        "--spdx",
+        out_path_spdx.as_posix(),
+        "--type",
+        "both",
+    ]
+    assert subprocess.run(cmd, check=True).returncode == 0
+    assert out_path_cdx.exists()
+    assert out_path_spdx.exists()
+
+    cmd = [
+        COMPARE_SBOMS,
+        out_path_cdx,
+        out_path_spdx,
+    ]
+    assert subprocess.run(cmd, check=True).returncode == 0
+
+
 ################################################################################
 
 
 def test_vulnxscan_help_flake():
-    """
-    Test vulnxscan command line argument: '-h' running vulnxscan as flake
-    """
-
+    """Test vulnxscan command line argument: '-h' running vulnxscan as flake"""
     cmd = ["nix", "run", f"{REPOROOT}#vulnxscan", "--", "-h"]
     assert subprocess.run(cmd, check=True).returncode == 0
 
 
 @pytest.mark.skip_in_ci
 def test_vulnxscan_scan_nix_result():
-    """
-    Test vulnxscan scan with TEST_NIX_RESULT as input
-    """
-
+    """Test vulnxscan scan with TEST_NIX_RESULT as input"""
     cmd = [
         "nix",
         "run",
@@ -375,10 +417,7 @@ def test_vulnxscan_scan_nix_result():
 
 @pytest.mark.skip_in_ci
 def test_vulnxscan_scan_sbom():
-    """
-    Test vulnxscan scan with SBOM as input
-    """
-
+    """Test vulnxscan scan with SBOM as input"""
     out_path_cdx = TEST_WORK_DIR / "sbom_cdx_test.json"
     cmd = [
         "nix",


### PR DESCRIPTION
Add support for sbom output in spdx json format
- sbomnix: support spdx json output (--spdx) argument
- test: add relevant test cases to validate spdx output
- include spdx documents from sbomnix itself to release assets
- fix relevant documentation

In addition this commit includes a fix to Makefile to prune python eggs from the list of python targets.

Signed-off-by: Henri Rosten <henri.rosten@unikie.com>