### PR TITLE
Fix test_nixgraph_csv_graph_inverse

### DIFF
--- a/scripts/vulnxscan/README.md
+++ b/scripts/vulnxscan/README.md
@@ -11,14 +11,14 @@ SPDX-License-Identifier: Apache-2.0
 Table of Contents
 =================
 * [Getting Started](#getting-started)
-* [Usage Examples](#usage-examples)
+* [Example Target](#example-target)
 * [Supported Scanners](#supported-scanners)
    * [Nix and OSV Vulnerability Database](#nix-and-osv-vulnerability-database)
    * [Nix and Grype](#nix-and-grype)
    * [Vulnix](#vulnix)
 * [Vulnxscan Usage Examples](#vulnxscan-usage-examples)
    * [Running Vulnxscan as Flake](#running-vulnxscan-as-flake)
-   * [Vulnxscan Installation](#vulnxscan-installation)
+   * [Running from Nix Development Shell](#running-from-nix-development-shell)
    * [Find Vulnerabilities Impacting Runtime Dependencies](#find-vulnerabilities-impacting-runtime-dependencies)
    * [Find Vulnerabilities Given SBOM as Input](#find-vulnerabilities-given-sbom-as-input)
    * [Find Vulnerabilities Impacting Buildtime and Runtime Dependencies](#find-vulnerabilities-impacting-buildtime-and-runtime-dependencies)
@@ -27,7 +27,7 @@ Table of Contents
 ## Getting Started
 To get started, follow the [Getting Started](../../README.md#getting-started) section from the main [README](../../README.md).
 
-## Usage Examples
+## Example Target
 In the below examples, we use `sbomnix` itself as an example target for `vulnxscan`.
 To get the target out-path, build `sbomnix` with `nix-build`:
 ```bash
@@ -76,15 +76,32 @@ $ cd sbomnix
 $ nix run .#vulnxscan -- --help
 ```
 
-### Vulnxscan Installation
-To install `vulnxscan`, follow the [Installation](../../README.md#installation) instructions from the main [README](../../README.md).
+### Running from Nix Development Shell
+
+If you have nix flakes enabled, run:
+```bash
+$ git clone https://github.com/tiiuae/sbomnix
+$ cd sbomnix
+$ nix develop
+```
+
+You can also use `nix-shell` to enter the development shell:
+```bash
+$ git clone https://github.com/tiiuae/sbomnix
+$ cd sbomnix
+$ nix-shell
+```
+
+From the development shell, run `vulnxscan` as follows:
+```bash
+$ scripts/vulnxscan/vulnxscan.py --help
+```
 
 ### Find Vulnerabilities Impacting Runtime Dependencies
 This example shows how to use `vulnxscan` to summarize vulnerabilities impacting the given target or any of its runtime dependencies.
 
 ```bash
-# Alternatively, run with flakes: 'nix run .#vulnxscan -- ./result'
-$ vulnxscan ./result
+$ nix run .#vulnxscan -- ./result
 
 INFO     Generating SBOM for target '/nix/store/8pvrr84a3aw12bvi45hl7wx01a8iqgni-python3.10-sbomnix-1.2.0'
 INFO     Loading runtime dependencies referenced by '/nix/store/8pvrr84a3aw12bvi45hl7wx01a8iqgni-python3.10-sbomnix-1.2.0'
@@ -159,8 +176,8 @@ INFO     Wrote: sbom.cdx.json
 
 Then, give the generated SBOM as input to `vulnxscan`:
 ```bash
-# Alternatively, run with flakes: 'nix run .#vulnxscan -- --sbom sbom.cdx.json'
-$ vulnxscan --sbom sbom.cdx.json
+$ nix run .#vulnxscan -- --sbom sbom.cdx.json
+
 INFO     Running grype scan
 INFO     Running OSV scan
 INFO     Querying vulnerabilities
@@ -221,8 +238,8 @@ Notice that `vulnxscan` drops the Vulnix scan when the input is SBOM. This is du
 By default, `vulnxscan` scans the given target for vulnerabilities that impact its runtime-only dependencies. This example shows how to use `vulnxscan` to include also buildtime dependencies to the scan.
 
 ```bash
-# Alternatively, run with flakes: 'nix run .#vulnxscan -- ./result --buildtime'
-$ vulnxscan ./result --buildtime
+$ nix run .#vulnxscan -- ./result --buildtime
+
 # ... output not included in this snippet ... 
 ```
 

--- a/shell.nix
+++ b/shell.nix
@@ -9,16 +9,35 @@
 pkgs.mkShell rec {
   name = "sbomnix-dev-shell";
 
-  sbomnix = import ./default.nix { pkgs=pkgs; };
-  vulnxscan = import ./scripts/vulnxscan/vulnxscan.nix { pkgs=pkgs; };
-  repology_cli = import ./scripts/repology/repology_cli.nix { pkgs=pkgs; };
   nix_outdated = import ./scripts/nixupdate/nix_outdated.nix { pkgs=pkgs; };
+  nix_visualize = import ./scripts/nixupdate/nix-visualize.nix { pkgs=pkgs; };
+  requests-ratelimiter = import ./scripts/repology/requests-ratelimiter.nix { pkgs=pkgs; };
+  vulnix = import ./scripts/vulnxscan/vulnix.nix { nixpkgs=pkgs.path; pkgs=pkgs; };
 
   buildInputs = [ 
-    sbomnix
-    vulnxscan
-    repology_cli
     nix_outdated
+    nix_visualize
+    requests-ratelimiter
+    vulnix
+    pkgs.coreutils
+    pkgs.curl
+    pkgs.gnugrep
+    pkgs.gnused
+    pkgs.graphviz
+    pkgs.grype
+    pkgs.gzip
+    pkgs.nix
+    pkgs.reuse
+    pythonPackages.beautifulsoup4
+    pythonPackages.colorlog
+    pythonPackages.graphviz
+    pythonPackages.numpy
+    pythonPackages.packageurl-python
+    pythonPackages.packaging
+    pythonPackages.pandas
+    pythonPackages.requests
+    pythonPackages.requests-cache
+    pythonPackages.tabulate
     pythonPackages.wheel
     pythonPackages.venvShellHook
   ];

--- a/tests/test_sbomnix.py
+++ b/tests/test_sbomnix.py
@@ -237,20 +237,6 @@ def test_nixgraph_csv_graph_inverse():
     df_out_inv = pd.read_csv(csv_out_inv)
     assert not df_out_inv.empty
 
-    # When 'depth' covers the entire graph, the output from
-    # the two above commands should be the same, except for column
-    # 'graph_depth': below, we remove that column from both outputs and
-    # compare the two dataframes
-
-    df_out = df_out.drop("graph_depth", axis=1)
-    df_out = df_out.sort_values(by=["src_path"])
-
-    df_out_inv = df_out_inv.drop("graph_depth", axis=1)
-    df_out_inv = df_out_inv.sort_values(by=["src_path"])
-
-    df_diff = df_difference(df_out, df_out_inv)
-    assert df_diff.empty, df_to_string(df_diff)
-
 
 ################################################################################
 


### PR DESCRIPTION
- Test case 'test_nixgraph_csv_graph_inverse' assumed the dependency graph for nix package 'hello' had no other leaves except 'libunistring' which is no longer true due to changes in gcc dependencies. Simplify the test by not comparing the full forward and inverse graphs.

- Don't import vulnxscan, nixupdate, or cpedict nix files, but list the dependencies explicitly in the main shell.nix. This makes it easier to develop those scripts in nix devshell.

- Fix vulnxscan usage instructions now that it's no longer installed by setup.py.