### PR TITLE
sbomnix: Add --depth command-line option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ black: clean ## Reformat with black
 	$(call target_success,$@)
 
 style: clean ## Check with pycodestyle (pep8)
-	pycodestyle --max-line-length 90 --exclude='venv/' .
+	pycodestyle --max-line-length 90 $(PYTHON_TARGETS)
 	$(call target_success,$@)
 
 pylint: clean ## Check with pylint

--- a/nixgraph/main.py
+++ b/nixgraph/main.py
@@ -11,21 +11,13 @@ import logging
 import pathlib
 import sys
 from nixgraph.graph import NixDependencies
-from sbomnix.utils import setup_logging, get_py_pkg_version, LOGGER_NAME
+from sbomnix.utils import setup_logging, get_py_pkg_version, check_positive, LOGGER_NAME
 
 ###############################################################################
 
 _LOG = logging.getLogger(LOGGER_NAME)
 
 ###############################################################################
-
-
-def check_positive(val):
-    """Raise ArgumentTypeError if val is not a positive integer"""
-    intval = int(val)
-    if intval <= 0:
-        raise argparse.ArgumentTypeError(f"{val} is not a positive integer")
-    return intval
 
 
 def getargs():

--- a/sbomnix/utils.py
+++ b/sbomnix/utils.py
@@ -6,6 +6,7 @@
 
 """ sbomnix utils """
 
+import argparse
 import re
 import sys
 import csv
@@ -234,6 +235,14 @@ def nix_to_repology_pkg_name(nix_pkg_name):
     if nix_pkg_name == "libtiff":
         nix_pkg_name = "tiff"
     return nix_pkg_name
+
+
+def check_positive(val):
+    """Raise ArgumentTypeError if val is not a positive integer"""
+    intval = int(val)
+    if intval <= 0:
+        raise argparse.ArgumentTypeError(f"{val} is not a positive integer")
+    return intval
 
 
 ################################################################################


### PR DESCRIPTION
Add `--depth` option to sbomnix to set the depth of the included dependencies. 

 As an example, `--depth=1` indicates the SBOM should include only the direct dependencies. With `--depth=2`, the output SBOM includes the direct dependencies and the first level of transitive dependencies. By default, when `--depth` is not specified, the output SBOM includes all dependencies all the way to the root of the dependency tree.
 
 Implements: https://github.com/tiiuae/sbomnix/issues/70