### PR TITLE
gha: Release action needs write permission

### DIFF
--- a/.github/workflows/release_sbomnix.yml
+++ b/.github/workflows/release_sbomnix.yml
@@ -14,6 +14,8 @@ jobs:
   build: 
     name: Upload Release Asset
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v22


### PR DESCRIPTION
Add [granular write permission](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) required by [release action](https://github.com/svenstaro/upload-release-action#permissions).