### PR TITLE
vulnxscan: make grype and vulnix depenendencies explicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - source /etc/profile.d/nix.sh
   - nix-build '<nixpkgs>' -A hello
   # Install python requirements:
-  - pip3 install -r requirements.txt
+  - pip install -r requirements.txt
 script:
   # Ensure 'test-ci' targets pass:
   - make test-ci

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 SHELL := bash
-PYTHON_TARGETS := $(shell find . -path ./venv -prune -o -path "*.eggs" -prune -o -name "*.py")
+PYTHON_TARGETS := $(shell find . -name "*.py" ! -path "*venv*" ! -path "*eggs*")
 
 define target_success
 	@printf "\033[32m==> Target \"$(1)\" passed\033[0m\n\n"
@@ -25,22 +25,22 @@ help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?##.*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install sbomnix
-	pip3 install --user .
+	pip install --user .
 	$(call try_run_sbomnix,$@)
 	$(call target_success,$@)
 
 install-dev: uninstall install-dev-requirements ## Install for development
-	pip3 install --editable .
+	pip install --editable .
 	$(call try_run_sbomnix,$@)
 	$(call target_success,$@)
 
 uninstall: ## Uninstall sbomnix
 	find . -name '*.egg-info' -exec rm -fr {} +
-	pip3 uninstall -y sbomnix 
+	pip uninstall -y sbomnix 
 	$(call target_success,$@)
 
 install-dev-requirements: clean ## Install all requirements
-	pip3 install -q -r requirements.txt --no-cache-dir
+	pip install -q -r requirements.txt --no-cache-dir
 	$(call target_success,$@)
 
 pre-push: test black style pylint reuse-lint  ## Run tests, pycodestyle, pylint, reuse-lint

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Running `sbomnix` as Python script requires Python packages specified in [requir
 ```bash
 $ git clone https://github.com/tiiuae/sbomnix
 $ cd sbomnix
-$ pip3 install --user -r requirements.txt
+$ pip install --user -r requirements.txt
 ```
 After requirements have been installed, you can run sbomnix without installation as follows:
 ```bash

--- a/default.nix
+++ b/default.nix
@@ -3,12 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   pkgs ? import <nixpkgs> {},
-  pythonPackages ? pkgs.python3Packages
+  pythonPackages ? pkgs.python3Packages,
+  vulnix ? import ./scripts/vulnxscan/vulnix.nix { nixpkgs=pkgs.path; pkgs=pkgs; },
 }:
 
 pythonPackages.buildPythonPackage rec {
   pname = "sbomnix";
-  version = "1.3.0";
+  version = "1.4.1";
   format = "setuptools";
 
   src = ./.;
@@ -22,6 +23,7 @@ pythonPackages.buildPythonPackage rec {
   propagatedBuildInputs = [ 
     pkgs.reuse
     pkgs.grype
+    vulnix
     pythonPackages.numpy
     pythonPackages.pandas
     pythonPackages.colorlog

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675545634,
-        "narHash": "sha256-TbQeQcM5TA/wIho6xtzG+inUfiGzUXi8ewwttiQWYJE=",
+        "lastModified": 1676202775,
+        "narHash": "sha256-gV/RnfVZkGLHn+5rmX2GSh5aquVHpWOJw1cnpEV03tQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0591d6b57bfeb55dfeec99a671843337bc2c3323",
+        "rev": "d917136f550a8c36efb1724390c7245105f79023",
         "type": "github"
       },
       "original": {

--- a/scripts/vulnxscan/vulnix.nix
+++ b/scripts/vulnxscan/vulnix.nix
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{ nixpkgs ? <nixpkgs>
+, pkgs ? import nixpkgs {}
+, lib ? pkgs.lib
+}:
+
+# Use build in upstream nixpkgs
+(pkgs.callPackage "${nixpkgs}/pkgs/tools/security/vulnix" {
+  python3Packages = pkgs.python3Packages;
+}).overrideAttrs (
+  old: rec {
+    # We use vulnix from 'https://github.com/henrirosten/vulnix' to get
+    # vulnix support for runtime-only scan ('-C' command-line option)
+    # which is currently not available in released version of vulnix.
+    src = pkgs.fetchFromGitHub {
+      owner = "henrirosten";
+      repo = "vulnix";
+      rev = "ad28b2924027a44a9b81493a0f9de1b0e8641005";
+      sha256 = "sha256-KXvmnaMjv//zd4aSwu4qmbon1Iyzdod6CPms7LIxeVU=";
+    };
+    version = "1.10.2.dev0";
+    name = "vulnix-${version}";
+  }
+)

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   pkgs ? import <nixpkgs> {},
-  pythonPackages ? pkgs.python3Packages
+  pythonPackages ? pkgs.python3Packages,
+  vulnix ? import ./scripts/vulnxscan/vulnix.nix { nixpkgs=pkgs.path; pkgs=pkgs; },
 }:
 
 pkgs.mkShell {
@@ -12,6 +13,8 @@ pkgs.mkShell {
   buildInputs = [ 
     pkgs.reuse
     pkgs.grype
+    vulnix
+    pythonPackages.pip
     pythonPackages.numpy
     pythonPackages.pandas
     pythonPackages.colorlog
@@ -28,6 +31,10 @@ pkgs.mkShell {
     pythonPackages.venvShellHook
   ];
   venvDir = "venv";
+  # https://github.com/NixOS/nix/issues/1009:
+  shellHook = ''
+    export TMPDIR="/tmp"
+  '';
   postShellHook = ''
     make install-dev
   '';


### PR DESCRIPTION
- Make grype and vulnix dependencies explicit
- Flake update
- Use pip in place of pip3 in documentation and Makefile
- Up the version to 1.4.1

Signed-off-by: Henri Rosten <henri.rosten@unikie.com>