### PR TITLE
Allow running sbomnix without realising out paths

### DIFF
--- a/nixgraph/main.py
+++ b/nixgraph/main.py
@@ -8,10 +8,8 @@
 
 import argparse
 import pathlib
-import sys
 from nixgraph.graph import NixDependencies
 from sbomnix.utils import (
-    LOG,
     set_log_verbosity,
     get_py_pkg_version,
     check_positive,
@@ -83,11 +81,9 @@ def main():
     """main entry point"""
     args = getargs()
     set_log_verbosity(args.verbose)
-    if not args.NIX_PATH.exists():
-        LOG.fatal("Invalid path: '%s'", args.NIX_PATH)
-        sys.exit(1)
     target_path = args.NIX_PATH.resolve().as_posix()
-    exit_unless_nix_artifact(target_path)
+    runtime = args.buildtime is False
+    exit_unless_nix_artifact(target_path, force_realise=runtime)
     deps = NixDependencies(target_path, args.buildtime)
     deps.graph(args)
 

--- a/sbomnix/main.py
+++ b/sbomnix/main.py
@@ -8,7 +8,6 @@
 
 import argparse
 import pathlib
-import sys
 from sbomnix.sbomdb import SbomDb
 from sbomnix.utils import (
     LOG,
@@ -81,19 +80,15 @@ def main():
     """main entry point"""
     args = getargs()
     set_log_verbosity(args.verbose)
-    if not args.NIX_PATH.exists():
-        LOG.fatal("Invalid path: '%s'", args.NIX_PATH)
-        sys.exit(1)
     target_path = args.NIX_PATH.resolve().as_posix()
-    exit_unless_nix_artifact(target_path)
+    runtime = args.type in ("runtime", "both")
+    buildtime = args.type in ("buildtime", "both")
+    exit_unless_nix_artifact(target_path, force_realise=runtime)
     if not args.meta:
         LOG.warning(
             "Command line argument '--meta' missing: SBOM will not include "
             "license information (see '--help' for more details)"
         )
-    runtime = args.type in ("runtime", "both")
-    buildtime = args.type in ("buildtime", "both")
-
     sbomdb = SbomDb(target_path, runtime, buildtime, args.meta, args.depth)
     if args.cdx:
         sbomdb.to_cdx(args.cdx)

--- a/sbomnix/nix.py
+++ b/sbomnix/nix.py
@@ -97,11 +97,6 @@ def find_deriver(path):
     LOG.debug(path)
     if path.endswith(".drv"):
         return path
-    # Deriver from QueryPathInfo
-    qpi_deriver = exec_cmd(["nix-store", "-qd", path]).strip()
-    LOG.debug("qpi_deriver: %s", qpi_deriver)
-    if qpi_deriver and qpi_deriver != "unknown-deriver" and os.path.exists(qpi_deriver):
-        return qpi_deriver
     # Deriver from QueryValidDerivers
     ret = exec_cmd(["nix", "show-derivation", path], raise_on_error=False)
     if not ret:
@@ -115,6 +110,11 @@ def find_deriver(path):
     LOG.debug("qvd_deriver: %s", qvd_deriver)
     if qvd_deriver and os.path.exists(qvd_deriver):
         return qvd_deriver
+    # Deriver from QueryPathInfo
+    qpi_deriver = exec_cmd(["nix-store", "-qd", path]).strip()
+    LOG.debug("qpi_deriver: %s", qpi_deriver)
+    if qpi_deriver and qpi_deriver != "unknown-deriver" and os.path.exists(qpi_deriver):
+        return qpi_deriver
 
     error = ""
     if qpi_deriver and qpi_deriver != "unknown-deriver":

--- a/sbomnix/utils.py
+++ b/sbomnix/utils.py
@@ -126,9 +126,17 @@ def exec_cmd(cmd, raise_on_error=True, return_error=False):
         return None
 
 
-def exit_unless_nix_artifact(path):
-    """Exit with error if `path` is not a nix artifact"""
-    cmd = ["nix-store", "-q", path]
+def exit_unless_nix_artifact(path, force_realise=False):
+    """
+    Exit with error if `path` is not a nix artifact. If `force_realize` is True,
+    run the nix-store-query command with `--force-realize` realising the `path`
+    argument before running query.
+    """
+    LOG.debug("force_realize: %s", force_realise)
+    if force_realise:
+        cmd = ["nix-store", "-qf", path]
+    else:
+        cmd = ["nix-store", "-q", path]
     try:
         exec_cmd(cmd)
         return

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -35,7 +35,10 @@ else
 fi
 # Remove duplicates from the PYTHONPATH, preserving order
 PYTHONPATH=$(remove_dups "$PYTHONPATH")
-echo "export PYTHONPATH=$PYTHONPATH"
 export PYTHONPATH="$PYTHONPATH"
+# Add all subdirs of REPOROOTDIR/scripts/ to PATH
+for d in "$REPOROOTDIR/scripts/"*; do if [ -d "$d" ]; then PATH="$d:$PATH"; fi; done
+PATH=$(remove_dups "$PATH")
+export PATH="$PATH"
 
 ################################################################################

--- a/scripts/nixupdate/nix_secupdates.py
+++ b/scripts/nixupdate/nix_secupdates.py
@@ -61,10 +61,7 @@ def getargs():
         "not enabled by default."
     )
     parser.add_argument("--pr", help=helps, action="store_true")
-    helps = (
-        "Include target's buildtime dependencies to the scan. "
-        "By default, only runtime dependencies are considered."
-    )
+    helps = "Scan target buildtime instead of runtime dependencies."
     parser.add_argument("--buildtime", help=helps, action="store_true")
     helps = "Path to output file (default: ./nix_secupdates.csv)"
     parser.add_argument("--out", nargs="?", help=helps, default="nix_secupdates.csv")
@@ -400,7 +397,11 @@ def main():
     """main entry point"""
     args = getargs()
     set_log_verbosity(args.verbose)
-    exit_unless_nix_artifact(args.NIXPATH.resolve().as_posix())
+    runtime = args.buildtime is False
+    nix_path = args.NIXPATH.resolve().as_posix()
+    dtype = "runtime" if runtime else "buildtime"
+    LOG.info("Checking %s dependencies referenced by '%s'", dtype, nix_path)
+    exit_unless_nix_artifact(nix_path, runtime)
     df = _find_secupdates(args)
     _report(df)
     df_to_csv_file(df, args.out)


### PR DESCRIPTION
Allow running sbomnix, nixgraph, vulnxscan, nix_outdated, and nix_secupdates without realising the target output if `--buildtime` was requested.

This change also adds another fix (on top of 8de1be529f500332d259f32c10064b59f977e9be) to allow installing sbomnix tooling in nix development shell in editable mode.