### PR TITLE
vulnxscan: Add cve-bin-tool scanner

### DIFF
--- a/scripts/vulnxscan/cve-bin-tool.nix
+++ b/scripts/vulnxscan/cve-bin-tool.nix
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{ nixpkgs ? <nixpkgs>
+, pkgs ? import nixpkgs {}
+, pythonPackages ? pkgs.python3Packages
+, lib ? pkgs.lib
+}:
+
+let
+  lib4sbom = pythonPackages.buildPythonPackage rec {
+    version = "0.3.1";
+    pname="lib4sbom";
+    format = "setuptools";
+    src = pkgs.fetchFromGitHub {
+      owner = "anthonyharrison";
+      repo = "lib4sbom";
+      rev = "v${version}";
+      hash = "sha256-RfJ7V4VRYlceGl4xlTMmm2kHNtxNryb+JHvZQakkM7w=";
+    };
+    propagatedBuildInputs = with pythonPackages; [
+      pyyaml
+      semantic-version
+    ];
+    doCheck = false;
+  };
+in
+pythonPackages.buildPythonPackage rec {
+  version = "3.2.1";
+  pname = "cve-bin-tool";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "henrirosten";
+    repo = pname;
+    rev = "7b5d0160032e067fcea69194c5c2e29ba4c6ae4d";
+    hash = "sha256-y7cQwV8xblcZ13QeRe0IaeXX7dJk5EmvAxjq2RzyEXw=";
+  };
+  propagatedBuildInputs = with pythonPackages; [
+    pkgs.google-cloud-sdk
+    lib4sbom
+    python-gnupg
+    jsonschema
+    plotly
+    beautifulsoup4
+    pyyaml
+    isort
+    py
+    jinja2
+    rpmfile
+    reportlab
+    zstandard
+    rich
+    aiohttp
+    toml
+    distro
+    aiodns
+    brotlipy
+    faust-cchardet
+    pillow
+    setuptools
+    xmlschema
+    cvss
+    packaging
+  ];
+  doCheck = false;
+}

--- a/scripts/vulnxscan/vulnxscan.nix
+++ b/scripts/vulnxscan/vulnxscan.nix
@@ -14,8 +14,9 @@ pythonPackages.buildPythonPackage rec {
 
   src = ../../.;
   sbomnix = import ../../default.nix { pkgs=pkgs; };
+  cve-bin-tool = import ./cve-bin-tool.nix { pkgs=pkgs; };
   makeWrapperArgs = [
-    "--prefix PATH : ${pkgs.lib.makeBinPath [ sbomnix pkgs.grype pkgs.nix vulnix ]}"
+    "--prefix PATH : ${pkgs.lib.makeBinPath [ sbomnix pkgs.grype pkgs.nix vulnix cve-bin-tool ]}"
   ];
 
   propagatedBuildInputs = [ 

--- a/shell.nix
+++ b/shell.nix
@@ -9,6 +9,7 @@
 pkgs.mkShell rec {
   name = "sbomnix-dev-shell";
 
+  cve-bin-tool = import ./scripts/vulnxscan/cve-bin-tool.nix { pkgs=pkgs; };
   nixupdate = import ./scripts/nixupdate/nixupdate.nix { pkgs=pkgs; };
   nix_visualize = import ./scripts/nixupdate/nix-visualize.nix { pkgs=pkgs; };
   requests-ratelimiter = import ./scripts/repology/requests-ratelimiter.nix { pkgs=pkgs; };
@@ -17,6 +18,7 @@ pkgs.mkShell rec {
   vulnxscan = import ./scripts/vulnxscan/vulnxscan.nix { pkgs=pkgs; };
 
   buildInputs = [ 
+    cve-bin-tool
     nixupdate
     nix_visualize
     requests-ratelimiter


### PR DESCRIPTION
Adds [cve-bin-tool](https://github.com/intel/cve-bin-tool/tree/main) scanner to vulnxscan.

Why do we use cve-bin-tool [fork](https://github.com/henrirosten/cve-bin-tool) instead of the [upstream](https://github.com/intel/cve-bin-tool/tree/main) or the [version in nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/tools/security/cve-bin-tool/default.nix)?
The main reason is, both the upstream and the nixpkgs versions require an older version of [python packaging](https://pypi.org/project/packaging/). This project (vulnxscan) also requires packaging, but it needs a newer version. This results a conflict in python dependencies. The cve-bin-tool [fork](ttps://github.com/henrirosten/cve-bin-tool) we are using in this PR attempts to [resolve](https://github.com/intel/cve-bin-tool/commit/7b5d0160032e067fcea69194c5c2e29ba4c6ae4d) the upstream cve-bin-tool python dependencies issues so that newer version of packaging can be used in cve-bin-tool. As soon as the [issue](https://github.com/intel/cve-bin-tool/pull/2436) is properly resoved upstream and in nixpkgs, we should change vulnxscan to also start using the cve-bin-tool version from nixpkgs.