### PR TITLE
nix_secupdates.py: initial version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       pkgs = import nixpkgs { system = "x86_64-linux"; };
       vulnxscan = import ./scripts/vulnxscan/vulnxscan.nix { pkgs = pkgs; };
       repology_cli = import ./scripts/repology/repology_cli.nix { pkgs = pkgs; };
-      nix_outdated = import ./scripts/nixupdate/nix_outdated.nix { pkgs = pkgs; };
+      nixupdate = import ./scripts/nixupdate/nixupdate.nix { pkgs = pkgs; };
       sbomnix = import ./default.nix { pkgs = pkgs; };
       sbomnix-shell = import ./shell.nix { pkgs = pkgs; };
     in rec {
@@ -19,7 +19,7 @@
       # nix package
       packages.x86_64-linux = {
         inherit repology_cli;
-        inherit nix_outdated;
+        inherit nixupdate;
         inherit vulnxscan;
         inherit sbomnix;
         default = sbomnix;
@@ -52,7 +52,13 @@
       # nix run .#nix_outdated
       apps.x86_64-linux.nix_outdated= {
         type = "app";
-        program = "${self.packages.x86_64-linux.nix_outdated}/bin/nix_outdated.py";
+        program = "${self.packages.x86_64-linux.nixupdate}/bin/nix_outdated.py";
+      };
+
+      # nix run .#nix_secupdates
+      apps.x86_64-linux.nix_secupdates = {
+        type = "app";
+        program = "${self.packages.x86_64-linux.nixupdate}/bin/nix_secupdates.py";
       };
 
       # nix develop

--- a/nixgraph/main.py
+++ b/nixgraph/main.py
@@ -11,7 +11,7 @@ import logging
 import pathlib
 import sys
 from nixgraph.graph import NixDependencies
-from sbomnix.utils import setup_logging, get_version, LOGGER_NAME
+from sbomnix.utils import setup_logging, get_py_pkg_version, LOGGER_NAME
 
 ###############################################################################
 
@@ -36,7 +36,7 @@ def getargs():
 
     helps = "Path to nix artifact, e.g.: derivation file or nix output path"
     parser.add_argument("NIX_PATH", help=helps, type=pathlib.Path)
-    parser.add_argument("--version", action="version", version=get_version())
+    parser.add_argument("--version", action="version", version=get_py_pkg_version())
 
     helps = "Scan buildtime dependencies instead of runtime dependencies"
     parser.add_argument("--buildtime", help=helps, action="store_true")

--- a/sbomnix/main.py
+++ b/sbomnix/main.py
@@ -13,7 +13,7 @@ import sys
 from sbomnix.sbomdb import SbomDb
 from sbomnix.utils import (
     setup_logging,
-    get_version,
+    get_py_pkg_version,
     LOGGER_NAME,
 )
 
@@ -36,7 +36,7 @@ def getargs():
 
     helps = "Path to nix artifact, e.g.: derivation file or nix output path"
     parser.add_argument("NIX_PATH", help=helps, type=pathlib.Path)
-    parser.add_argument("--version", action="version", version=get_version())
+    parser.add_argument("--version", action="version", version=get_py_pkg_version())
 
     helps = "Set the debug verbosity level between 0-3 (default: --verbose=1)"
     parser.add_argument("--verbose", help=helps, type=int, default=1)

--- a/sbomnix/sbomdb.py
+++ b/sbomnix/sbomdb.py
@@ -21,7 +21,7 @@ from sbomnix.nix import Store, find_deriver
 from sbomnix.utils import (
     LOGGER_NAME,
     df_to_csv_file,
-    get_version,
+    get_py_pkg_version,
 )
 
 ###############################################################################
@@ -171,7 +171,7 @@ class SbomDb:
         tool = {}
         tool["vendor"] = "TII"
         tool["name"] = "sbomnix"
-        tool["version"] = get_version()
+        tool["version"] = get_py_pkg_version()
         cdx["metadata"]["tools"] = []
         cdx["metadata"]["tools"].append(tool)
         cdx["components"] = []
@@ -198,7 +198,7 @@ class SbomDb:
         creation_info = {}
         creation_info["created"] = datetime.now(timezone.utc).astimezone().isoformat()
         creation_info["creators"] = []
-        creation_info["creators"].append(f"Tool: sbomnix-{get_version()}")
+        creation_info["creators"].append(f"Tool: sbomnix-{get_py_pkg_version()}")
         spdx["creationInfo"] = creation_info
         spdx["comment"] = f"included dependencies: '{self.sbom_type}'"
         spdx["packages"] = []

--- a/sbomnix/utils.py
+++ b/sbomnix/utils.py
@@ -11,7 +11,8 @@ import sys
 import csv
 import logging
 import subprocess
-from importlib.metadata import version, PackageNotFoundError
+import importlib.metadata
+import packaging.version
 from tabulate import tabulate
 from colorlog import ColoredFormatter, default_log_colors
 import pandas as pd
@@ -123,14 +124,114 @@ def regex_match(regex, string):
     return re.match(regex, string) is not None
 
 
-def get_version(package="sbomnix"):
+def get_py_pkg_version(package="sbomnix"):
     """Return package version string"""
     versionstr = ""
     try:
-        versionstr = version(package)
-    except PackageNotFoundError:
+        versionstr = importlib.metadata.version(package)
+    except importlib.metadata.PackageNotFoundError:
         versionstr = "0.0.0"
     return versionstr
+
+
+def number_distance(n1, n2):
+    """
+    Return float value between [0.0,1.0] indicating the closeness
+    of the given two numbers.
+    Returns 1.0 if the two integers are equal.
+    Returns 0.0 if either argument is not a number.
+    """
+    if not isinstance(n1, (float, int)) or not isinstance(n2, (float, int)):
+        return 0.0
+    min_n = min(n1, n2)
+    max_n = max(n1, n2)
+    if max_n == 0:
+        return 1.0
+    if min_n == 0:
+        min_n += 1
+        max_n += 1
+    return min_n / max_n
+
+
+def version_distance(v1, v2):
+    """
+    Return float value between [0.0,1.0] indicating the closeness
+    of the given two version number strings.
+    """
+    v1 = str(v1)
+    v2 = str(v2)
+    re_vclean = re.compile(r"[^0-9.]+")
+    v1_clean = re_vclean.sub(r"", v1)
+    v2_clean = re_vclean.sub(r"", v2)
+    re_vsplit = re.compile(r"(?P<ver_beg>[0-9][0-9]*)(?P<ver_end>.*)$")
+    match = re.match(re_vsplit, v1_clean)
+    if not match:
+        logging.getLogger(LOGGER_NAME).warning("Unexpected v1 version '%s'", v1)
+        return 0.0
+    v1_major = match.group("ver_beg")
+    v1_minor = match.group("ver_end").replace(".", "")
+    v1_float = float(v1_major + "." + v1_minor)
+    match = re.match(re_vsplit, v2_clean)
+    if not match:
+        logging.getLogger(LOGGER_NAME).warning("Unexpected v2 version '%s'", v2)
+        return 0.0
+    v2_major = match.group("ver_beg")
+    v2_minor = match.group("ver_end").replace(".", "")
+    v2_float = float(v2_major + "." + v2_minor)
+    return number_distance(v1_float, v2_float)
+
+
+def parse_version(ver_str):
+    """
+    Return comparable version object from the given version string.
+    Returns None if the version string can not be converted to version object.
+    """
+    ver_str = str(ver_str)
+    re_ver = re.compile(r"(?P<ver_beg>[0-9][0-9.]*)(?P<ver_end>.*)$")
+    match = re_ver.match(ver_str)
+    if not match:
+        logging.getLogger(LOGGER_NAME).warning("Unable to parse version '%s'", ver_str)
+        return None
+    ver_beg = match.group("ver_beg").rstrip(".")
+    ver_end = match.group("ver_end")
+    re_vclean = re.compile("[^0-9.]+")
+    ver_end = re_vclean.sub(r"", ver_end)
+    if ver_end:
+        ver_end = f"+{ver_end}"
+    else:
+        ver_end = ""
+    ver_end = ver_end.rstrip(".")
+    ver = f"{ver_beg}{ver_end}"
+    logging.getLogger(LOGGER_NAME).log(LOG_SPAM, "%s --> %s", ver_str, ver)
+    if not ver:
+        logging.getLogger(LOGGER_NAME).warning("Invalid version '%s'", ver_str)
+        return None
+    return packaging.version.parse(ver)
+
+
+def nix_to_repology_pkg_name(nix_pkg_name):
+    """Convert nix package name to repology package name"""
+    if not nix_pkg_name or pd.isnull(nix_pkg_name):
+        return nix_pkg_name
+    # Convert nix_pkg_name so it matches repology package name
+    nix_pkg_name = nix_pkg_name.lower()
+    re_nix_to_repo = re.compile(
+        r"^(?:"
+        r"(python)|(perl)|(emacs)|(vim)plugin|(ocaml)|"
+        r"(gnome)-shell-extension|(lisp)|(ruby)|(lua)|"
+        r"(php)[0-9]*Packages|(go)|(coq)|(rust)"
+        r")"
+        r"[0-9.]*-(.+)"
+    )
+    match = re.match(re_nix_to_repo, nix_pkg_name)
+    if match:
+        # Filter out all non-matched groups
+        matches = list(filter(None, match.groups()))
+        assert len(matches) == 2, f"Unexpected package name '{nix_pkg_name}'"
+        nix_pkg_name = f"{matches[0]}:{matches[1]}"
+    if nix_pkg_name == "python3":
+        nix_pkg_name = "python"
+    return nix_pkg_name
 
 
 ################################################################################

--- a/scripts/nixupdate/README.md
+++ b/scripts/nixupdate/README.md
@@ -4,12 +4,19 @@ SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# nix_outdated
+Table of Contents
+=================
 
-`nix_outdated` is a command line tool to list outdated nix dependencies for given target nix out path. By default, the script outputs runtime dependencies for the given nix out path that appear outdated in nixpkgs 'nix_unstable' channel - the list of output packages would potentially need a PR to update the package in nixpkgs to the latest upstream release version specified in the output table column 'version_upstream'. The list of output packages is in priority order based on how many other packages depend on the potentially outdated package.
+* [Getting Started](#getting-started)
+   * [Running as Nix Flake](#running-as-nix-flake)
+   * [Running from Nix Development Shell](#running-from-nix-development-shell)
+   * [Example Target](#example-target)
+* [nix_outdated](#nix_outdated)
+* [nix_secupdates](#nix_secupdates)
 
+# Getting Started
 ## Running as Nix Flake
-`nix_outdated` can be run as a [Nix flake](https://nixos.wiki/wiki/Flakes) from the `tiiuae/sbomnix` repository:
+`nix_outdated.py` and `nix_secupdates.py` can be run as a [Nix flake](https://nixos.wiki/wiki/Flakes) from the `tiiuae/sbomnix` repository:
 ```bash
 # '--' signifies the end of argument list for `nix`.
 # '--help' is the first argument to `nix_outdated`
@@ -20,7 +27,7 @@ or from a local repository:
 ```bash
 $ git clone https://github.com/tiiuae/sbomnix
 $ cd sbomnix
-$ nix run .#nix_outdated -- --help
+$ nix run .#nix_secupdates -- --help
 ```
 
 ## Running from Nix Development Shell
@@ -39,13 +46,17 @@ $ cd sbomnix
 $ nix-shell
 ```
 
-From the development shell, you can run `repology_cli` as follows:
+From the development shell, you can run `nix_outdated.py` or `nix_secupdates.py` as follows:
 ```bash
+# Run nix_outdated from nix devshell:
 $ scripts/nixupdate/nix_outdated.py --help
+
+# Run nix_secupdates from nix devshell:
+$ scripts/nixupdate/nix_secupdates.py --help
 ```
 
-## Example Usage
 
+## Example Target
 We use Nix package `git` as an example target.
 To install git and print out its out-path on your local system, try something like:
 ```bash
@@ -53,9 +64,13 @@ $ nix-shell -p git --run exit && nix eval -f '<nixpkgs>' 'git.outPath'
 "/nix/store/2853v0cidl7jww2hs1mlkg0i372mk368-git-2.39.2"
 ```
 
+# nix_outdated
+`nix_outdated` is a command line tool to list outdated nix dependencies for given target nix out path. By default, the script outputs runtime dependencies for the given nix out path that appear outdated in nixpkgs 'nix_unstable' channel - the list of output packages would potentially need a PR to update the package in nixpkgs to the latest upstream release version specified in the output table column 'version_upstream'. The list of output packages is in priority order based on how many other packages depend on the potentially outdated package.
+
 Below command finds runtime dependencies of `git` that would have an update in the package's upstream repository based on repology, but the latest release version is not available in nix unstable:
 
 ```bash
+# In nix devshell
 $ scripts/nixupdate/nix_outdated.py /nix/store/2853v0cidl7jww2hs1mlkg0i372mk368-git-2.39.2
 INFO     Generating SBOM for target '/nix/store/2853v0cidl7jww2hs1mlkg0i372mk368-git-2.39.2'
 INFO     Loading runtime dependencies referenced by '/nix/store/2853v0cidl7jww2hs1mlkg0i372mk368-git-2.39.2'
@@ -105,3 +120,79 @@ As an example, the first row in the above output table means that:
 - `libidn2` newest version in nix unstable is 2.3.2 (based on repology.org).
 - `libidn2` newest release version in the package's upstream repository is 2.3.4 (based on repology.org).
 - `libidn2` is considered outdated, because the version string in `version_upstream` is later than the version string in `version_nixpkgs`.
+
+
+# nix_secupdates
+`nix_secupdates` is a command line tool that demonstrates finding and classifying potential security updates for given nix target or any of its dependencies.
+
+Below command finds security issues for runtime dependencies of `firefox`, and classifies the update availability for each vulnerability:
+
+```bash
+# In devshell
+scripts/nixupdate/nix_secupdates.py /nix/store/pidpcf621di8xkp41b0anb61rjfalh9w-firefox-112.0
+INFO     Running vulnxscan for target '/nix/store/pidpcf621di8xkp41b0anb61rjfalh9w-firefox-112.0'
+INFO     Using vulnxscan result: '/tmp/secupdates_vulnxscan_h4pw7a6g.csv'
+INFO     Querying repology
+INFO     Console report
+
+Potential vulnerabilities impacting version_local, with suggested update actions:
+
+|                     |                | version | version | version  |                                      |
+| vuln_id             |  package       | local   | nixpkgs | upstream | classify                             |
+|---------------------+----------------+---------+---------+----------+--------------------------------------|
+| CVE-2023-29383      |  shadow        | 4.13    | 4.13    | 4.13     | fix_not_available                    |
+| CVE-2023-27371      |  libmicrohttpd | 0.9.71  | 0.9.72  | 0.9.76   | fix_update_to_version_upstream       |
+| CVE-2023-1916       |  libtiff       | 4.5.0   |         |          | err_missing_repology_version         |
+| CVE-2023-0466       |  openssl       | 3.0.8   | 3.0.8   | 3.1.0    | err_not_vulnerable_based_on_repology |
+| CVE-2023-0465       |  openssl       | 3.0.8   | 3.0.8   | 3.1.0    | err_not_vulnerable_based_on_repology |
+| CVE-2023-0464       |  openssl       | 3.0.8   | 3.0.8   | 3.1.0    | err_not_vulnerable_based_on_repology |
+| OSV-2023-323        |  harfbuzz      | 7.1.0   | 7.1.0   | 7.1.0    | err_not_vulnerable_based_on_repology |
+| OSV-2023-222        |  harfbuzz      | 7.1.0   | 7.1.0   | 7.1.0    | err_not_vulnerable_based_on_repology |
+| OSV-2023-170        |  harfbuzz      | 7.1.0   | 7.1.0   | 7.1.0    | err_not_vulnerable_based_on_repology |
+| OSV-2023-137        |  harfbuzz      | 7.1.0   | 7.1.0   | 7.1.0    | err_not_vulnerable_based_on_repology |
+| CVE-2022-48281      |  libtiff       | 4.5.0   |         |          | err_missing_repology_version         |
+| CVE-2022-47021      |  opusfile      | 0.12    | 0.12    | 0.12     | fix_not_available                    |
+| CVE-2022-28506      |  giflib        | 5.2.1   | 5.2.1   | 5.2.1    | fix_not_available                    |
+| CVE-2022-28321      |  linux-pam     | 1.5.2   |         |          | err_missing_repology_version         |
+| CVE-2022-26691      |  cups          | 2.4.2   | 2.4.2   | 2.4.2    | fix_not_available                    |
+| CVE-2022-3965       |  ffmpeg        | 5.1.2   | 6.0     | 6.0      | fix_update_to_version_nixpkgs        |
+| CVE-2022-3964       |  ffmpeg        | 5.1.2   | 6.0     | 6.0      | fix_update_to_version_nixpkgs        |
+| CVE-2022-3219       |  gnupg         | 2.4.0   | 2.4.0   | 2.4.0    | err_not_vulnerable_based_on_repology |
+| OSV-2022-1168       |  gstreamer     | 1.20.3  | 1.20.3  | 1.22.2   | err_not_vulnerable_based_on_repology |
+| OSV-2022-1089       |  gstreamer     | 1.20.3  | 1.20.3  | 1.22.2   | err_not_vulnerable_based_on_repology |
+| OSV-2022-908        |  bluez         | 5.66    | 5.66    | 5.66     | err_not_vulnerable_based_on_repology |
+| OSV-2022-859        |  bluez         | 5.66    | 5.66    | 5.66     | err_not_vulnerable_based_on_repology |
+| GHSA-6898-wx94-8jq8 |  libnotify     | 0.8.2   | 0.8.2   | 0.8.2    | err_not_vulnerable_based_on_repology |
+| CVE-2021-26720      |  avahi         | 0.8     | 0.8     | 0.8      | fix_not_available                    |
+| CVE-2021-3468       |  avahi         | 0.8     | 0.8     | 0.8      | fix_not_available                    |
+| OSV-2021-777        |  libxml2       | 2.10.3  | 2.10.3  | 2.10.4   | err_not_vulnerable_based_on_repology |
+| CVE-2020-24490      |  bluez         | 5.66    | 5.66    | 5.66     | err_not_vulnerable_based_on_repology |
+| CVE-2019-6462       |  cairo         | 1.16.0  | 1.16.0  | 1.16.0   | fix_not_available                    |
+| CVE-2019-6461       |  cairo         | 1.16.0  | 1.16.0  | 1.16.0   | fix_not_available                    |
+| CVE-2018-7263       |  libmad        | 0.15.1b | 0.15.1b | 0.16.3   | err_not_vulnerable_based_on_repology |
+| CVE-2018-6553       |  cups          | 2.4.2   | 2.4.2   | 2.4.2    | err_not_vulnerable_based_on_repology |
+| CVE-2017-6839       |  audiofile     | 0.3.6   | 0.3.6   | 0.3.6    | fix_not_available                    |
+| CVE-2017-6838       |  audiofile     | 0.3.6   | 0.3.6   | 0.3.6    | fix_not_available                    |
+| CVE-2017-6837       |  audiofile     | 0.3.6   | 0.3.6   | 0.3.6    | fix_not_available                    |
+| CVE-2017-6836       |  audiofile     | 0.3.6   | 0.3.6   | 0.3.6    | fix_not_available                    |
+| CVE-2017-6835       |  audiofile     | 0.3.6   | 0.3.6   | 0.3.6    | fix_not_available                    |
+| CVE-2017-6834       |  audiofile     | 0.3.6   | 0.3.6   | 0.3.6    | fix_not_available                    |
+| CVE-2017-6833       |  audiofile     | 0.3.6   | 0.3.6   | 0.3.6    | fix_not_available                    |
+| CVE-2017-6832       |  audiofile     | 0.3.6   | 0.3.6   | 0.3.6    | fix_not_available                    |
+| CVE-2017-6831       |  audiofile     | 0.3.6   | 0.3.6   | 0.3.6    | fix_not_available                    |
+| CVE-2017-6830       |  audiofile     | 0.3.6   | 0.3.6   | 0.3.6    | fix_not_available                    |
+| CVE-2017-6829       |  audiofile     | 0.3.6   | 0.3.6   | 0.3.6    | fix_not_available                    |
+| CVE-2017-6828       |  audiofile     | 0.3.6   | 0.3.6   | 0.3.6    | fix_not_available                    |
+| CVE-2017-6827       |  audiofile     | 0.3.6   | 0.3.6   | 0.3.6    | fix_not_available                    |
+| CVE-2017-5436       |  graphite2     | 1.3.14  | 1.3.14  | 1.3.14   | err_not_vulnerable_based_on_repology |
+| CVE-2016-2781       |  coreutils     | 9.1     | 9.1     | 9.3      | fix_not_available                    |
+| CVE-2015-7313       |  libtiff       | 4.5.0   |         |          | err_missing_repology_version         |
+
+```
+
+As an example, the output table states the following:
+- Package `shadow`, which is a runtime dependency of firefox, is potentially vulnerable to CVE-2023-29383.
+- The dependency package `shadow` local version is 4.13. Based on repology.org, version 4.13 is also the latest available release version both in nixpkgs (nix_unstable channel) as well as the package's upstream repository. Since there's no known fixed version available in nixpkgs nor upstream, `nix_secupdates` classifies the update as `fix_not_available`. Note: the fix might still be in-progress, but not yet available in nix_unstable. Also, if the vulnerability is fixed with a patch without updating the version number, vulnxscan might still flag the issue (i.e. the output table will include false positives).
+- Package `libmicrohttpd` local version 0.9.71 is potentially vulnerable to CVE-2023-27371. Latest version in nix_unstable is 0.9.72. However, that version is also vulnerable to CVE-2023-27371. Version 0.9.76, which is currently available in upstream, is not vulnerable. Therefore, `nix_secupdates` classifies the update as `fix_update_to_version_upstream` indicating `libmicrohttpd` should be updated to 0.9.76 which is currently available in upstream to mitigate the vulnerability.
+- Package `libtiff` local version 4.5.0 is potentially vulnerable to CVE-2023-1916, however, `libtiff` is not available in repology so the latest nixpkgs version, as well as the upstream version are unknown. Therefore, `nix_secupdates` classifies the update as `err_missing_repology_version`.
+- Package `openssl` local version 3.0.8 is potentially vulnerable to CVE-2023-0466. However, based on repology.org, `openssl` 3.0.8 is not vulnerable to CVE-2023-0466. Therefore, `nix_secupdates` is not able to determine the potential fixed version and sets the classification to `err_not_vulnerable_based_on_repology`.

--- a/scripts/nixupdate/nix_secupdates.py
+++ b/scripts/nixupdate/nix_secupdates.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=invalid-name too-many-return-statements fixme
+
+"""
+Command line tool to demonstrate finding and classifying potential security
+updates for dependencies of given nix target
+"""
+
+import logging
+import os
+import sys
+import pathlib
+from tempfile import NamedTemporaryFile
+from argparse import ArgumentParser
+import pandas as pd
+from tabulate import tabulate
+from sbomnix.utils import (
+    setup_logging,
+    LOGGER_NAME,
+    LOG_SPAM,
+    exec_cmd,
+    df_from_csv_file,
+    df_log,
+    df_to_csv_file,
+    nix_to_repology_pkg_name,
+    parse_version,
+    version_distance,
+)
+
+###############################################################################
+
+_LOG = logging.getLogger(LOGGER_NAME)
+
+###############################################################################
+
+
+def getargs():
+    """Parse command line arguments"""
+    desc = (
+        "Command line tool to demonstrate finding and classifying potential "
+        "security updates for nix target or any of its dependencies."
+    )
+    epil = f"Example: ./{os.path.basename(__file__)} '/nix/target/out/path'"
+    parser = ArgumentParser(description=desc, epilog=epil)
+    # Arguments that specify the target:
+    helps = "Target nix out path"
+    parser.add_argument("NIXPATH", help=helps, type=pathlib.Path)
+    # Other arguments:
+    helps = (
+        "Include target's buildtime dependencies to the scan. "
+        "By default, only runtime dependencies are considered."
+    )
+    parser.add_argument("--buildtime", help=helps, action="store_true")
+    helps = "Path to output file (default: ./nix_secupdates.csv)"
+    parser.add_argument("--out", nargs="?", help=helps, default="nix_secupdates.csv")
+    helps = "Set the debug verbosity level between 0-3 (default: --verbose=1)"
+    parser.add_argument("--verbose", help=helps, type=int, default=1)
+    return parser.parse_args()
+
+
+################################################################################
+
+_repology_cve_dfs = {}
+_repology_cli_dfs = {}
+_repology_nix_repo = "nix_unstable"
+
+
+def _run_vulnxscan(target_path, buildtime=False):
+    _LOG.info("Running vulnxscan for target '%s'", target_path)
+    prefix = "secupdates_vulnxscan_"
+    suffix = ".csv"
+    with NamedTemporaryFile(delete=False, prefix=prefix, suffix=suffix) as f:
+        extra_args = "--buildtime" if buildtime else ""
+        cmd = f"vulnxscan.py {extra_args} --out={f.name} {target_path}"
+        exec_cmd(cmd.split())
+        try:
+            df = df_from_csv_file(f.name)
+            _LOG.info("Using vulnxscan result: '%s'", f.name)
+        except pd.errors.EmptyDataError:
+            _LOG.info("No vulnerabilities found")
+            sys.exit(0)
+        return df
+
+
+def _select_newest(df):
+    df_ret = None
+    for pkg_name in df["package"].unique():
+        df_pkg = df[df["package"] == str(pkg_name)]
+        # Newest by status:
+        df_newest = df_pkg[df_pkg["status"] == "newest"]
+        if df_newest.empty:
+            # If there's no newest by status, take the newest by version:
+            df_newest = df_pkg.sort_values(by=["version"]).iloc[[-1]]
+        df_ret = pd.concat([df_ret, df_newest], ignore_index=True)
+    return df_ret
+
+
+def _run_repology_cli(pname, match_type="--pkg_exact"):
+    _LOG.log(LOG_SPAM, "Running repology_cli for '%s'", pname)
+    df_repology_cli = None
+    if pname in _repology_cli_dfs:
+        _LOG.log(LOG_SPAM, "Using cached repology_cli results")
+        df_repology_cli = _repology_cli_dfs[pname]
+    else:
+        prefix = "repology_cli_"
+        suffix = ".csv"
+        with NamedTemporaryFile(delete=True, prefix=prefix, suffix=suffix) as f:
+            repo = f"--repository {_repology_nix_repo}"
+            status = "--re_status=outdated|newest|devel|unique"
+            out = f"--out={f.name}"
+            search = f"{match_type}={pname}"
+            cmd = f"repology_cli.py {repo} {status} {search} {out} "
+            ret = exec_cmd(cmd.split(), raise_on_error=False, return_error=True)
+            if ret and ret.stderr and "No matching packages" in ret.stderr:
+                return None
+            df_repology_cli = df_from_csv_file(f.name)
+            df_repology_cli = _select_newest(df_repology_cli)
+            _repology_cli_dfs[pname] = df_repology_cli
+            df_log(df_repology_cli, LOG_SPAM)
+    return df_repology_cli
+
+
+def _add_vuln_item(out_dict, vuln, df_repo=None):
+    if df_repo is None:
+        out_dict.setdefault("vuln_id", []).append(vuln.vuln_id)
+        out_dict.setdefault("url", []).append(vuln.url)
+        out_dict.setdefault("package", []).append(vuln.package)
+        out_dict.setdefault("version_local", []).append(vuln.version)
+        out_dict.setdefault("version_nixpkgs", []).append("")
+        out_dict.setdefault("version_upstream", []).append("")
+        out_dict.setdefault("package_repology", []).append("")
+        out_dict.setdefault("sortcol", []).append(vuln.sortcol)
+        return
+    for item in df_repo.itertuples():
+        out_dict.setdefault("vuln_id", []).append(vuln.vuln_id)
+        out_dict.setdefault("url", []).append(vuln.url)
+        out_dict.setdefault("package", []).append(vuln.package)
+        out_dict.setdefault("version_local", []).append(vuln.version)
+        out_dict.setdefault("version_nixpkgs", []).append(item.version)
+        out_dict.setdefault("version_upstream", []).append(item.newest_upstream_release)
+        out_dict.setdefault("package_repology", []).append(item.package)
+        out_dict.setdefault("sortcol", []).append(vuln.sortcol)
+
+
+def _version_similarity(row):
+    ratio = version_distance(row.version, row.version_cmp)
+    _LOG.log(
+        LOG_SPAM,
+        "Version similarity ('%s' vs '%s' ==> %s)",
+        row.version,
+        row.version_cmp,
+        ratio,
+    )
+    return ratio
+
+
+def _query_repology_versions(df_vuln_pkgs):
+    _LOG.info("Querying repology")
+    result_dict = {}
+    for vuln in df_vuln_pkgs.itertuples():
+        repo_pkg = nix_to_repology_pkg_name(vuln.package)
+        _LOG.log(LOG_SPAM, "Package '%s' ==> '%s'", vuln.package, repo_pkg)
+        df_repology_cli = _run_repology_cli(repo_pkg)
+        if df_repology_cli is not None and not df_repology_cli.empty:
+            # If there's one match, there's no need to check other details
+            if df_repology_cli.shape[0] == 1:
+                _LOG.log(LOG_SPAM, "One repology package matches")
+                _add_vuln_item(result_dict, vuln, df_repology_cli)
+                continue
+            # Match based on version: exact match
+            df = df_repology_cli[df_repology_cli["version"] == vuln.version]
+            if not df.empty:
+                _LOG.log(LOG_SPAM, "Exact version match '%s'", vuln.version)
+                _add_vuln_item(result_dict, vuln, df)
+                continue
+            # Match based on version: similarity
+            df_repology_cli["version_cmp"] = vuln.version
+            df_repology_cli["similarity"] = df_repology_cli.apply(
+                _version_similarity, axis=1
+            )
+            df = df_repology_cli[df_repology_cli["similarity"] >= 0.7]
+            if not df.empty:
+                _LOG.log(LOG_SPAM, "Version similarity match:\n%s", df)
+                _add_vuln_item(result_dict, vuln, df)
+                continue
+            # Otherwise, we need to conclude that we don't know which repology
+            # package (as returned by _run_repology_cli()), the nix package
+            # 'vuln.package' maps to.
+            # TODO: if we end up here, we could do another search with:
+            # _run_repology_cli(repo_pkg, match_type='--pkg_search')
+            _LOG.log(LOG_SPAM, "Vague match in repology pkg, adding vuln only")
+            _add_vuln_item(result_dict, vuln)
+        else:
+            _add_vuln_item(result_dict, vuln)
+    df_result = pd.DataFrame(result_dict)
+    df_result.fillna("", inplace=True)
+    df_result.reset_index(drop=True, inplace=True)
+    return df_result
+
+
+def _find_secupdates(args):
+    target_path_abs = args.NIXPATH.resolve().as_posix()
+    # Find vulnerable packages
+    df_vulnx = _run_vulnxscan(target_path_abs, args.buildtime)
+    uids = ["vuln_id", "package", "version", "url", "sortcol"]
+    df_vuln_pkgs = df_vulnx.groupby(by=uids).size().reset_index(name="count")
+    _LOG.debug("Number of vulnerable packages: %s", df_vuln_pkgs.shape[0])
+    df_log(df_vuln_pkgs, LOG_SPAM)
+    # Find the repology version info for the vulnerable packages
+    df_vuln_pkgs = _query_repology_versions(df_vuln_pkgs)
+    _LOG.debug("Vulnerable pkgs with repology version info: %s", df_vuln_pkgs.shape[0])
+    df_log(df_vuln_pkgs, LOG_SPAM)
+    # Classify each vulnerable package
+    df_vuln_pkgs["classify"] = df_vuln_pkgs.apply(_vuln_update_classify, axis=1)
+    # Sort the data based on the following columns
+    sort_cols = ["sortcol", "package", "version_local"]
+    df_vuln_pkgs.sort_values(by=sort_cols, ascending=False, inplace=True)
+    return df_vuln_pkgs
+
+
+def _pkg_is_vulnerable(repo_pkg_name, pkg_version, cve_id=None):
+    """
+    Return true if given pkg version is vulnerable. If cve_id is specified,
+    return true only if pkg is affected by the given cve id.
+    """
+    # For now, we rely on repology for the vulnerability info.
+    _LOG.debug("Finding vulnerability status for %s:%s", repo_pkg_name, pkg_version)
+    key = f"{repo_pkg_name}:{pkg_version}"
+    if key in _repology_cve_dfs:
+        _LOG.log(LOG_SPAM, "Using cached repology_cve results")
+        df = _repology_cve_dfs[key]
+    else:
+        prefix = "repology_cve_"
+        suffix = ".csv"
+        with NamedTemporaryFile(delete=True, prefix=prefix, suffix=suffix) as f:
+            args = f"{repo_pkg_name} {pkg_version}"
+            cmd = f"repology_cve.py --out={f.name} {args}"
+            exec_cmd(cmd.split(), raise_on_error=False)
+            try:
+                df = df_from_csv_file(f.name)
+                df_log(df, LOG_SPAM)
+            except pd.errors.EmptyDataError:
+                df = pd.DataFrame()
+        _repology_cve_dfs[key] = df
+    if cve_id and not df.empty:
+        df = df[df["cve"] == cve_id]
+    return not df.empty
+
+
+def _vuln_update_classify(row):
+    if not row.version_nixpkgs and not row.version_upstream:
+        return "err_missing_repology_version"
+
+    # Check that the package is also vulnerable based on repology
+    if row.version_local and not _pkg_is_vulnerable(
+        row.package_repology, row.version_local, row.vuln_id
+    ):
+        return "err_not_vulnerable_based_on_repology"
+
+    # Check if there's an update available in nixpkgs
+    version_local = parse_version(row.version_local)
+    version_nixpkgs = parse_version(row.version_nixpkgs)
+    if not version_local:
+        return "err_invalid_version"
+    if not version_nixpkgs:
+        return "err_invalid_version"
+    if row.version_nixpkgs and version_local < version_nixpkgs:
+        # Classify accordingly if the nixpkgs update is not vulnerable
+        if not _pkg_is_vulnerable(
+            row.package_repology, row.version_nixpkgs, row.vuln_id
+        ):
+            return "fix_update_to_version_nixpkgs"
+
+    # Check if there's an update available in upstream
+    if row.version_upstream and ";" in row.version_upstream:
+        version_upstream_str = row.version_upstream.split(";")[0]
+    else:
+        version_upstream_str = row.version_upstream
+    version_upstream = parse_version(version_upstream_str)
+    if not version_upstream:
+        return "err_invalid_version"
+    if version_upstream_str and version_local < version_upstream:
+        # Classify accordingly if the upstream update is not vulnerable
+        if not _pkg_is_vulnerable(
+            row.package_repology, version_upstream_str, row.vuln_id
+        ):
+            return "fix_update_to_version_upstream"
+
+    # Issue appears valid, but there's no known fix.
+    # Note: a fix might still be in progress. We should check the current PRs
+    # in github to find out if update is in progress but not yet available in
+    # nix_unstable.
+    return "fix_not_available"
+
+
+def _report(df_vulns):
+    df = df_vulns.copy()
+    if df.empty:
+        _LOG.warning("No vulnerabilities found")
+        sys.exit(0)
+    # Truncate version strings
+    df["version_local"] = df["version_local"].str.slice(0, 16)
+    df["version_nixpkgs"] = df["version_nixpkgs"].str.slice(0, 16)
+    df["version_upstream"] = df["version_upstream"].str.slice(0, 16)
+    # Don't print the following columns to console
+    df = df.drop("sortcol", axis=1)
+    df = df.drop("package_repology", axis=1)
+    # Write the console report
+    table = tabulate(
+        df,
+        headers="keys",
+        tablefmt="orgtbl",
+        numalign="center",
+        showindex=False,
+    )
+    _LOG.info(
+        "Console report\n\n"
+        "Potential vulnerabilities impacting version_local, with suggested "
+        "update actions:\n\n%s\n\n",
+        table,
+    )
+
+
+################################################################################
+
+
+def main():
+    """main entry point"""
+    args = getargs()
+    setup_logging(args.verbose)
+    if not args.NIXPATH.exists():
+        _LOG.fatal("Invalid path: '%s", args.NIXPATH)
+        sys.exit(1)
+    df = _find_secupdates(args)
+    _report(df)
+    df_to_csv_file(df, args.out)
+
+
+################################################################################
+
+if __name__ == "__main__":
+    main()
+
+################################################################################

--- a/scripts/nixupdate/nixupdate.nix
+++ b/scripts/nixupdate/nixupdate.nix
@@ -7,16 +7,17 @@
 }:
 
 pythonPackages.buildPythonPackage rec {
-  pname = "nix_outdated";
+  pname = "nixupdate";
   version = pkgs.lib.removeSuffix "\n" (builtins.readFile ../../VERSION);
   format = "setuptools";
 
   src = ../../.;
   sbomnix = import ../../default.nix { pkgs=pkgs; };
   repology_cli = import ../repology/repology_cli.nix { pkgs=pkgs; };
-  nix_visualize = import ../nixupdate/nix-visualize.nix { pkgs=pkgs; };
+  nix_visualize = import ./nix-visualize.nix { pkgs=pkgs; };
+  vulnxscan = import ../vulnxscan/vulnxscan.nix { pkgs=pkgs; };
   makeWrapperArgs = [
-    "--prefix PATH : ${pkgs.lib.makeBinPath [ sbomnix repology_cli nix_visualize ]}"
+    "--prefix PATH : ${pkgs.lib.makeBinPath [ sbomnix repology_cli nix_visualize vulnxscan ]}"
   ];
 
   propagatedBuildInputs = [ 
@@ -25,6 +26,7 @@ pythonPackages.buildPythonPackage rec {
 
   postInstall = ''
     install -vD scripts/nixupdate/nix_outdated.py $out/bin/nix_outdated.py
+    install -vD scripts/nixupdate/nix_secupdates.py $out/bin/nix_secupdates.py
   '';
 
   pythonImportsCheck = [ "sbomnix" ];

--- a/scripts/repology/repology_cli.nix
+++ b/scripts/repology/repology_cli.nix
@@ -30,6 +30,7 @@ pythonPackages.buildPythonPackage rec {
 
   postInstall = ''
     install -vD scripts/repology/repology_cli.py $out/bin/repology_cli.py
+    install -vD scripts/repology/repology_cve.py $out/bin/repology_cve.py
   '';
 
   pythonImportsCheck = [ "sbomnix" ];

--- a/scripts/repology/repology_cve.py
+++ b/scripts/repology/repology_cve.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=invalid-name abstract-method too-many-locals
+
+""" Command-line interface to query CVE info from repology.org """
+
+import logging
+import os
+import sys
+import re
+import urllib.parse
+from argparse import ArgumentParser, ArgumentTypeError
+from requests import Session
+from requests_cache import CacheMixin
+from requests_ratelimiter import LimiterMixin
+from bs4 import BeautifulSoup
+import numpy as np
+import pandas as pd
+from tabulate import tabulate
+from sbomnix.utils import (
+    setup_logging,
+    LOGGER_NAME,
+    LOG_SPAM,
+    df_to_csv_file,
+    parse_version,
+)
+
+###############################################################################
+
+_LOG = logging.getLogger(LOGGER_NAME)
+
+###############################################################################
+
+
+def _pkg_str(str_obj):
+    if isinstance(str_obj, str) and len(str_obj) > 0:
+        return str_obj
+    raise ArgumentTypeError("Value must be a non-empty string")
+
+
+def getargs():
+    """Parse command line arguments"""
+    desc = (
+        "Query repology.org for CVEs that impact package PKG_NAME version "
+        "PKG_VERSION."
+    )
+    epil = f"Example: ./{os.path.basename(__file__)} openssl 3.1.0"
+    parser = ArgumentParser(description=desc, epilog=epil)
+    helps = "Target package name"
+    parser.add_argument("PKG_NAME", help=helps, type=_pkg_str)
+    helps = "Target package version"
+    parser.add_argument("PKG_VERSION", help=helps, type=str)
+    helps = "Set the debug verbosity level between 0-2 (default: --verbose=1)"
+    parser.add_argument("--verbose", help=helps, type=int, default=1)
+    helps = "Path to output file (default: ./repology_cves.csv)"
+    parser.add_argument("--out", nargs="?", help=helps, default="repology_cves.csv")
+    return parser.parse_args()
+
+
+################################################################################
+
+
+class CachedLimiterSession(CacheMixin, LimiterMixin, Session):
+    """Session class with caching and rate-limiting"""
+
+    # See: https://requests-cache.readthedocs.io/en/stable/user_guide/compatibility.html
+
+
+def _parse_cve_resp(resp, pkg_name, pkg_version):
+    soup = BeautifulSoup(resp.text, "html.parser")
+    tables = soup.find_all("table")
+    if not tables:
+        _LOG.debug("Unexpected response: CVE table missing")
+        return pd.DataFrame()
+    cve_table = tables[0]
+    headers = {}
+    for idx, header in enumerate(cve_table.thead.find_all("th")):
+        headers[header.text] = idx
+    if not headers or "CVE ID" not in headers:
+        _LOG.fatal("Unexpected response")
+        sys.exit(1)
+    _LOG.log(LOG_SPAM, headers)
+    cve_table_rows = cve_table.tbody.find_all("tr")
+    cve_dict = {}
+    for row in cve_table_rows:
+        affected_versions = row.find_all("span", {"class": "version version-outdated"})
+        if not affected_versions:
+            continue
+        cols = row.find_all("td")
+        if not cols:
+            continue
+        cve_row = cols[headers["CVE ID"]]
+        _LOG.log(LOG_SPAM, "CVE: %s", cve_row)
+        ver_row = cols[headers["Affected version(s)"]]
+        _LOG.log(LOG_SPAM, "Versions: %s", ver_row)
+        # Repology might show that a package is affected, even thought the
+        # "Affected version(s)" indicates it isn't. Below, we try to manually
+        # check if pkg_version is included in the affected versions.
+        if not _is_affected(pkg_version, ver_row.text):
+            continue
+        cve_info = cve_row.text.strip().split("\n")
+        _LOG.debug("CVE info: %s", cve_info)
+        cve_dict.setdefault("package", []).append(pkg_name)
+        cve_dict.setdefault("version", []).append(pkg_version)
+        cve_dict.setdefault("cve", []).append(cve_info[0])
+    df = pd.DataFrame.from_dict(cve_dict)
+    df.replace(np.nan, "", regex=True, inplace=True)
+    df.drop_duplicates(keep="first", inplace=True)
+    return df
+
+
+def _is_affected(version, affected_ver_str):
+    """
+    Return True if version number is included in the repology affected version
+    string. Also returns true if parsing affected version string fails,
+    in order to avoid false negatives.
+    """
+    _LOG.log(LOG_SPAM, "Affected version(s): %s", affected_ver_str)
+    re_ver = re.compile(
+        r"^(?P<beg>[(\[])(?P<begver>[^,]*), *(?P<endver>[^)\]]*)(?P<end>[\])])"
+    )
+    match = re_ver.match(affected_ver_str)
+    if not match:
+        _LOG.debug("Unable to parse affected version string: '%s'", affected_ver_str)
+        return True
+    version_parsed = parse_version(version)
+    if not version_parsed:
+        _LOG.fatal("Unexpected local version string: %s", version)
+        sys.exit(1)
+    beg_ind = match.group("beg")
+    beg_ver_parsed = parse_version(match.group("begver"))
+    if not beg_ver_parsed:
+        return True
+    end_ind = match.group("end")
+    end_ver_parsed = parse_version(match.group("endver"))
+    if not end_ver_parsed:
+        return True
+    beg_affected = False
+    end_affected = False
+    if (version_parsed > beg_ver_parsed) or (
+        version_parsed == beg_ver_parsed and beg_ind == "["
+    ):
+        beg_affected = True
+    if (version_parsed < end_ver_parsed) or (
+        version_parsed == end_ver_parsed and end_ind == "]"
+    ):
+        end_affected = True
+    if beg_affected and end_affected:
+        return True
+    return False
+
+
+def _report(df):
+    if df.empty:
+        _LOG.warning("No matching vulnerabilities found")
+        sys.exit(0)
+    # Write the console report
+    table = tabulate(
+        df,
+        headers="keys",
+        tablefmt="orgtbl",
+        numalign="center",
+        showindex=False,
+    )
+    _LOG.info("Repology affected CVE(s)\n\n%s\n\n", table)
+
+
+def _query_cve(pkg_name, pkg_version):
+    session = CachedLimiterSession(per_second=1, expire_after=3600)
+    ua_product = "repology_cli/0"
+    ua_comment = "(https://github.com/tiiuae/sbomnix/tree/main/scripts/repology)"
+    headers = {"User-Agent": f"{ua_product} {ua_comment}"}
+    pkg = urllib.parse.quote(pkg_name)
+    ver = urllib.parse.quote(pkg_version)
+    query = f"https://repology.org/project/{pkg}/cves?version={ver}"
+    _LOG.info("GET: %s", query)
+    resp = session.get(query, headers=headers)
+    _LOG.debug("resp.status_code: %s", resp.status_code)
+    if resp.status_code == 404:
+        _LOG.fatal("Package '%s' not found", pkg_name)
+        sys.exit(1)
+    resp.raise_for_status()
+    return _parse_cve_resp(resp, pkg_name, pkg_version)
+
+
+################################################################################
+
+
+def main():
+    """main entry point"""
+    args = getargs()
+    setup_logging(args.verbose)
+    df = _query_cve(args.PKG_NAME, args.PKG_VERSION)
+    _report(df)
+    df_to_csv_file(df, args.out)
+
+
+################################################################################
+
+if __name__ == "__main__":
+    main()
+
+################################################################################

--- a/shell.nix
+++ b/shell.nix
@@ -9,18 +9,20 @@
 pkgs.mkShell rec {
   name = "sbomnix-dev-shell";
 
-  nix_outdated = import ./scripts/nixupdate/nix_outdated.nix { pkgs=pkgs; };
+  nixupdate = import ./scripts/nixupdate/nixupdate.nix { pkgs=pkgs; };
   nix_visualize = import ./scripts/nixupdate/nix-visualize.nix { pkgs=pkgs; };
   requests-ratelimiter = import ./scripts/repology/requests-ratelimiter.nix { pkgs=pkgs; };
   repology_cli = import ./scripts/repology/repology_cli.nix { pkgs=pkgs; };
   vulnix = import ./scripts/vulnxscan/vulnix.nix { nixpkgs=pkgs.path; pkgs=pkgs; };
+  vulnxscan = import ./scripts/vulnxscan/vulnxscan.nix { pkgs=pkgs; };
 
   buildInputs = [ 
-    nix_outdated
+    nixupdate
     nix_visualize
     requests-ratelimiter
     repology_cli
     vulnix
+    vulnxscan
     pkgs.coreutils
     pkgs.curl
     pkgs.gnugrep

--- a/shell.nix
+++ b/shell.nix
@@ -12,12 +12,14 @@ pkgs.mkShell rec {
   nix_outdated = import ./scripts/nixupdate/nix_outdated.nix { pkgs=pkgs; };
   nix_visualize = import ./scripts/nixupdate/nix-visualize.nix { pkgs=pkgs; };
   requests-ratelimiter = import ./scripts/repology/requests-ratelimiter.nix { pkgs=pkgs; };
+  repology_cli = import ./scripts/repology/repology_cli.nix { pkgs=pkgs; };
   vulnix = import ./scripts/vulnxscan/vulnix.nix { nixpkgs=pkgs.path; pkgs=pkgs; };
 
   buildInputs = [ 
     nix_outdated
     nix_visualize
     requests-ratelimiter
+    repology_cli
     vulnix
     pkgs.coreutils
     pkgs.curl

--- a/tests/test_sbomnix.py
+++ b/tests/test_sbomnix.py
@@ -528,6 +528,33 @@ def test_nix_outdated_result():
 ################################################################################
 
 
+def test_nix_secupdate_help_flake():
+    """
+    Test nix_secupdates command line argument: '-h' running nix_secupdates as flake
+    """
+    cmd = ["nix", "run", f"{REPOROOT}#nix_secupdates", "--", "-h"]
+    assert subprocess.run(cmd, check=True).returncode == 0
+
+
+@pytest.mark.skip_in_ci
+def test_nix_secupdate_result():
+    """Test nix_secupdate with TEST_NIX_RESULT as input"""
+    out_path_nix_outdated = TEST_WORK_DIR / "nix_secupdates.csv"
+    cmd = [
+        "nix",
+        "run",
+        f"{REPOROOT}#nix_secupdates",
+        "--",
+        "--out",
+        out_path_nix_outdated.as_posix(),
+        TEST_NIX_RESULT,
+    ]
+    assert subprocess.run(cmd, check=True).returncode == 0
+
+
+################################################################################
+
+
 def validate_json(file_path, schema_path):
     """Validate json file matches schema"""
     with open(file_path, encoding="utf-8") as json_file, open(


### PR DESCRIPTION
nix_secupdates.py: initial version
    
- Add nix_secupdates.py script that demonstrates finding potential security updates for nix dependencies. See more details in the [README.md](https://github.com/tiiuae/sbomnix/blob/057ea8b1e0f20982609789778c09efb5d0587279/scripts/nixupdate/README.md#nix_secupdates) section _nix_secupdates_.
- Add repology_cve.py for querying CVEs that impact given package and version. This script is needed by nix_secupdates.py.
- Add support for querying also buildtime packages with nix_outdated.py.
- Import vulnxscan in shell.nix.
- Add more common functions to utils.py.
- Update relevant README.md.