### PR TITLE
sbomnix: fix nix dev shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -31,11 +31,11 @@ pkgs.mkShell {
     pythonPackages.venvShellHook
   ];
   venvDir = "venv";
-  # https://github.com/NixOS/nix/issues/1009:
-  shellHook = ''
-    export TMPDIR="/tmp"
-  '';
   postShellHook = ''
+    # https://github.com/NixOS/nix/issues/1009:
+    export TMPDIR="/tmp"
+    
+    # Enter python development environment
     make install-dev
   '';
 }


### PR DESCRIPTION
This commit fixes an issue that made the sbomnix nix development shell not trigger the venvShellHook. This issue was introduced in commit: 60c81a4de4249142c763b657bae6063b8500d6fc.