### PR TITLE
Make `flake.nix` support multiple systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,60 +8,70 @@
 
   outputs = { self, nixpkgs }:
     let
-      pkgs = import nixpkgs { system = "x86_64-linux"; };
-      vulnxscan = import ./scripts/vulnxscan/vulnxscan.nix { pkgs = pkgs; };
-      repology_cli = import ./scripts/repology/repology_cli.nix { pkgs = pkgs; };
-      nixupdate = import ./scripts/nixupdate/nixupdate.nix { pkgs = pkgs; };
-      sbomnix = import ./default.nix { pkgs = pkgs; };
-      sbomnix-shell = import ./shell.nix { pkgs = pkgs; };
-    in rec {
-      
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      # forEachSystem [ "x86_64-linux" ] { example = true; } -> { x86_64-linux.example = true }
+      forEachSystem = nixpkgs.lib.genAttrs systems;
+      # Imports a module expecting a system to be passed in
+      importExpectingSystem = module: system: import module {
+        pkgs = import nixpkgs { inherit system; };
+      };
+      vulnxscan = importExpectingSystem ./scripts/vulnxscan/vulnxscan.nix;
+      repology_cli = importExpectingSystem ./scripts/repology/repology_cli.nix;
+      nixupdate = importExpectingSystem ./scripts/nixupdate/nixupdate.nix;
+      sbomnix = importExpectingSystem ./default.nix;
+      sbomnix-shell = importExpectingSystem ./shell.nix;
+    in
+    {
       # nix package
-      packages.x86_64-linux = {
-        inherit repology_cli;
-        inherit nixupdate;
-        inherit vulnxscan;
-        inherit sbomnix;
-        default = sbomnix;
-      };
+      packages = forEachSystem (system: {
+        repology_cli = repology_cli system;
+        nixupdate = nixupdate system;
+        vulnxscan = vulnxscan system;
+        sbomnix = sbomnix system;
+        default = sbomnix system;
+      });
 
-      # nix run .#sbomnix
-      apps.x86_64-linux.sbomnix = {
-        type = "app";
-        program = "${self.packages.x86_64-linux.sbomnix}/bin/sbomnix";
-      };
+      apps = forEachSystem (system: {
+        # nix run .#sbomnix
+        sbomnix = {
+          type = "app";
+          program = "${self.packages.${system}.sbomnix}/bin/sbomnix";
+        };
 
-      # nix run .#nixgraph
-      apps.x86_64-linux.nixgraph = {
-        type = "app";
-        program = "${self.packages.x86_64-linux.sbomnix}/bin/nixgraph";
-      };
+        # nix run .#nixgraph
+        nixgraph = {
+          type = "app";
+          program = "${self.packages.${system}.sbomnix}/bin/nixgraph";
+        };
 
-      # nix run .#vulnxscan
-      apps.x86_64-linux.vulnxscan = {
-        type = "app";
-        program = "${self.packages.x86_64-linux.vulnxscan}/bin/vulnxscan.py";
-      };
+        # nix run .#vulnxscan
+        vulnxscan = {
+          type = "app";
+          program = "${self.packages.${system}.vulnxscan}/bin/vulnxscan.py";
+        };
 
-      # nix run .#repology_cli
-      apps.x86_64-linux.repology_cli = {
-        type = "app";
-        program = "${self.packages.x86_64-linux.repology_cli}/bin/repology_cli.py";
-      };
+        # nix run .#repology_cli
+        repology_cli = {
+          type = "app";
+          program = "${self.packages.${system}.repology_cli}/bin/repology_cli.py";
+        };
 
-      # nix run .#nix_outdated
-      apps.x86_64-linux.nix_outdated= {
-        type = "app";
-        program = "${self.packages.x86_64-linux.nixupdate}/bin/nix_outdated.py";
-      };
+        # nix run .#nix_outdated
+        nix_outdated = {
+          type = "app";
+          program = "${self.packages.${system}.nixupdate}/bin/nix_outdated.py";
+        };
 
-      # nix run .#nix_secupdates
-      apps.x86_64-linux.nix_secupdates = {
-        type = "app";
-        program = "${self.packages.x86_64-linux.nixupdate}/bin/nix_secupdates.py";
-      };
+        # nix run .#nix_secupdates
+        nix_secupdates = {
+          type = "app";
+          program = "${self.packages.${system}.nixupdate}/bin/nix_secupdates.py";
+        };
+      });
 
       # nix develop
-      devShells.x86_64-linux.default = sbomnix-shell;
+      devShells = forEachSystem (system: {
+        default = sbomnix-shell system;
+      });
     };
 }


### PR DESCRIPTION
This is an exciting project, and I cannot wait to see what comes of it.

This PR adjusts `flake.nix` to add outputs for linux `aarch64`, and should make it trivial to add more platforms in the future. Supporting multiple platforms should not complicate development unless running into the dreaded [Import From Derivation](https://nixos.wiki/wiki/Import_From_Derivation).

I have confirmed that tests pass on both `x86_64-linux` and `aarch64-linux`.

I also attempted to get `aarch64-darwin` to work, however it currently fails on `test_nixgraph_csv_graph_inverse` for some reason.