### PR TITLE
sbomnix: Force-realise runtime dependency paths

### DIFF
--- a/sbomnix/main.py
+++ b/sbomnix/main.py
@@ -50,7 +50,13 @@ def getargs():
     )
     parser.add_argument("--meta", nargs="?", help=helps, default=None)
 
-    helps = "Set the type of dependencies included to the SBOM (default: runtime)"
+    helps = (
+        "Set the type of dependencies included to the SBOM (default: runtime). "
+        "Note: generating 'runtime' SBOM requires realising (building) the "
+        "output paths of the target derivation. When 'runtime' SBOM is "
+        "requested, sbomnix will realise the derivation unless its already "
+        "realised. See `nix-store --realise --help` for more info."
+    )
     types = ["runtime", "buildtime", "both"]
     parser.add_argument("--type", choices=types, help=helps, default="runtime")
 

--- a/sbomnix/nix.py
+++ b/sbomnix/nix.py
@@ -80,7 +80,7 @@ class Store:
             self._add_cached(nixpath, drv=drv_obj)
 
     def add_path(self, nixpath):
-        """Add the the derivation referenced by a store path (nixpath)"""
+        """Add the derivation referenced by a store path (nixpath)"""
         _LOG.debug(nixpath)
         if self._is_cached(nixpath):
             _LOG.debug("Skipping redundant path '%s'", nixpath)


### PR DESCRIPTION
This PR improves the way sbomnix behaves in case the target derivation isn't realised and runtime dependencies are requested. The issue is described in https://github.com/tiiuae/sbomnix/issues/63.

In essence, this change adds the `--force-realise` option for nix-store query when runtime dependencies are requested.