### PR TITLE
nix_secupdates.py: add nixpkgs pr search

### DIFF
--- a/sbomnix/utils.py
+++ b/sbomnix/utils.py
@@ -231,6 +231,8 @@ def nix_to_repology_pkg_name(nix_pkg_name):
         nix_pkg_name = f"{matches[0]}:{matches[1]}"
     if nix_pkg_name == "python3":
         nix_pkg_name = "python"
+    if nix_pkg_name == "libtiff":
+        nix_pkg_name = "tiff"
     return nix_pkg_name
 
 

--- a/scripts/nixupdate/nixupdate.nix
+++ b/scripts/nixupdate/nixupdate.nix
@@ -20,8 +20,13 @@ pythonPackages.buildPythonPackage rec {
     "--prefix PATH : ${pkgs.lib.makeBinPath [ sbomnix repology_cli nix_visualize vulnxscan ]}"
   ];
 
+  requests-ratelimiter = import ../repology/requests-ratelimiter.nix { pkgs=pkgs; };
+
   propagatedBuildInputs = [ 
+    requests-ratelimiter
     sbomnix
+    pythonPackages.requests
+    pythonPackages.requests-cache
   ];
 
   postInstall = ''


### PR DESCRIPTION
Add '--pr' command-line option to search nixpkgs github for PRs that might include more information concerning the (potentially ongoing) fix for the vulnerability. Adds a URL to best matching PR (if any) to the output table. The PR search takes significant time due to github API rate limits, which is why '--pr' is not enabled by default.