### PR TITLE
derivation.py: improve derivation attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,12 +75,16 @@ reuse-lint: clean ## Check with reuse lint
 
 release-asset: clean install-dev-requirements ## Build release asset
 	nix build
+	nix-shell -p nix-info --run "nix-info -m"
+	nix-env -qa --meta --json -f $(shell nix-shell -p nix-info --run "nix-info -m" | grep "nixpkgs: " | cut -d'`' -f2) '.*' >meta.json
 	mkdir -p build/
 	nix run .#sbomnix -- result --type=runtime \
+		--meta=./meta.json \
         --cdx=./build/sbom.runtime.cdx.json \
         --spdx=./build/sbom.runtime.spdx.json \
         --csv=./build/sbom.runtime.csv
 	nix run .#sbomnix -- result --type=buildtime \
+		--meta=./meta.json \
         --cdx=./build/sbom.buildtime.cdx.json \
         --spdx=./build/sbom.buildtime.spdx.json \
         --csv=./build/sbom.buildtime.csv

--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@
 
 pythonPackages.buildPythonPackage rec {
   pname = "sbomnix";
-  version = "1.4.1";
+  version = "1.4.2";
   format = "setuptools";
 
   src = ./.;

--- a/tests/compare_deps.py
+++ b/tests/compare_deps.py
@@ -78,9 +78,6 @@ def _parse_sbom(path):
                     outpaths.append(prop_dict["value"])
                 elif "drv_path" in prop_dict["name"]:
                     setcol("drv_path", []).append(prop_dict["value"])
-                else:
-                    _LOG.fatal("Unexpected property: %s", prop_dict)
-                    sys.exit(1)
             setcol("out_path", []).append(outpaths)
         df_components = pd.DataFrame(comp_parsed_dict)
 

--- a/tests/test_sbomnix.py
+++ b/tests/test_sbomnix.py
@@ -47,6 +47,23 @@ def set_up_test_data():
     shutil.rmtree(TEST_WORK_DIR)
 
 
+################################################################################
+
+
+def test_nix_shell():
+    """Test nix-shell doesn't fail and enters venv"""
+    # Test running nix-shell. Inside the shell, test that
+    # VIRTUAL_ENV variable is set, exit with failure if it is not set:
+    run_cmd = "if [ -z ${VIRTUAL_ENV+x} ]; then exit 1; else exit 0; fi"
+    cmd = ["nix-shell", "--run", run_cmd]
+    os.chdir(REPOROOT)
+    assert subprocess.run(cmd, check=True).returncode == 0
+    os.chdir(TEST_WORK_DIR)
+
+
+################################################################################
+
+
 def test_sbomnix_help():
     """Test sbomnix command line argument: '-h'"""
     cmd = [SBOMNIX, "-h"]


### PR DESCRIPTION
Improve derivation attributes:
- Make derivation pname more accurate e.g. for perl packages.
- Do not generate purl or cpe for packages with pname 'source'. Pname 'source' has a special meaning in in Nix - it is the default name for all fetchFromGitHub derivations.
- Add 'urls' attribute, which contains the package fetch url (if any).
- Add license and other meta information to the sbomnix release asset SBOMs.

In addition, this PR includes the following other changes:
- Add a test case that checks the nix-shell works as expected to prevent cases like https://github.com/tiiuae/sbomnix/pull/44 in the future.
- Read 'unfree' and 'description' from each nix package meta information if available.
- Add more properties to SPDX sbom: package summary, downloadLocation.
- Add more properties to CDX sbom: component description, fetch_url, homepage.
- Up the version to 1.4.2.