### PR TITLE
sbomnix: Remove command-line argument: --type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,12 @@ release-asset: clean ## Build release asset
 	nix-shell -p nix-info --run "nix-info -m"
 	nix-env -qa --meta --json -f $(shell nix-shell -p nix-info --run "nix-info -m" | grep "nixpkgs: " | cut -d'`' -f2) '.*' >meta.json
 	mkdir -p build/
-	nix run .#sbomnix -- result --type=runtime \
+	nix run .#sbomnix -- result \
 		--meta=./meta.json \
         --cdx=./build/sbom.runtime.cdx.json \
         --spdx=./build/sbom.runtime.spdx.json \
         --csv=./build/sbom.runtime.csv
-	nix run .#sbomnix -- result --type=buildtime \
+	nix run .#sbomnix -- result --buildtime \
 		--meta=./meta.json \
         --cdx=./build/sbom.buildtime.cdx.json \
         --spdx=./build/sbom.buildtime.spdx.json \

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ For reference, following is a link to graph from an example hello-world C progra
 <img src="doc/img/c_hello_world_runtime.svg" width="700">
 
 
+By default, all the tools in this repository assume runtime dependencies. This means, for instance, that unless specified otherwise, `sbomnix` will output an SBOM including the target runtime dependencies, `nixgraph` outputs runtime dependency graph, and `vulnxscan` and `nix_outdated` scan runtime dependencies. Since Nix needs to build the target output to determine the runtime dependencies, all the tools in this repository will also build (force-realise) the target output as part of each tool's invocation when determining the runtime dependencies. All the mentioned tools in this repository also support working with buildtime dependencies instead of runtime dependencies with the help of `--buildtime` command line argument. As mentioned earlier, generating buildtime dependencies in Nix does not require building the target. Similarly, when `--buildtime` is specified, the tools in this repository do not need to be build the given target.
+
+
 ## Usage Examples
 The usage examples work for both the built package, as well as inside the devshell.
 
@@ -126,7 +129,7 @@ $ nix eval -f '<nixpkgs>' 'wget.outPath'
 
 #### Generate SBOM Based on Derivation File or Out-path
 By default `sbomnix` scans the given target and generates an SBOM including the runtime dependencies.
-Keep in mind that determining the target runtime dependencies requires building the target.
+Notice: determining the target runtime dependencies in Nix requires building the target.
 ```bash
 $ sbomnix /nix/store/8nbv1drmvh588pwiwsxa47iprzlgwx6j-wget-1.21.3
 ...
@@ -147,11 +150,11 @@ $ sbomnix /nix/store/8nbv1drmvh588pwiwsxa47iprzlgwx6j-wget-1.21.3 --meta meta.js
 ```
 
 #### Generate SBOM Including Buildtime Dependencies
-By default `sbomnix` scans the given target for runtime dependencies. You can tell sbomnix to determine the buildtime dependencies using the `--type` argument. 
-Acceptable values for `--type` are `runtime, buildtime, both`. Below example generates SBOM including buildtime dependencies.
+By default `sbomnix` scans the given target for runtime dependencies. You can tell sbomnix to determine the buildtime dependencies using the `--buildtime` argument. 
+Below example generates SBOM including buildtime dependencies.
 Notice: as opposed to runtime dependencies, determining the buildtime dependencies does not require building the target.
 ```bash
-$ sbomnix /nix/store/8nbv1drmvh588pwiwsxa47iprzlgwx6j-wget-1.21.3 --meta meta.json --type=buildtime
+$ sbomnix /nix/store/8nbv1drmvh588pwiwsxa47iprzlgwx6j-wget-1.21.3 --meta meta.json --buildtime
 ```
 #### Generate SBOM Based on Result Symlink
 `sbomnix` can be used with output paths too (e.g. anything which produces a result symlink):

--- a/src/nixupdate/nix_outdated.py
+++ b/src/nixupdate/nix_outdated.py
@@ -75,9 +75,9 @@ def getargs():
 ################################################################################
 
 
-def _generate_sbom(target_path, runtime=True, buildtime=False):
+def _generate_sbom(target_path, buildtime=False):
     LOG.info("Generating SBOM for target '%s'", target_path)
-    sbomdb = SbomDb(target_path, runtime, buildtime, meta_path=None)
+    sbomdb = SbomDb(target_path, buildtime, meta_path=None)
     prefix = "nixdeps_"
     suffix = ".cdx.json"
     with NamedTemporaryFile(delete=False, prefix=prefix, suffix=suffix) as f:
@@ -121,7 +121,7 @@ def _nix_visualize_csv_to_df(csvpath):
         # Followed by the version string
         r"(\d[-_.0-9pf]*g?b?(?:pre[0-9])*(?:\+git[0-9]*)?)"
         # Optionally followed by any of the following strings
-        r"(?:-lib|-bin|-env|-man|-su|-dev|-doc|-info|-nc|-host|-p[0-9]+|)"
+        r"(?:-lib|-bin|-env|-man|-su|-dev|-doc|-info|-nc|-host|-p[0-9]+|\.drv|)"
         # Followed by the end of line
         r"$"
     )
@@ -256,7 +256,7 @@ def main():
     LOG.info("Checking %s dependencies referenced by '%s'", dtype, target_path_abs)
     exit_unless_nix_artifact(target_path_abs, force_realise=runtime)
 
-    sbom_path = _generate_sbom(target_path_abs, runtime, args.buildtime)
+    sbom_path = _generate_sbom(target_path_abs, args.buildtime)
     LOG.debug("Using SBOM '%s'", sbom_path)
 
     df_repology = _run_repology_cli(sbom_path)
@@ -276,6 +276,8 @@ def main():
         LOG.info("Not running nix-visualize due to '--buildtime' argument")
         df_nix_visualize = None
 
+    df_log(df_repology, logging.DEBUG)
+    df_log(df_nix_visualize, logging.DEBUG)
     df_report = _generate_report_df(df_nix_visualize, df_repology)
     _report(df_report, args)
 

--- a/src/sbomnix/main.py
+++ b/src/sbomnix/main.py
@@ -40,15 +40,8 @@ def getargs():
         "to the output of this script (default: None)"
     )
     parser.add_argument("--meta", nargs="?", help=helps, default=None)
-    helps = (
-        "Set the type of dependencies included to the SBOM (default: runtime). "
-        "Note: generating 'runtime' SBOM requires realising (building) the "
-        "output paths of the target derivation. When 'runtime' SBOM is "
-        "requested, sbomnix will realise the target derivation unless its already "
-        "realised. See `nix-store --realise --help` for more info."
-    )
-    types = ["runtime", "buildtime", "both"]
-    parser.add_argument("--type", choices=types, help=helps, default="runtime")
+    helps = "Scan buildtime dependencies instead of runtime dependencies"
+    parser.add_argument("--buildtime", help=helps, action="store_true")
     helps = (
         "Set the depth of the included dependencies. As an example, --depth=1 "
         "indicates the SBOM should include only the NIX_PATH direct dependencies. "
@@ -81,15 +74,14 @@ def main():
     args = getargs()
     set_log_verbosity(args.verbose)
     target_path = args.NIX_PATH.resolve().as_posix()
-    runtime = args.type in ("runtime", "both")
-    buildtime = args.type in ("buildtime", "both")
+    runtime = args.buildtime is False
     exit_unless_nix_artifact(target_path, force_realise=runtime)
     if not args.meta:
         LOG.warning(
             "Command line argument '--meta' missing: SBOM will not include "
             "license information (see '--help' for more details)"
         )
-    sbomdb = SbomDb(target_path, runtime, buildtime, args.meta, args.depth)
+    sbomdb = SbomDb(target_path, args.buildtime, args.meta, args.depth)
     if args.cdx:
         sbomdb.to_cdx(args.cdx)
     if args.spdx:

--- a/src/vulnxscan/vulnxscan_cli.py
+++ b/src/vulnxscan/vulnxscan_cli.py
@@ -734,9 +734,9 @@ def _is_patched(row):
     return False
 
 
-def _generate_sbom(target_path, runtime=True, buildtime=False):
+def _generate_sbom(target_path, buildtime=False):
     LOG.info("Generating SBOM for target '%s'", target_path)
-    sbomdb = SbomDb(target_path, runtime, buildtime, meta_path=None)
+    sbomdb = SbomDb(target_path, buildtime, meta_path=None)
     prefix = "vulnxscan_"
     cdx_suffix = ".json"
     csv_suffix = ".csv"
@@ -884,9 +884,7 @@ def main():
     else:
         runtime = args.buildtime is False
         exit_unless_nix_artifact(target_path_abs, force_realise=runtime)
-        sbom_cdx_path, sbom_csv_path = _generate_sbom(
-            target_path_abs, runtime, args.buildtime
-        )
+        sbom_cdx_path, sbom_csv_path = _generate_sbom(target_path_abs, args.buildtime)
         LOG.debug("Using cdx SBOM '%s'", sbom_cdx_path)
         LOG.debug("Using csv SBOM '%s'", sbom_csv_path)
         scanner.scan_vulnix(target_path_abs, args.buildtime)

--- a/tests/compare_deps.py
+++ b/tests/compare_deps.py
@@ -157,7 +157,7 @@ def compare_dependencies(df_sbom, df_graph, sbom_type, graph_type):
     df_sbom = df_sbom.astype(str)
 
     if (graph_type == "runtime" and sbom_type != "runtime_only") or (
-        graph_type == "buildtime" and sbom_type != "buildtime_only"
+        graph_type == "buildtime" and sbom_type == "runtime_only"
     ):
         LOG.fatal("Unable to compare: graph='%s' vs sbom='%s'", graph_type, sbom_type)
         return False

--- a/tests/test_sbomnix.py
+++ b/tests/test_sbomnix.py
@@ -100,7 +100,7 @@ def test_sbomnix_help():
 
 
 def test_sbomnix_type_runtime():
-    """Test sbomnix '--type=runtime' generates valid CycloneDX json"""
+    """Test sbomnix generates valid CycloneDX json with runtime dependencies"""
     out_path_cdx = TEST_WORK_DIR / "sbom_cdx_test.json"
     out_path_spdx = TEST_WORK_DIR / "sbom_spdx_test.json"
     _run_python_script(
@@ -111,8 +111,6 @@ def test_sbomnix_type_runtime():
             out_path_cdx.as_posix(),
             "--spdx",
             out_path_spdx.as_posix(),
-            "--type",
-            "runtime",
         ]
     )
     assert out_path_cdx.exists()
@@ -126,7 +124,7 @@ def test_sbomnix_type_runtime():
 
 
 def test_sbomnix_type_buildtime():
-    """Test sbomnix '--type=runtime' generates valid CycloneDX json"""
+    """Test sbomnix generates valid CycloneDX json with buildtime dependencies"""
     out_path_cdx = TEST_WORK_DIR / "sbom_cdx_test.json"
     out_path_spdx = TEST_WORK_DIR / "sbom_spdx_test.json"
     _run_python_script(
@@ -137,34 +135,7 @@ def test_sbomnix_type_buildtime():
             out_path_cdx.as_posix(),
             "--spdx",
             out_path_spdx.as_posix(),
-            "--type",
-            "buildtime",
-        ]
-    )
-    assert out_path_cdx.exists()
-    assert out_path_spdx.exists()
-    cdx_schema_path = MYDIR / "resources" / "cdx_bom-1.3.schema.json"
-    assert cdx_schema_path.exists()
-    validate_json(out_path_cdx.as_posix(), cdx_schema_path)
-    spdx_schema_path = MYDIR / "resources" / "spdx_bom-2.3.schema.json"
-    assert spdx_schema_path.exists()
-    validate_json(out_path_spdx.as_posix(), spdx_schema_path)
-
-
-def test_sbomnix_cdx_type_both():
-    """Test sbomnix '--type=both' generates valid CycloneDX json"""
-    out_path_cdx = TEST_WORK_DIR / "sbom_cdx_test.json"
-    out_path_spdx = TEST_WORK_DIR / "sbom_spdx_test.json"
-    _run_python_script(
-        [
-            SBOMNIX,
-            TEST_NIX_RESULT,
-            "--cdx",
-            out_path_cdx.as_posix(),
-            "--spdx",
-            out_path_spdx.as_posix(),
-            "--type",
-            "both",
+            "--buildtime",
         ]
     )
     assert out_path_cdx.exists()
@@ -187,8 +158,6 @@ def test_sbomnix_depth():
             TEST_NIX_RESULT,
             "--csv",
             out_path_csv_1.as_posix(),
-            "--type",
-            "runtime",
         ]
     )
     assert out_path_csv_1.exists()
@@ -201,8 +170,6 @@ def test_sbomnix_depth():
             TEST_NIX_RESULT,
             "--csv",
             out_path_csv_2.as_posix(),
-            "--type",
-            "runtime",
             "--depth=1",
         ]
     )
@@ -319,8 +286,6 @@ def test_compare_deps_runtime():
             TEST_NIX_RESULT,
             "--cdx",
             out_path_cdx.as_posix(),
-            "--type",
-            "runtime",
         ]
     )
     assert out_path_cdx.exists()
@@ -358,8 +323,7 @@ def test_compare_deps_buildtime():
             TEST_NIX_RESULT,
             "--cdx",
             out_path_cdx.as_posix(),
-            "--type",
-            "buildtime",
+            "--buildtime",
         ]
     )
     assert out_path_cdx.exists()
@@ -384,8 +348,7 @@ def test_compare_subsequent_cdx_sboms():
             TEST_NIX_RESULT,
             "--cdx",
             out_path_cdx_1.as_posix(),
-            "--type",
-            "both",
+            "--buildtime",
         ]
     )
     assert out_path_cdx_1.exists()
@@ -397,8 +360,7 @@ def test_compare_subsequent_cdx_sboms():
             TEST_NIX_RESULT,
             "--cdx",
             out_path_cdx_2.as_posix(),
-            "--type",
-            "both",
+            "--buildtime",
         ]
     )
     assert out_path_cdx_2.exists()
@@ -421,8 +383,7 @@ def test_compare_subsequent_spdx_sboms():
             TEST_NIX_RESULT,
             "--spdx",
             out_path_spdx_1.as_posix(),
-            "--type",
-            "both",
+            "--buildtime",
         ]
     )
     assert out_path_spdx_1.exists()
@@ -434,8 +395,7 @@ def test_compare_subsequent_spdx_sboms():
             TEST_NIX_RESULT,
             "--spdx",
             out_path_spdx_2.as_posix(),
-            "--type",
-            "both",
+            "--buildtime",
         ]
     )
     assert out_path_spdx_2.exists()
@@ -461,8 +421,7 @@ def test_compare_spdx_and_cdx_sboms():
             out_path_cdx.as_posix(),
             "--spdx",
             out_path_spdx.as_posix(),
-            "--type",
-            "both",
+            "--buildtime",
         ]
     )
     assert out_path_cdx.exists()


### PR DESCRIPTION
Remove `--type` command-line argument from sbomnix replacing it with `--buildtime` argument to align the command-line usage with other tools in this repository. Also, update relevant documentation and tests.


Note: this change breaks the command line usage of the `sbomnix` tool for those users who use the `--type` argument, and it should be replaced as follows:
- `--type=buildtime` should be replaced with `--buildtime` after this change
- `--type=both` should be replaced with `--buildtime` after this change
- `--type=runtime` is still the default mode (i.e. the absence of `--buildtime`)