### PR TITLE
repology_cli: command line client to query repology.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 sbomnix_test_data/
 result
 *.py[cod]
+*.sqlite
 /*.csv
 /*.log
 /*.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ requests
 requests-ratelimiter
 requests-cache
 bs4
+packaging
 
 # dev requirements
 pycodestyle

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,13 @@ packageurl-python
 # nixgraph
 graphviz
 
-# osv.py (demo)
+# vulnxscan 
 requests
+
+# repology
+requests-ratelimiter
+requests-cache
+bs4
 
 # dev requirements
 pycodestyle

--- a/scripts/repology/README.md
+++ b/scripts/repology/README.md
@@ -1,0 +1,233 @@
+<!--
+SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# repology_cli
+
+`repology_cli` is a command line interface to [repology.org](https://repology.org/). It supports querying package information via package search terms in the same manner as https://repology.org/projects/?search. In addition, it supports querying package information from all packages in a CycloneDX SBOM and printing out some simple statistics based on the input.
+
+
+Table of Contents
+=================
+
+* [Getting Started](#getting-started)
+   * [Running from Nix Development Shell](#running-from-nix-development-shell)
+   * [Running as Python Script](#running-as-python-script)
+* [Usage Examples](#usage-examples)
+   * [Search by Package Name Exact Match](#search-by-package-name-exact-match)
+   * [Search by Package Name Search Term](#search-by-package-name-search-term)
+   * [Search by Package Names in SBOM](#search-by-package-names-in-sbom)
+   * [Statistics: SBOM Packages](#statistics-sbom-packages)
+
+## Getting Started
+
+### Running from Nix Development Shell
+
+If you have nix flakes enabled, run:
+```bash
+$ git clone https://github.com/tiiuae/sbomnix
+$ cd sbomnix
+$ nix develop
+```
+
+You can also use `nix-shell` to enter the development shell:
+```bash
+$ git clone https://github.com/tiiuae/sbomnix
+$ cd sbomnix
+$ nix-shell
+```
+
+From the development shell, you can run `repology_cli` as follows:
+```bash
+$ scripts/repology/repology_cli.py
+```
+
+### Running as Python Script
+Running `repology_cli` as Python script requires Python packages specified in [requirements.txt](./requirements.txt). You can install the required packages with:
+```bash
+$ git clone https://github.com/tiiuae/sbomnix
+$ cd sbomnix
+$ pip install --user -r requirements.txt
+```
+After requirements have been installed, you can run repology_cli.py as follows:
+```bash
+$ source scripts/env.sh
+$ scripts/repology/repology_cli.py 
+```
+
+## Usage Examples
+
+### Search by Package Name Exact Match
+Following query finds package name 'firefox' versions in 'nix_unstable' repository:
+```bash
+$ scripts/repology/repology_cli.py --pkg_exact "firefox" --repository nix_unstable
+
+INFO     GET: https://repology.org/projects/?search=firefox&inrepo=nix_unstable
+INFO     Repology package info, packages:5
+
+| repo         | package | version               | status   | potentially_vulnerable | newest_upstream_release | repo_version_classify |
+|--------------+---------+-----------------------+----------+------------------------+-------------------------+-----------------------|
+| nix_unstable | firefox | 102-unwrapped-102.8.0 | legacy   |           1            | 110.0.1                 |                       |
+| nix_unstable | firefox | 102.8.0               | legacy   |           1            | 110.0.1                 |                       |
+| nix_unstable | firefox | 110.0.1               | newest   |           0            | 110.0.1                 |                       |
+| nix_unstable | firefox | 111.0b7               | outdated |           0            | 110.0.1                 | repo_pkg_needs_update |
+| nix_unstable | firefox | 111.0b8               | devel    |           0            | 110.0.1                 |                       |
+
+For more details, see: https://repology.org/projects/?search=firefox&inrepo=nix_unstable
+
+INFO     Wrote: repology_report.csv
+```
+
+Output table includes the datapoints available in repology.org, as stated by each column name. As an example, the first row in the above output table means:
+- package information was fetched for repository 'nix_unstable'
+- package name is 'firefox'
+- latest 'nix_unstable' includes a version of firefox with version string '102-unwrapped-102.8.0'
+- firefox '102-unwrapped-102.8.0' status is 'legacy'. The details of each classification status is available in https://repology.org/docs/about.
+- firefox '102-unwrapped-102.8.0' is potentially vulnerable, meaning the package version is associated to at least one CVE. For details of which CVEs repology determined the package is associated to, see: https://repology.org/project/firefox/cves or https://repology.org/project/firefox/cves?version=102-unwrapped-102.8.0
+- newest upstream release version of firefox known to repology is '110.0.1'
+
+In addition to the above datapoints, `repology_cli` adds the column 'repo_version_classify', which simply states whether the specific package version appears updatable in the given repository. As an example, in the above output, the second last row states 'repo_pkg_needs_update' which means that it appears 'nix_unstable' should update the firefox '111.0b7' to the latest firefox upstream release version '110.0.1'.
+
+Full list of repositories available in repology are available in https://repology.org/repositories/statistics. As an example, to repeat the earlier query for Debian 12, you would run:
+
+```bash
+$ scripts/repology/repology_cli.py --pkg_exact "firefox" --repository debian_12
+
+INFO     GET: https://repology.org/projects/?search=firefox&inrepo=debian_12
+INFO     Repology package info, packages:1
+
+| repo      | package   | version   | status   |  potentially_vulnerable  | newest_upstream_release   | repo_version_classify   |
+|-----------+-----------+-----------+----------+--------------------------+---------------------------+-------------------------|
+| debian_12 | firefox   | 102.8.0   | outdated |            1             | 110.0.1                   | repo_pkg_needs_update   |
+
+For more details, see: https://repology.org/projects/?search=firefox&inrepo=debian_12
+
+INFO     Wrote: repology_report.csv
+```
+
+### Search by Package Name Search Term
+Following query finds 'debian_12' packages that include 'firefox' anywhere in the name string:
+
+```bash
+$ scripts/repology/repology_cli.py --pkg_search "firefox" --repository debian_12
+
+INFO     GET: https://repology.org/projects/?search=firefox&inrepo=debian_12
+INFO     Repology package info, packages:5
+
+| repo      | package                     | version | status   | potentially_vulnerable | newest_upstream_release | repo_version_classify |
+|-----------+-----------------------------+---------+----------+------------------------+-------------------------+-----------------------|
+| debian_12 | activity-aware-firefox      | 0.4.1   | unique   |           0            |                         |                       |
+| debian_12 | firefox                     | 102.8.0 | outdated |           1            | 110.0.1                 | repo_pkg_needs_update |
+| debian_12 | firefox-esr-mobile-config   | 3.2.0   | unique   |           0            |                         |                       |
+| debian_12 | foxyproxy-firefox-extension | 7.5.1   | unique   |           0            |                         |                       |
+| debian_12 | perl:firefox-marionette     | 1.35    | newest   |           0            | 1.35                    |                       |
+```
+
+Notice: using short search strings with `--pkg_search` might result a large number of matches and, thus, potentially a large number of queries to repology.org. To avoid spamming repology.org with such queries, `repology_cli` limits the number of requests sent to repology.org to at most one request per second. In addition, it caches all responses locally for 3600 seconds.
+
+### Search by Package Names in SBOM
+Following query finds 'nix_unstable' packages that match the packages in the CycloneDX sbom 'wget.runtime.sbom.cdx.json':
+
+```bash
+$ scripts/repology/repology_cli.py --sbom_cdx  wget.runtime.sbom.cdx.json --repository nix_unstable
+
+INFO     GET: https://repology.org/projects/?search=glibc&inrepo=nix_unstable
+INFO     GET: https://repology.org/projects/?search=libidn2&inrepo=nix_unstable
+INFO     GET: https://repology.org/projects/?search=libunistring&inrepo=nix_unstable
+INFO     GET: https://repology.org/projects/?search=openssl&inrepo=nix_unstable
+INFO     GET: https://repology.org/projects/?search=pcre&inrepo=nix_unstable
+INFO     GET: https://repology.org/projects/?search=util-linux-minimal&inrepo=nix_unstable
+INFO     GET: https://repology.org/projects/?search=wget&inrepo=nix_unstable
+INFO     GET: https://repology.org/projects/?search=zlib&inrepo=nix_unstable
+INFO     Repology package info, packages:9
+
+| repo         | package      | version  | status   | potentially_vulnerable | newest_upstream_release | version_sbom | sbom_version_classify | repo_version_classify |
+|--------------+--------------+----------+----------+------------------------+-------------------------+--------------+-----------------------+-----------------------|
+| nix_unstable | glibc        | 2.35-224 | outdated |           0            | 2.37                    | 2.35-224     | sbom_pkg_needs_update | repo_pkg_needs_update |
+| nix_unstable | libidn2      | 2.3.2    | outdated |           0            | 2.3.4                   | 2.3.2        | sbom_pkg_needs_update | repo_pkg_needs_update |
+| nix_unstable | libunistring | 1.0      | outdated |           0            | 1.1                     | 1.0          | sbom_pkg_needs_update | repo_pkg_needs_update |
+| nix_unstable | openssl      | 1.1.1t   | legacy   |           0            | 3.0.8                   | 3.0.8        |                       |                       |
+| nix_unstable | openssl      | 3.0.8    | newest   |           0            | 3.0.8                   | 3.0.8        |                       |                       |
+| nix_unstable | pcre         | 8.45     | newest   |           0            | 8.45                    | 8.45         |                       |                       |
+| nix_unstable | wget         | 1.21.3   | legacy   |           0            | 2.0.1                   | 1.21.3       |                       |                       |
+| nix_unstable | wget         | 2.0.1    | newest   |           0            | 2.0.1                   | 1.21.3       | sbom_pkg_needs_update |                       |
+| nix_unstable | zlib         | 1.2.13   | newest   |           0            | 1.2.13                  | 1.2.13       |                       |                       |
+```
+
+Output includes package details from the packages in the given SBOM that were also found in repology.org. In addition to the datapoints covered in section [Search by Package Name Exact Match](#search-by-package-name-exact-match), `repology_cli` adds the column 'sbom_version_classify' which states whether the package version in SBOM appears outdated. As an example, in the above output, package 'wget' version in sbom is '1.21.3'. Column 'sbom_version_classify' states 'sbom_pkg_needs_update' because 'nix_unstable' would have an update to the 'wget' package to version '2.0.1'.
+
+### Statistics: SBOM Packages
+Following is the same query as above, but adds the command-line argument `--stats` to print out some simple statistics that might help explain the results.
+
+```bash
+$ scripts/repology/repology_cli.py --sbom_cdx  wget.runtime.sbom.cdx.json --repository nix_unstable --stats
+INFO     GET: https://repology.org/projects/?search=glibc&inrepo=nix_unstable
+INFO     GET: https://repology.org/projects/?search=libidn2&inrepo=nix_unstable
+INFO     GET: https://repology.org/projects/?search=libunistring&inrepo=nix_unstable
+INFO     GET: https://repology.org/projects/?search=openssl&inrepo=nix_unstable
+INFO     GET: https://repology.org/projects/?search=pcre&inrepo=nix_unstable
+INFO     GET: https://repology.org/projects/?search=util-linux-minimal&inrepo=nix_unstable
+INFO     GET: https://repology.org/projects/?search=wget&inrepo=nix_unstable
+INFO     GET: https://repology.org/projects/?search=zlib&inrepo=nix_unstable
+INFO     Repology package info, packages:9
+
+| repo         | package      | version   | status   |  potentially_vulnerable  | newest_upstream_release   | version_sbom   | sbom_version_classify   | repo_version_classify   |
+|--------------+--------------+-----------+----------+--------------------------+---------------------------+----------------+-------------------------+-------------------------|
+| nix_unstable | glibc        | 2.35-224  | outdated |            0             | 2.37                      | 2.35-224       | sbom_pkg_needs_update   | repo_pkg_needs_update   |
+| nix_unstable | libidn2      | 2.3.2     | outdated |            0             | 2.3.4                     | 2.3.2          | sbom_pkg_needs_update   | repo_pkg_needs_update   |
+| nix_unstable | libunistring | 1.0       | outdated |            0             | 1.1                       | 1.0            | sbom_pkg_needs_update   | repo_pkg_needs_update   |
+| nix_unstable | openssl      | 1.1.1t    | legacy   |            0             | 3.0.8                     | 3.0.8          |                         |                         |
+| nix_unstable | openssl      | 3.0.8     | newest   |            0             | 3.0.8                     | 3.0.8          |                         |                         |
+| nix_unstable | pcre         | 8.45      | newest   |            0             | 8.45                      | 8.45           |                         |                         |
+| nix_unstable | wget         | 1.21.3    | legacy   |            0             | 2.0.1                     | 1.21.3         |                         |                         |
+| nix_unstable | wget         | 2.0.1     | newest   |            0             | 2.0.1                     | 1.21.3         | sbom_pkg_needs_update   |                         |
+| nix_unstable | zlib         | 1.2.13    | newest   |            0             | 1.2.13                    | 1.2.13         |                         |                         |
+
+For more details, see: https://repology.org/projects/
+
+INFO     
+	Repology package statistics:
+	 (see the status descriptions in: https://repology.org/docs/about)
+	   Unique compared packages: 7 (100%)	(status in: ['newest', 'devel', 'unique', 'outdated'])
+	    ==> newest: 4 (57%)
+	    ==> outdated: 3 (43%)
+	    ==> devel or unique: 0 (0%)
+	    ==> potentially vulnerable: 0 (0%)
+
+INFO     
+	Repology SBOM package statistics:
+	  Unique packages: 10 (100%)
+	   ==> sbom packages in repology: 9 (90%)
+	   ==> sbom packages not in repology: 1 (10%)
+	        - IGNORED (sbom component is not a package in repology): 0
+	        - NO_VERSION (sbom component is missing the version number): 0
+	        - NOT_FOUND (sbom component was not found in repology): 1
+
+INFO     Wrote: repology_report.csv
+```
+Section 'Repology package statistics' in the console output indicates that:
+- There were seven packages whose status was one of `['newest', 'devel', 'unique', 'outdated']`. These are the package statuses `repology_cli` considers in the statistics output.
+- Four out of the total of seven packages had the status 'newest'. This number indicates how many packages are up-to-date with its known latest release version in upstream.
+- Three out of seven packages have the status 'outdated'. This number indicates how many packages are not up-to-date with its known latest upstream release version in 'nix_unstable' repository.
+- There were no devel or unique packages. 'devel' packages indicate latest development or unstable package versions, whereas, 'unique' packages are only present in a single repository family, meaning there are no other sources for repology.org to compare them against.
+- There were no packages with known vulnerabilities associated to them.
+
+Section 'Repology SBOM package statistics' in the console output indicates that:
+- The baseline for SBOM package comparison is ten unique packages. This number includes the unique components in the cdx SBOM (as identified by the component name and version), as well as other current package versions in 'nix_unstable' known to repology.
+- Nine component names in the SBOM can be matched with package names in repology.
+- One package was not included to the comparison by `repology_cli`. The reason is 'NOT_FOUND', meaning the package was not found in repology.org. Other possible reasons for `repology_cli` to skip SBOM packages are IGNORED and NO_VERSION. IGNORED means the sbom component name indicates the component is not a package in repology.org. Typical examples of IGNORED packages would be archives (.tar.gz) or patches (.patch). NO_VERSION means the sbom component was missing the version information. Typically, such packages are service files, scripts, or configuration files that are not considered as packages in repology.org but can be included as separate components in the SBOM.
+
+In addition to the console output `repology_cli` outputs the full data set in csv file. As an example, you could query the `repology_report.csv` for more details of the skipped packages:
+
+```bash
+
+$ csvsql --query "select * from repology_report where status == 'NOT_FOUND'" repology_report.csv | csvlook
+
+| repo         | package            | version | status    |       | version_sbom |
+| ------------ | ------------------ | ------- | --------- |  ...  | ------------ |
+| nix_unstable | util-linux-minimal | 2.38.1  | NOT_FOUND |       | 2.38.1       |
+```
+
+Above, we can see the package 'util-linux-minimal' which is one of the components in the example sbom 'wget.runtime.sbom.cdx.json', is not available (with that exact same name) in repology.org.

--- a/scripts/repology/__init__.py
+++ b/scripts/repology/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/scripts/repology/repology_cli.py
+++ b/scripts/repology/repology_cli.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=invalid-name, import-error, unexpected-keyword-arg,
+# pylint: disable=abstract-method, too-few-public-methods,
+# pylint: disable=too-many-instance-attributes
+
+""" Demonstrate querying repology api from command-line """
+
+import logging
+import os
+import sys
+from argparse import ArgumentParser, ArgumentTypeError, SUPPRESS
+from requests import Session
+from requests_cache import CacheMixin
+from requests_ratelimiter import LimiterMixin
+from bs4 import BeautifulSoup
+import numpy as np
+import pandas as pd
+from tabulate import tabulate
+from sbomnix.utils import (
+    setup_logging,
+    LOGGER_NAME,
+    LOG_SPAM,
+    df_to_csv_file,
+    df_regex_filter,
+    df_log,
+)
+
+###############################################################################
+
+_LOG = logging.getLogger(LOGGER_NAME)
+
+###############################################################################
+
+
+def _pkg_str(str_obj):
+    if isinstance(str_obj, str) and len(str_obj) > 0:
+        return str_obj
+    raise ArgumentTypeError("Value must be a non-empty string")
+
+
+def getargs():
+    """Parse command line arguments"""
+    desc = (
+        "Command line client to query repology.org for package information "
+        "across various software repositories."
+    )
+    epil = f"Example: ./{os.path.basename(__file__)} --pkg 'firefox' -r 'nix'"
+    parser = ArgumentParser(description=desc, epilog=epil, add_help=False)
+    requiredq = parser.add_argument_group(
+        "Required query arguments",
+        "Following arguments mutually exclusive:",
+    )
+    exclusiveq = requiredq.add_mutually_exclusive_group(required=True)
+    optionalq = parser.add_argument_group("Optional query arguments")
+    filtergr = parser.add_argument_group(
+        "Optional output filter arguments (regular expressions)"
+    )
+    optional = parser.add_argument_group("Optional other arguments")
+    helps = "Show this help message and exit"
+    optional.add_argument("-h", "--help", action="help", default=SUPPRESS, help=helps)
+    # Arguments that impact repology.org queries:
+    helps = "Package name search term (see: https://repology.org/projects/?search=)"
+    exclusiveq.add_argument("--pkg_search", help=helps, type=_pkg_str)
+    helps = "Package name exact match"
+    exclusiveq.add_argument("--pkg", help=helps, type=_pkg_str)
+    helps = "Repository name exact match (see: https://repology.org/repositories)"
+    optionalq.add_argument("--repository", help=helps, type=str, default="")
+    helps = "Add 'potentially_vulnerable' column to the report"
+    optionalq.add_argument("--vuln_info", help=helps, action="store_true")
+    # Arguments that impact output results:
+    helps = "Filter reported results based on repository name"
+    filtergr.add_argument("-r", "--re_repo", help=helps, type=str, default=None)
+    helps = "Filter reported results based on package name"
+    filtergr.add_argument("-p", "--re_package", help=helps, type=str, default=None)
+    helps = "Filter reported results based on version string"
+    filtergr.add_argument("-v", "--re_version", help=helps, type=str, default=None)
+    helps = "Filter reported results based on status string"
+    filtergr.add_argument("-s", "--re_status", help=helps, type=str, default=None)
+    helps = "Filter reported results based on vulnerability status"
+    filtergr.add_argument("-c", "--re_vuln", help=helps, type=str, default=None)
+    # Other arguments:
+    helps = "Set the debug verbosity level between 0-3 (default: --verbose=1)"
+    optional.add_argument("--verbose", help=helps, type=int, default=1)
+    helps = "Path to output report file (default: ./repology_report.csv)"
+    optional.add_argument("--out", help=helps, default="repology_report.csv")
+    return parser.parse_args()
+
+
+################################################################################
+
+
+class CachedLimiterSession(CacheMixin, LimiterMixin, Session):
+    """Session class with caching and rate-limiting"""
+
+    # See: https://requests-cache.readthedocs.io/en/stable/user_guide/compatibility.html
+
+
+class Repology:
+    """Query and parse Repology package data"""
+
+    def __init__(self):
+        self.packages_dict = {}
+        self.urlq = None
+        self.url_api_projects = "https://repology.org/api/v1/projects/"
+        self.url_api_project = "https://repology.org/api/v1/project/"
+        self.url_projects = "https://repology.org/projects/"
+        self.url_project = "https://repology.org/project/"
+        # Comply with the "terms of use" in https://repology.org/api:
+        # - Limit non-cached requests to 1 requests per second
+        # - Identify repology_cli with custom user-agent
+        # In addition:
+        # - Cache all responses for 3600 seconds
+        self.session = CachedLimiterSession(per_second=1, expire_after=3600)
+        ua_product = "repology_cli/0"
+        ua_comment = "(https://github.com/tiiuae/sbomnix)"
+        self.headers = {"User-Agent": f"{ua_product} {ua_comment}"}
+
+    def _get_resp(self, query):
+        _LOG.info("GET: %s", query)
+        resp = self.session.get(query, headers=self.headers)
+        _LOG.debug("resp.status_code: %s", resp.status_code)
+        resp.raise_for_status()
+        return resp
+
+    def _parse_api_response(self, resp_json):
+        pkg_names = list(resp_json.keys())
+        pkg_names.sort()
+        setcol = self.packages_dict.setdefault
+        for pname in resp_json:
+            _LOG.log(LOG_SPAM, "pname: %s", pname)
+            for package in resp_json[pname]:
+                setcol("repo", []).append(package.get("repo", ""))
+                setcol("package", []).append(pname)
+                setcol("version", []).append(package.get("version", ""))
+                setcol("status", []).append(package.get("status", ""))
+        return pkg_names
+
+    def _query_potentially_vulnerable(self, df):
+        # There is apparently no way to get package's vulnerability info
+        # using the repology API. Therefore, this function scrapes the
+        # package's vulnerability info from the html page at:
+        # https://repology.org/project/PACKAGE_NAME/cves?version=VERSION
+
+        # Get unique combination of following column values (packages)
+        group_by_cols = ["package", "version"]
+        df_pkgs = df.groupby(group_by_cols).size().reset_index(name="count")
+        df_log(df_pkgs, logging.DEBUG)
+        max_queries = 100
+        if df_pkgs.shape[0] > max_queries:
+            _LOG.warning(
+                "Skipping vulnerable package query as it would require "
+                "more than %s requests to repology.org",
+                max_queries,
+            )
+            return df
+        # Scrape the vulnerability status
+        vuln_col = []
+        for pkg in df_pkgs.itertuples():
+            query = f"{self.url_project}{pkg.package}/cves?version={pkg.version}"
+            resp = self._get_resp(query)
+            soup = BeautifulSoup(resp.text, "html.parser")
+            tables = soup.find_all("table")
+            if not tables:
+                vuln_col.append(int(False))
+            else:
+                span = tables[0].find_all("span", {"class": "version version-outdated"})
+                _LOG.log(LOG_SPAM, span)
+                vuln_col.append(int(bool(span)))
+        df_pkgs["potentially_vulnerable"] = vuln_col
+        # Merge with df to add the 'potentially_vulnerable' column to original data
+        cols = group_by_cols + ["potentially_vulnerable"]
+        return df.merge(df_pkgs[cols], how="left").astype(str)
+
+    def _report(self, args):
+        """Generate result report to console and to csv file"""
+        # Get DataFrame, drop duplicates, sort
+        df = pd.DataFrame.from_dict(self.packages_dict)
+        df.replace(np.nan, "", regex=True, inplace=True)
+        df.drop_duplicates(keep="first", inplace=True)
+        df_cols = df.columns.values.tolist()
+        df.sort_values(by=df_cols, inplace=True)
+
+        # Repology API repo search requests (with 'inrepo' query string)
+        # return packages that are in the requested repository, but the
+        # response includes matching packages from from all other repositories
+        # too. Below, we filter out packages from other repositories
+        # to not confuse the user:
+        if args.repository and "repo" in df_cols:
+            df = df_regex_filter(df, "repo", args.repository)
+
+        # Filter by the regex filters from command line args
+        if args.re_repo and "repo" in df_cols:
+            df = df_regex_filter(df, "repo", args.re_repo)
+        if args.re_package and "package" in df_cols:
+            df = df_regex_filter(df, "package", args.re_package)
+        if args.re_version and "version" in df_cols:
+            df = df_regex_filter(df, "version", args.re_version)
+        if args.re_status and "status" in df_cols:
+            df = df_regex_filter(df, "status", args.re_status)
+        if not df.empty and args.vuln_info:
+            # Query potentially vulnerable packages
+            df = self._query_potentially_vulnerable(df)
+            df_cols = df.columns.values.tolist()
+        if args.re_vuln and "potentially_vulnerable" in df_cols:
+            df = df_regex_filter(df, "potentially_vulnerable", args.re_vuln)
+        if df.empty:
+            _LOG.warning("No matching packages found")
+            sys.exit(1)
+        # Write the console report
+        table = tabulate(
+            df, headers="keys", tablefmt="orgtbl", numalign="center", showindex=False
+        )
+        _LOG.info(
+            "Console report\n\n%s\n\nFor more details, see: %s\n", table, self.urlq
+        )
+        # Write the report to csv file
+        df_to_csv_file(df, args.out)
+
+    def _query_pkg_search(self, args):
+        """Query using repology api/v1/projects/"""
+        search_term = f"?search={args.pkg_search}&inrepo={args.repository}"
+        query = f"{self.url_api_projects}{search_term}"
+        self.urlq = f"{self.url_projects}{search_term}"
+        while True:
+            resp_json = self._get_resp(query).json()
+            query_last = query
+            pkg_names = self._parse_api_response(resp_json)
+            number_of_packages = len(pkg_names)
+            _LOG.debug("number_of_packages: %s", number_of_packages)
+            _LOG.debug("pkg_names: %s", pkg_names)
+            # API returns at most 200 projects per one request, therefore,
+            # we know we got all the matches if the response includes less than
+            # 200 packages.
+            if number_of_packages < 200:
+                _LOG.debug("stopping (number_of_packages=%s)", number_of_packages)
+                break
+            # Otherwise, we need to make another query starting from the
+            # last returned project, for details, see: https://repology.org/api
+            last_project = pkg_names[-1]
+            query = f"{self.url_api_projects}{last_project}/{search_term}"
+            if query == query_last:
+                _LOG.debug("stopping ('%s'=='%s')", query_last, query)
+                break
+
+    def _query_pkg_exact(self, args):
+        """Query using repology api/v1/project/"""
+        search_term = f"{args.pkg}"
+        query = f"{self.url_api_project}{search_term}"
+        self.urlq = f"{self.url_project}{search_term}"
+        resp_json = self._get_resp(query).json()
+        # Wrap the response in a dictionary so we can re-use the parser
+        resp_json = {args.pkg: resp_json}
+        self._parse_api_response(resp_json)
+
+    def query(self, args):
+        """Query package information from repology.org"""
+        if args.pkg_search:
+            self._query_pkg_search(args)
+        else:
+            self._query_pkg_exact(args)
+
+        self._report(args)
+
+
+################################################################################
+
+
+def main():
+    """main entry point"""
+    args = getargs()
+    setup_logging(args.verbose)
+    pkg_len_limit = 3
+    if args.pkg_search and len(args.pkg_search) < pkg_len_limit:
+        _LOG.fatal(
+            "Package search term '%s' is shorter than %s characters. "
+            "Either provide longer package search term, or specify the exact "
+            "package name with '--pkg' argument. ",
+            args.pkg_search,
+            pkg_len_limit,
+        )
+        sys.exit(1)
+    repology = Repology()
+    repology.query(args)
+
+
+################################################################################
+
+if __name__ == "__main__":
+    main()
+
+################################################################################

--- a/scripts/repology/repology_cli.py
+++ b/scripts/repology/repology_cli.py
@@ -5,10 +5,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # pylint: disable=invalid-name, import-error, unexpected-keyword-arg,
-# pylint: disable=abstract-method, too-few-public-methods,
-# pylint: disable=too-many-instance-attributes
+# pylint: disable=abstract-method, too-few-public-methods
+# pylint: disable=too-many-instance-attributes, too-many-locals,
 
-""" Demonstrate querying repology api from command-line """
+""" Command-line interface to repology.org """
 
 import logging
 import os
@@ -16,6 +16,7 @@ import sys
 import pathlib
 import json
 import re
+import urllib.parse
 from argparse import ArgumentParser, ArgumentTypeError, SUPPRESS
 from requests import Session
 from requests_cache import CacheMixin
@@ -30,7 +31,6 @@ from sbomnix.utils import (
     LOG_SPAM,
     df_to_csv_file,
     df_regex_filter,
-    df_log,
 )
 
 ###############################################################################
@@ -48,18 +48,18 @@ def _pkg_str(str_obj):
 
 def getargs():
     """Parse command line arguments"""
-    desc = (
-        "Command line client to query repology.org for package information "
-        "across various software repositories."
+    desc = "Command line client to query repology.org for package information."
+    epil = (
+        f"Example: ./{os.path.basename(__file__)} --pkg_search 'firef' "
+        " --repository 'nix_unstable'"
     )
-    epil = f"Example: ./{os.path.basename(__file__)} --pkg 'firefox' -r 'nix'"
     parser = ArgumentParser(description=desc, epilog=epil, add_help=False)
-    requiredq = parser.add_argument_group(
+    required = parser.add_argument_group(
         "Required arguments",
         "Following arguments are mutually exclusive:",
     )
-    exclusiveq = requiredq.add_mutually_exclusive_group(required=True)
-    optionalq = parser.add_argument_group("Optional query arguments")
+    exclusiveq = required.add_mutually_exclusive_group(required=True)
+    requiredo = parser.add_argument_group("Required other arguments")
     filtergr = parser.add_argument_group(
         "Optional output filter arguments (regular expressions)"
     )
@@ -67,19 +67,17 @@ def getargs():
     helps = "Show this help message and exit"
     optional.add_argument("-h", "--help", action="help", default=SUPPRESS, help=helps)
     # Arguments that impact repology.org queries:
-    helps = "Package name exact match"
-    exclusiveq.add_argument("--pkg", help=helps, type=_pkg_str)
-    helps = "Package name search term (see: https://repology.org/projects/?search=)"
+    helps = "Package name exact match (see: https://repology.org/projects/)"
+    exclusiveq.add_argument("--pkg_exact", help=helps, type=_pkg_str)
+    helps = "Package name search term (see: https://repology.org/projects/)"
     exclusiveq.add_argument("--pkg_search", help=helps, type=_pkg_str)
     helps = "Read the package names and versions from the given cdx SBOM"
-    exclusiveq.add_argument("--sbom", help=helps, type=pathlib.Path)
+    exclusiveq.add_argument("--sbom_cdx", help=helps, type=pathlib.Path)
     helps = "Repository name exact match (see: https://repology.org/repositories)"
-    optionalq.add_argument("--repository", help=helps, type=str, default="")
-    helps = "Add 'potentially_vulnerable' column to the report"
-    optionalq.add_argument("--vuln_info", help=helps, action="store_true")
+    requiredo.add_argument(
+        "--repository", required=True, help=helps, type=str, default=""
+    )
     # Arguments that impact output results:
-    helps = "Filter reported results based on repository name"
-    filtergr.add_argument("-r", "--re_repo", help=helps, type=str, default=None)
     helps = "Filter reported results based on package name"
     filtergr.add_argument("-p", "--re_package", help=helps, type=str, default=None)
     helps = "Filter reported results based on version string"
@@ -109,184 +107,205 @@ class Repology:
     """Query and parse Repology package data"""
 
     def __init__(self):
-        self.packages_dict = {}
+        self.processed = set()
+        self.pkgs_dict = {}
+        self.df = pd.DataFrame()
         self.urlq = None
-        self.url_api_projects = "https://repology.org/api/v1/projects/"
-        self.url_api_project = "https://repology.org/api/v1/project/"
+        self.df_sbom = None
+        # We don't use the v1 api endpoints (https://repology.org/api/v1) as it
+        # seems there is no effective way to query the API for all the
+        # datapoints we need: (repo, package, version, status,
+        # vulnerability info, newest_releases). We left a draft
+        # implementation of a version of this client that makes use of the
+        # repology.org v1 api in the git commit history, so it would be possible
+        # to later rework on it if necessary.
+        # For now, we scrape the information from the following endpoint
+        # instead:
         self.url_projects = "https://repology.org/projects/"
-        self.url_project = "https://repology.org/project/"
         # Comply with the "terms of use" in https://repology.org/api:
-        # - Limit non-cached requests to 1 requests per second
-        # - Identify repology_cli with custom user-agent
+        # - Limit non-cached requests to 1 request per second
+        # - Identify this client with custom user-agent
         # In addition:
-        # - Cache all responses for 3600 seconds
+        # - Cache all responses locally for 3600 seconds
         self.session = CachedLimiterSession(per_second=1, expire_after=3600)
         ua_product = "repology_cli/0"
         ua_comment = "(https://github.com/tiiuae/sbomnix)"
         self.headers = {"User-Agent": f"{ua_product} {ua_comment}"}
 
-    def _get_resp(self, query):
-        _LOG.info("GET: %s", query)
-        resp = self.session.get(query, headers=self.headers)
-        _LOG.debug("resp.status_code: %s", resp.status_code)
-        resp.raise_for_status()
-        return resp
-
-    def _parse_api_response(self, resp_json, match_version=None):
-        pkg_names = list(resp_json.keys())
-        pkg_names.sort()
-        setcol = self.packages_dict.setdefault
-        for pname in resp_json:
-            _LOG.log(LOG_SPAM, "pname: %s", pname)
-            for package in resp_json[pname]:
-                pkg_version = package.get("version", "")
-                if match_version and pkg_version != match_version:
-                    continue
-                setcol("repo", []).append(package.get("repo", ""))
-                setcol("package", []).append(pname)
-                setcol("version", []).append(pkg_version)
-                setcol("status", []).append(package.get("status", ""))
-        return pkg_names
-
-    def _query_potentially_vulnerable(self, df):
-        # There is apparently no way to get package's vulnerability info
-        # using the repology API. Therefore, this function scrapes the
-        # package's vulnerability info from the html page at:
-        # https://repology.org/project/PACKAGE_NAME/cves?version=VERSION
-
-        # Get unique combination of following column values (packages)
-        group_by_cols = ["package", "version"]
-        df_pkgs = df.groupby(group_by_cols).size().reset_index(name="count")
-        df_log(df_pkgs, logging.DEBUG)
-        max_queries = 100
-        if df_pkgs.shape[0] > max_queries:
-            _LOG.warning(
-                "Skipping vulnerable package query as it would require "
-                "more than %s requests to repology.org",
-                max_queries,
-            )
-            return df
-        # Scrape the vulnerability status
-        vuln_col = []
-        for pkg in df_pkgs.itertuples():
-            query = f"{self.url_project}{pkg.package}/cves?version={pkg.version}"
-            resp = self._get_resp(query)
-            soup = BeautifulSoup(resp.text, "html.parser")
-            tables = soup.find_all("table")
-            if not tables:
-                vuln_col.append(int(False))
-            else:
-                span = tables[0].find_all("span", {"class": "version version-outdated"})
-                _LOG.log(LOG_SPAM, span)
-                vuln_col.append(int(bool(span)))
-        df_pkgs["potentially_vulnerable"] = vuln_col
-        # Merge with df to add the 'potentially_vulnerable' column to original data
-        cols = group_by_cols + ["potentially_vulnerable"]
-        return df.merge(df_pkgs[cols], how="left").astype(str)
-
-    def _report(self, args):
-        """Generate result report to console and to csv file"""
+    def _packages_to_df(self, args, re_pkg_internal=None):
+        if not self.pkgs_dict:
+            return
+        _LOG.debug("packages in pkgs_dict: %s", len(self.pkgs_dict["package"]))
         # Get DataFrame, drop duplicates, sort
-        df = pd.DataFrame.from_dict(self.packages_dict)
-        df.replace(np.nan, "", regex=True, inplace=True)
-        df.drop_duplicates(keep="first", inplace=True)
+        df = pd.DataFrame.from_dict(self.pkgs_dict)
         df_cols = df.columns.values.tolist()
-        df.sort_values(by=df_cols, inplace=True)
-
-        # Repology API repo search requests (with 'inrepo' query string)
-        # return packages that are in the requested repository, but the
-        # response includes matching packages from from all other repositories
-        # too. Below, we filter out packages from other repositories
-        # to not confuse the user:
+        # Filter by repository name
         if args.repository and "repo" in df_cols:
-            df = df_regex_filter(df, "repo", args.repository)
-
+            df = df_regex_filter(df, "repo", re.escape(args.repository))
+        if re_pkg_internal and "package" in df_cols:
+            re_pkg_internal = f"^{re.escape(re_pkg_internal)}$"
+            df = df_regex_filter(df, "package", re_pkg_internal)
         # Filter by the regex filters from command line args
-        if args.re_repo and "repo" in df_cols:
-            df = df_regex_filter(df, "repo", args.re_repo)
         if args.re_package and "package" in df_cols:
             df = df_regex_filter(df, "package", args.re_package)
         if args.re_version and "version" in df_cols:
             df = df_regex_filter(df, "version", args.re_version)
         if args.re_status and "status" in df_cols:
             df = df_regex_filter(df, "status", args.re_status)
-        if not df.empty and args.vuln_info:
-            # Query potentially vulnerable packages
-            df = self._query_potentially_vulnerable(df)
-            df_cols = df.columns.values.tolist()
         if args.re_vuln and "potentially_vulnerable" in df_cols:
             df = df_regex_filter(df, "potentially_vulnerable", args.re_vuln)
-        if df.empty:
+        self.df = pd.concat([self.df, df])
+        self.df.replace(np.nan, "", regex=True, inplace=True)
+        self.df.drop_duplicates(keep="first", inplace=True)
+        self.df.sort_values(by=self.df.columns.values.tolist(), inplace=True)
+
+    def _sbom_fields(self):
+        # Merge self.df with self.df_sbom to get the version_sbom column
+        self.df = self.df.merge(
+            self.df_sbom,
+            how="left",
+            left_on=["package"],
+            right_on=["name"],
+            suffixes=["", "_sbom"],
+        )
+        # Drop the "name" column which is a duplicate to "package"
+        self.df.drop("name", axis=1, inplace=True)
+
+    def _get_resp(self, query):
+        _LOG.info("GET: %s", query)
+        resp = self.session.get(query, headers=self.headers)
+        _LOG.debug("resp.status_code: %s", resp.status_code)
+        if resp.status_code == 404:
+            _LOG.fatal("No matching packages found")
+            sys.exit(1)
+        resp.raise_for_status()
+        return resp
+
+    def _report(self, args):
+        """Generate result report to console and to csv file"""
+        if self.df.empty:
             _LOG.warning("No matching packages found")
             sys.exit(1)
+        if self.df_sbom is not None:
+            self._sbom_fields()
+        # Copy the df to only make changes to the console report
+        df = self.df.copy(deep=True)
+        # Remove rows we don't want to print to the console report
+        df = df[~df.status.isin(["IGNORED", "NO_VERSION"])]
+        df = df.drop_duplicates(keep="first")
         # Write the console report
         table = tabulate(
-            df, headers="keys", tablefmt="orgtbl", numalign="center", showindex=False
+            df,
+            headers="keys",
+            tablefmt="orgtbl",
+            numalign="center",
+            showindex=False,
         )
         _LOG.info(
-            "Console report\n\n%s\n\nFor more details, see: %s\n", table, self.urlq
+            "Repology package info, packages:%s\n\n%s\n\n"
+            "For more details, see: %s\n",
+            df.shape[0],
+            table,
+            self.urlq,
         )
-        # Write the report to csv file
-        df_to_csv_file(df, args.out)
+        # Write the full report to csv file
+        df_to_csv_file(self.df, args.out)
 
-    def _query_pkg_search(self, args):
-        """Query using repology api/v1/projects/"""
-        search_term = f"?search={args.pkg_search}&inrepo={args.repository}"
-        query = f"{self.url_api_projects}{search_term}"
-        self.urlq = f"{self.url_projects}{search_term}"
-        while True:
-            resp_json = self._get_resp(query).json()
-            query_last = query
-            pkg_names = self._parse_api_response(resp_json)
-            number_of_packages = len(pkg_names)
-            _LOG.debug("number_of_packages: %s", number_of_packages)
-            _LOG.debug("pkg_names: %s", pkg_names)
-            # API returns at most 200 projects per one request, therefore,
-            # we know we got all the matches if the response includes less than
-            # 200 packages.
-            if number_of_packages < 200:
-                _LOG.debug("stopping (number_of_packages=%s)", number_of_packages)
-                break
-            # Otherwise, we need to make another query starting from the
-            # last returned project, for details, see: https://repology.org/api
-            last_project = pkg_names[-1]
-            query = f"{self.url_api_projects}{last_project}/{search_term}"
-            if query == query_last:
-                _LOG.debug("stopping ('%s'=='%s')", query_last, query)
-                break
+    def _parse_pkg_search_resp(self, resp, repo, pkg_stop=None):
+        next_query_project = ""
+        soup = BeautifulSoup(resp.text, "html.parser")
+        tables = soup.find_all("table")
+        if not tables:
+            _LOG.debug("Projects table missing: no matching packages")
+            return next_query_project
+        projects_table = tables[0]
+        headers = {}
+        for idx, header in enumerate(projects_table.thead.find_all("th")):
+            headers[header.text] = idx
+        if not headers:
+            _LOG.fatal("Unexpected response")
+            sys.exit(1)
+        _LOG.log(LOG_SPAM, headers)
+        projects_table_rows = projects_table.tbody.find_all("tr")
+        stop_query = False
+        for row in projects_table_rows:
+            cols = row.find_all("td")
+            if not cols:
+                _LOG.log(LOG_SPAM, "No columns on row: %s", row)
+                continue
+            _LOG.log(LOG_SPAM, "cols: %s", cols)
+            pkg = cols[headers["Project"]]
+            pkg_name = pkg.find_all("a")[0].string
+            # Stop further queries if any package name matches pkg_stop
+            stop_query = bool(not stop_query and pkg_stop and pkg_name == pkg_stop)
+            pkg_id = f"{repo}:{pkg_name}"
+            if pkg_id in self.processed:
+                _LOG.debug("Package '%s' in search resp already processed", pkg_name)
+                continue
+            _LOG.debug("Adding package '%s' to self.processed", pkg_name)
+            self.processed.add(pkg_id)
+            # Extract newest release versions
+            newest = cols[headers["Newest"]]
+            nspans = newest.find_all("span", {"class": "version-newest"})
+            newest_releases = []
+            if nspans:
+                for nspan in nspans:
+                    # Extract version number removing non-ascii characters
+                    rel_version = re.sub(r"[^\x00-\x7f]+", "", nspan.text)
+                    newest_releases.append(rel_version)
+            # Extract 'selected' package version
+            sel = cols[headers["Selected"]]
+            statuses = re.findall(r'version-([^"]+)"', str(sel))
+            vspans = sel.find_all("span", {"class": "version"})
+            for idx, vspan in enumerate(vspans):
+                # Extract version number removing non-ascii characters
+                version = re.sub(r"[^\x00-\x7f]+", "", vspan.text)
+                # Package version vulnerability status
+                vulnerable = bool(vspan.find_all("span", {"class": "vulnerable"}))
+                # Package version status information
+                status = statuses[idx]
+                # Collect results
+                self.pkgs_dict.setdefault("repo", []).append(repo)
+                self.pkgs_dict.setdefault("package", []).append(pkg_name)
+                self.pkgs_dict.setdefault("version", []).append(version)
+                self.pkgs_dict.setdefault("status", []).append(status)
+                self.pkgs_dict.setdefault("potentially_vulnerable", []).append(
+                    str(int(vulnerable))
+                )
+                self.pkgs_dict.setdefault("newest_upstream_release", []).append(
+                    ";".join(newest_releases)
+                )
+            # API returns at most 200 projects per one request. If the number
+            # or returned projects is 200, we know we need to make another
+            # query starting from the last returned project, for more details,
+            # see: https://repology.org/api
+            if len(projects_table_rows) == 200 and not stop_query:
+                next_query_project = pkg_name
+        return next_query_project
 
-    def _query_pkg_exact(self, args, match_version=None):
-        """Query using repology api/v1/project/"""
-        search_term = f"{args.pkg}"
-        query = f"{self.url_api_project}{search_term}"
-        self.urlq = f"{self.url_project}{search_term}"
-        resp_json = self._get_resp(query).json()
-        # Wrap the response in a dictionary so we can re-use the parser
-        resp_json = {args.pkg: resp_json}
-        self._parse_api_response(resp_json, match_version=match_version)
-
-    def _parse_sbom(self, path):
-        _LOG.debug("Parsing sbom: %s", path)
-        re_python = re.compile(r"python[^-]*-(?P<pname>.+)")
-        re_perl = re.compile(r"perl[^-]*-(?P<pname>.+)")
+    def _parse_sbom_cdx(self, path):
+        _LOG.debug("Parsing cdx sbom: %s", path)
         with open(path, encoding="utf-8") as inf:
             json_dict = json.loads(inf.read())
-            components = json_dict["components"] + [json_dict["metadata"]["component"]]
+            components = []
+            if "component" in json_dict["metadata"]:
+                components = [json_dict["metadata"]["component"]]
+            components = json_dict["components"] + components
             components_dict = {}
-            setcol = components_dict.setdefault
             for cmp in components:
                 name = cmp["name"]
-                match = re_python.match(name)
+                # Fix sbom package name so it matches repology package name
+                match = re.match(r"python[^-]*-(?P<pname>.+)", name)
                 if match:
                     name = f"python:{match.group('pname')}"
                 elif not match:
-                    match = re_perl.match(name)
+                    match = re.match(r"perl[^-]*-(?P<pname>.+)", name)
                     if match:
                         name = f"perl:{match.group('pname')}"
                 if name == "python3":
                     name = "python"
-                setcol("name", []).append(name)
-                setcol("version", []).append(cmp["version"])
+                components_dict.setdefault("name", []).append(name)
+                components_dict.setdefault("version", []).append(cmp["version"])
             df_components = pd.DataFrame(components_dict)
             df_components.fillna("", inplace=True)
             df_components = df_components.astype(str)
@@ -295,26 +314,104 @@ class Repology:
             df_components.reset_index(drop=True, inplace=True)
             return df_components
 
-    def _query_sbom(self, args):
-        df = self._parse_sbom(args.sbom.as_posix())
-        df_to_csv_file(df, "parsed_sbom.csv")
-        for cmp in df.itertuples():
-            _LOG.debug("package: %s", cmp)
-            if not cmp.version:
-                _LOG.warning("Missing version information: %s", cmp)
+    def _query_pkg_search(self, args, stop_pkg=None):
+        """Query repology.org/projects/"""
+        pkg = urllib.parse.quote(args.pkg_search)
+        repo = urllib.parse.quote(args.repository)
+        search_term = f"?search={pkg}&inrepo={repo}"
+        query = f"{self.url_projects}{search_term}"
+        self.urlq = query
+        while True:
+            resp = self._get_resp(query)
+            query_last = query
+            next_query_project = self._parse_pkg_search_resp(
+                resp, args.repository, stop_pkg
+            )
+            if not next_query_project:
+                _LOG.debug("stopping (no next_query_project)")
+                break
+            next_query_project = urllib.parse.quote(next_query_project)
+            query = f"{self.url_projects}{next_query_project}/{search_term}"
+            if query == query_last:
+                _LOG.debug("stopping ('%s'=='%s')", query_last, query)
+                break
+
+    def _query_pkg_exact(self, args):
+        """Query exact pkg match"""
+        # Search pkg_exact, stop after first query response
+        args.pkg_search = args.pkg_exact
+        self._query_pkg_search(args, stop_pkg=args.pkg_exact)
+
+    def _query_sbom_cdx(self, args):
+        """Query repology.org based on packages in cdx sbom"""
+        # Ignore the sbom packages whose name match any of the following
+        ignore_sbom_pkg_names = [
+            r".*\.gz",
+            r".*\.patch",
+            r".*\.xz",
+            r".*\.bz2",
+            r".*\.zip",
+            r".*\.gem",
+            r".*\.tgz",
+            r".*\.h",
+            r".*\.c",
+            r".*\.diff",
+            r".*\?.*",
+            r".*\&.*",
+        ]
+        ignore_regexes = f"(?:{'|'.join(ignore_sbom_pkg_names)})"
+        _LOG.debug("ignore_regexes: %s", ignore_regexes)
+        self.df_sbom = self._parse_sbom_cdx(args.sbom_cdx.as_posix())
+        for cmp in self.df_sbom.itertuples():
+            _LOG.debug("Package: %s", cmp)
             if not cmp.name:
-                _LOG.warning("Missing package name: %s", cmp)
-            args.pkg = cmp.name
-            self._query_pkg_exact(args, cmp.version)
+                _LOG.fatal("Missing package name: %s", cmp)
+                sys.exit(1)
+            if re.match(ignore_regexes, cmp.name):
+                # Remove the below comments to output ignored packages:
+                self.pkgs_dict.setdefault("repo", []).append(args.repository)
+                self.pkgs_dict.setdefault("package", []).append(cmp.name)
+                self.pkgs_dict.setdefault("version", []).append("")
+                self.pkgs_dict.setdefault("status", []).append("IGNORED")
+                self.pkgs_dict.setdefault("potentially_vulnerable", []).append("")
+                self.pkgs_dict.setdefault("newest_upstream_release", []).append("")
+                self._packages_to_df(args, re_pkg_internal=cmp.name)
+                continue
+            pkg_id = f"{args.repository}:{cmp.name}"
+            if pkg_id in self.processed:
+                _LOG.debug("Package '%s' in sbom already processed", cmp.name)
+                continue
+            if not cmp.version:
+                # Remove the below comments to output packages with no version:
+                self.pkgs_dict.setdefault("repo", []).append(args.repository)
+                self.pkgs_dict.setdefault("package", []).append(cmp.name)
+                self.pkgs_dict.setdefault("version", []).append("")
+                self.pkgs_dict.setdefault("status", []).append("NO_VERSION")
+                self.pkgs_dict.setdefault("potentially_vulnerable", []).append("")
+                self.pkgs_dict.setdefault("newest_upstream_release", []).append("")
+                self._packages_to_df(args, re_pkg_internal=cmp.name)
+                continue
+            args.pkg_exact = cmp.name
+            self._query_pkg_exact(args)
+            if pkg_id not in self.processed:
+                self.pkgs_dict.setdefault("repo", []).append(args.repository)
+                self.pkgs_dict.setdefault("package", []).append(cmp.name)
+                self.pkgs_dict.setdefault("version", []).append("")
+                self.pkgs_dict.setdefault("status", []).append("NOT_FOUND")
+                self.pkgs_dict.setdefault("potentially_vulnerable", []).append("")
+                self.pkgs_dict.setdefault("newest_upstream_release", []).append("")
+            self._packages_to_df(args, re_pkg_internal=cmp.name)
+        self.urlq = self.url_projects
 
     def query(self, args):
         """Query package information from repology.org"""
         if args.pkg_search:
             self._query_pkg_search(args)
-        elif args.pkg:
+        elif args.pkg_exact:
             self._query_pkg_exact(args)
-        elif args.sbom:
-            self._query_sbom(args)
+        elif args.sbom_cdx:
+            self._query_sbom_cdx(args)
+        self._packages_to_df(args, re_pkg_internal=args.pkg_exact)
         self._report(args)
 
 
@@ -325,16 +422,6 @@ def main():
     """main entry point"""
     args = getargs()
     setup_logging(args.verbose)
-    pkg_len_limit = 3
-    if args.pkg_search and len(args.pkg_search) < pkg_len_limit:
-        _LOG.fatal(
-            "Package search term '%s' is shorter than %s characters. "
-            "Either provide longer package search term, or specify the exact "
-            "package name with '--pkg' argument. ",
-            args.pkg_search,
-            pkg_len_limit,
-        )
-        sys.exit(1)
     repology = Repology()
     repology.query(args)
 


### PR DESCRIPTION
This PR adds a command line tool to demonstrate querying [repology](https://repology.org/) package information.
For more details, see the README.md included in this PR.

For now, consider `repology_cli` as a demonstration or proof-of-concept. It's already helpful in many ways, but it's clear more work is required, at least:
- repology_cli is missing all automated tests currently. It's gone through some manual testing, but there's very likely bugs here and there
- The implementation should be split into smaller modules
- It might be worth moving repology_cli to its own repository, since it's really not related to sbomnix
