### PR TITLE
vulnxscan: identify patched vulnerabilities

### DIFF
--- a/sbomnix/sbomdb.py
+++ b/sbomnix/sbomdb.py
@@ -214,9 +214,9 @@ class SbomDb:
                 spdx["relationships"].append(relation)
         self._write_json(spdx_path, spdx, printinfo)
 
-    def to_csv(self, csv_path):
+    def to_csv(self, csv_path, loglevel=logging.INFO):
         """Export sbomdb to csv file"""
-        df_to_csv_file(self.df_sbomdb, csv_path)
+        df_to_csv_file(self.df_sbomdb, csv_path, loglevel)
 
 
 ################################################################################

--- a/sbomnix/utils.py
+++ b/sbomnix/utils.py
@@ -25,12 +25,12 @@ LOG_SPAM = logging.DEBUG - 1
 ###############################################################################
 
 
-def df_to_csv_file(df, name):
+def df_to_csv_file(df, name, loglevel=logging.INFO):
     """Write dataframe to csv file"""
     df.to_csv(
         path_or_buf=name, quoting=csv.QUOTE_ALL, sep=",", index=False, encoding="utf-8"
     )
-    logging.getLogger(LOGGER_NAME).info("Wrote: %s", name)
+    logging.getLogger(LOGGER_NAME).log(loglevel, "Wrote: %s", name)
 
 
 def df_from_csv_file(name):


### PR DESCRIPTION
Identify patched vulnerabilities based on 'patches'-field in nix derivation. Matching patches is based on CVE or other vulnerability identifiers in the patch file name. It's a coarse heuristic, but certainly better than nothing.