### PR TITLE
fix: repology command references in vulnxscan

### DIFF
--- a/scripts/vulnxscan/vulnxscan.py
+++ b/scripts/vulnxscan/vulnxscan.py
@@ -557,7 +557,7 @@ def _pkg_is_vulnerable(repo_pkg_name, pkg_version, cve_id=None):
         suffix = ".csv"
         with NamedTemporaryFile(delete=True, prefix=prefix, suffix=suffix) as f:
             args = f"{repo_pkg_name} {pkg_version}"
-            cmd = f"repology_cve.py --out={f.name} {args}"
+            cmd = f"repology_cve --out={f.name} {args}"
             exec_cmd(cmd.split(), raise_on_error=False)
             df = df_from_csv_file(f.name, exit_on_error=False)
             if df is None:

--- a/scripts/vulnxscan/vulnxscan.py
+++ b/scripts/vulnxscan/vulnxscan.py
@@ -429,7 +429,7 @@ def _run_repology_cli(pname, match_type="--pkg_exact"):
             status = "--re_status=outdated|newest|devel|unique"
             out = f"--out={f.name}"
             search = f"{match_type}={pname}"
-            cmd = f"repology_cli.py {repo} {status} {search} {out} "
+            cmd = f"repology_cli {repo} {status} {search} {out} "
             ret = exec_cmd(cmd.split(), raise_on_error=False, return_error=True)
             if ret and ret.stderr and "No matching packages" in ret.stderr:
                 return None


### PR DESCRIPTION
- When invoking `repology_cli` as a command the `.py` extension is no longer required.
- When invoking `repology_cve` as a command the `.py` extension is no longer required.