### PR TITLE
Improve integration with nixpkgs metadata

### DIFF
--- a/.github/workflows/release_sbomnix.yml
+++ b/.github/workflows/release_sbomnix.yml
@@ -21,8 +21,6 @@ jobs:
       - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
-      - name: Make sure nix-build works
-        run: nix-build '<nixpkgs>' -A hello
       - name: Build release asset
         run: nix develop --command make release-asset
       - name: Upload release asset

--- a/Makefile
+++ b/Makefile
@@ -39,16 +39,12 @@ format: clean ## Reformat with black
 	$(call target_success,$@)
 
 release-asset: clean ## Build release asset
-	nix-shell -p nix-info --run "nix-info -m"
-	nix-env -qa --meta --json -f $(shell nix-shell -p nix-info --run "nix-info -m" | grep "nixpkgs: " | cut -d'`' -f2) '.*' >meta.json
 	mkdir -p build/
-	nix run .#sbomnix -- result \
-		--meta=./meta.json \
+	nix run .#sbomnix -- . \
         --cdx=./build/sbom.runtime.cdx.json \
         --spdx=./build/sbom.runtime.spdx.json \
         --csv=./build/sbom.runtime.csv
-	nix run .#sbomnix -- result --buildtime \
-		--meta=./meta.json \
+	nix run .#sbomnix -- --buildtime . \
         --cdx=./build/sbom.buildtime.cdx.json \
         --spdx=./build/sbom.buildtime.spdx.json \
         --csv=./build/sbom.buildtime.csv

--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ $ nix eval -f '<nixpkgs>' 'wget.outPath'
 By default `sbomnix` scans the given target and generates an SBOM including the runtime dependencies.
 Notice: determining the target runtime dependencies in Nix requires building the target.
 ```bash
+# Target can be specified with flakeref too, e.g.:
+# sbomnix .
+# sbomnix github:tiiuae/sbomnix
+# sbomnix nixpkgs#wget
+# Ref: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#flake-references
 $ sbomnix /nix/store/8nbv1drmvh588pwiwsxa47iprzlgwx6j-wget-1.21.3
 ...
 INFO     Wrote: sbom.cdx.json

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 This repository is home to various command line tools and Python libraries that aim to help with software supply chain challenges:
 - [`sbomnix`](#generate-sbom-based-on-derivation-file-or-out-path) is a utility that generates SBOMs given [Nix](https://nixos.org/) derivation or out path.
 - [`nixgraph`](./doc/nixgraph.md) helps query and visualize dependency graphs for [Nix](https://nixos.org/) derivation or out path.
+- [`nixmeta`](./doc/nixmeta.md) summarizes nixpkgs meta-attributes from the given nixpkgs version.
 - [`vulnxscan`](./doc/vulnxscan.md) is a vulnerability scanner demonstrating the usage of SBOMs in running vulnerability scans.
 - [`repology_cli`](./doc/replogoy_cli.md) and [`repology_cve`](./doc/replogoy_cli.md#repology-cve-search) are command line clients to [repology.org](https://repology.org/).
 - [`nix_outdated`](./doc/nix_outdated.md) is a utility that finds outdated nix dependencies for given out path, listing the outdated packages in priority order based on how many other packages depend on the given outdated package.
@@ -86,6 +87,9 @@ $ src/sbomnix/main.py --help
 # nixgraph:
 $ src/nixgraph/main.py --help
 
+# nixmeta:
+$ src/nixmeta/main.py --help
+
 # vulnxscan:
 $ src/vulnxscan/vulnxscan_cli.py --help
 
@@ -111,7 +115,7 @@ For reference, following is a link to graph from an example hello-world C progra
 <img src="doc/img/c_hello_world_runtime.svg" width="700">
 
 
-By default, all the tools in this repository assume runtime dependencies. This means, for instance, that unless specified otherwise, `sbomnix` will output an SBOM including the target runtime dependencies, `nixgraph` outputs runtime dependency graph, and `vulnxscan` and `nix_outdated` scan runtime dependencies. Since Nix needs to build the target output to determine the runtime dependencies, all the tools in this repository will also build (force-realise) the target output as part of each tool's invocation when determining the runtime dependencies. All the mentioned tools in this repository also support working with buildtime dependencies instead of runtime dependencies with the help of `--buildtime` command line argument. As mentioned earlier, generating buildtime dependencies in Nix does not require building the target. Similarly, when `--buildtime` is specified, the tools in this repository do not need to be build the given target.
+By default, where applicable, the tools in this repository assume runtime dependencies. This means, for instance, that unless specified otherwise, `sbomnix` will output an SBOM including runtime-only dependencies, `nixgraph` outputs runtime dependency graph, and `vulnxscan` and `nix_outdated` scan runtime dependencies. Since Nix needs to build the target output to determine the runtime dependencies, all the tools in this repository will also build (force-realise) the target output as part of each tool's invocation when determining the runtime dependencies. All the mentioned tools in this repository also support working with buildtime dependencies instead of runtime dependencies with the help of `--buildtime` command line argument. As mentioned earlier, generating buildtime dependencies in Nix does not require building the target. Similarly, when `--buildtime` is specified, the tools in this repository do not need to be build the given target.
 
 
 ## Usage Examples

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Table of Contents
    * [Generate SBOM Including Meta Information](#generate-sbom-including-meta-information)
    * [Generate SBOM Including Buildtime Dependencies](#generate-sbom-including-buildtime-dependencies)
    * [Generate SBOM Based on Result Symlink](#generate-sbom-based-on-result-symlink)
+   * [Generate SBOM Based on Flake Reference](#generate-sbom-based-on-flake-reference)
    * [Visualize Package Dependencies](#visualize-package-dependencies)
 * [Contribute](#contribute)
 * [License](#license)
@@ -143,28 +144,26 @@ INFO     Wrote: sbom.csv
 ```
 Main outputs are the SBOM json files sbom.cdx.json and sbom.spdx.json in [CycloneDX](https://cyclonedx.org/) and [SPDX](https://spdx.github.io/spdx-spec/v2.3/) formats.
 
-#### Generate SBOM Including Meta Information
-To include license information to the SBOM, first generate package meta information with `nix-env`:
-```bash
-$ nix-env -qa --meta --json '.*' >meta.json
-```
-Then, run `sbomnix` with `--meta` argument to tell sbomnix to read meta information from the given json file:
-```bash
-$ sbomnix /nix/store/8nbv1drmvh588pwiwsxa47iprzlgwx6j-wget-1.21.3 --meta meta.json
-```
-
 #### Generate SBOM Including Buildtime Dependencies
 By default `sbomnix` scans the given target for runtime dependencies. You can tell sbomnix to determine the buildtime dependencies using the `--buildtime` argument. 
 Below example generates SBOM including buildtime dependencies.
 Notice: as opposed to runtime dependencies, determining the buildtime dependencies does not require building the target.
 ```bash
-$ sbomnix /nix/store/8nbv1drmvh588pwiwsxa47iprzlgwx6j-wget-1.21.3 --meta meta.json --buildtime
+$ sbomnix /nix/store/8nbv1drmvh588pwiwsxa47iprzlgwx6j-wget-1.21.3 --buildtime
 ```
+
 #### Generate SBOM Based on Result Symlink
 `sbomnix` can be used with output paths too (e.g. anything which produces a result symlink):
 ```bash
 $ sbomnix /path/to/result 
 ```
+
+#### Generate SBOM Based on Flake Reference
+`sbomnix` also supports scanning [flake references](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#flake-references):
+```bash
+$ sbomnix github:NixOS/nixpkgs?ref=nixos-unstable#wget --buildtime
+```
+
 #### Visualize Package Dependencies
 `sbomnix` finds the package dependencies using `nixgraph`. 
 Moreover, `nixgraph` can also be used as a stand-alone tool for visualizing package dependencies.

--- a/doc/nix_outdated.md
+++ b/doc/nix_outdated.md
@@ -23,11 +23,16 @@ $ nix eval -f '<nixpkgs>' 'git.outPath'
 ```
 
 # nix_outdated
-[`nix_outdated`](../src/nixupdate/nix_outdated.py) is a command line tool to list outdated nix dependencies for given target nix out path. By default, the script outputs runtime dependencies for the given nix out path that appear outdated in nixpkgs 'nix_unstable' channel - the list of output packages would potentially need a PR to update the package in nixpkgs to the package's latest upstream release version specified in the output table column 'version_upstream'. The list of output packages is in priority order based on how many other packages depend on the potentially outdated package.
+[`nix_outdated`](../src/nixupdate/nix_outdated.py) is a command line tool to list outdated nix dependencies for given target nix out path or flakeref. By default, the script outputs runtime dependencies for the given target that appear outdated in nixpkgs 'nix_unstable' channel - the list of output packages would potentially need a PR to update the package in nixpkgs to the package's latest upstream release version specified in the output table column 'version_upstream'. The list of output packages is in priority order based on how many other packages depend on the potentially outdated package.
 
 Below command finds `git` runtime dependencies that would have an update in the package's upstream repository based on repology, and the latest release version is not available in nix unstable:
 
 ```bash
+# Target can be specified with flakeref too, e.g.:
+# nix_outdated .
+# nix_outdated github:tiiuae/sbomnix
+# nix_outdated nixpkgs#git
+# Ref: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#flake-references
 $ nix_outdated /nix/store/2853v0cidl7jww2hs1mlkg0i372mk368-git-2.39.2
 INFO     Generating SBOM for target '/nix/store/2853v0cidl7jww2hs1mlkg0i372mk368-git-2.39.2'
 INFO     Loading runtime dependencies referenced by '/nix/store/2853v0cidl7jww2hs1mlkg0i372mk368-git-2.39.2'

--- a/doc/nixgraph.md
+++ b/doc/nixgraph.md
@@ -42,6 +42,11 @@ $ nix eval -f '<nixpkgs>' 'wget.outPath'
 
 #### Example: package runtime dependencies
 ```bash
+# Target can be specified with flakeref too, e.g.:
+# nixgraph .
+# nixgraph github:tiiuae/sbomnix
+# nixgraph nixpkgs#wget
+# Ref: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#flake-references
 $ nixgraph /nix/store/8nbv1drmvh588pwiwsxa47iprzlgwx6j-wget-1.21.3
 
 INFO     Loading runtime dependencies referenced by '/nix/store/8nbv1drmvh588pwiwsxa47iprzlgwx6j-wget-1.21.3'

--- a/doc/nixmeta.md
+++ b/doc/nixmeta.md
@@ -1,0 +1,37 @@
+<!--
+SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Getting Started
+To get started, follow the [Getting Started](../README.md#getting-started) section from the main [README](../README.md).
+
+As an example, to run the [`nixmeta`](../src/nixmeta/main.py) from the `tiiuae/sbomnix` repository:
+```bash
+# '--' signifies the end of argument list for `nix`.
+# '--help' is the first argument to `nixmeta`
+$ nix run github:tiiuae/sbomnix#nixmeta -- --help
+```
+
+# nixmeta
+[`nixmeta`](../src/nixmeta/main.py) is a command line tool to summarize nixpkgs meta-attributes from the given nixpkgs version. The output is written to a csv file. Nixpkgs version is specified with [`flakeref`](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake#flake-references). As an example, `--flakeref=github:NixOS/nixpkgs?ref=master` would make `nixmeta` output the meta-attributes from the nixpkgs version in the [master](https://github.com/NixOS/nixpkgs/tree/master) branch. Similarly, `--flakeref=github:NixOS/nixpkgs?ref=release-23.11` would output the meta-attributes from the nixpkgs version in the [release-23.11](https://github.com/NixOS/nixpkgs/tree/release-23.11) branch. Note that `--flakeref` does not necessarily have to reference `github:NixOS/nixpkgs` but any flakeref or even `NIX_ENV` environment variable can be used to specify the nixpkgs version. As an example, `--flakeref=github:tiiuae/sbomnix` would make `nixmeta` output the meta-attributes from the nixpkgs version [pinned by the sbomnix flake](https://github.com/tiiuae/sbomnix/blob/c243db5272fb01c4d97cbbb01a095ae514cd2dcb/flake.lock#L68) in its default branch.
+
+As an example, below command outputs nixpkgs meta-attributes from the nixpkgs version pinned by flake `github:NixOS/nixpkgs?ref=master`:
+
+```bash
+$ ./src/nixmeta/main.py --flakeref=github:NixOS/nixpkgs?ref=master
+INFO     Finding meta-info for nixpkgs pinned in flake: github:NixOS/nixpkgs?ref=master
+INFO     Wrote: /home/foo/sbomnix-fork/nixmeta.csv
+```
+
+Output summarizes the meta-attributes of all the target nixpkgs packages enumerated by `nix-env --query --available`.
+For each package, the output includes the following details:
+
+```bash
+$ head -n2 nixmeta.csv | csvlook 
+| name       | pname | version | meta_homepage        | meta_unfree | meta_license_short               | meta_license_spdxid                    | meta_maintainers_email |
+| ---------- | ----- | ------- | -------------------- | ----------- | -------------------------------- | -------------------------------------- | ---------------------- |
+| 0ad-0.0.26 | 0ad   | 0.0.26  | https://play0ad.com/ |       False | gpl2;lgpl21;mit;cc-by-sa-30;zlib | GPL-2.0;LGPL-2.1;MIT;CC-BY-SA-3.0;Zlib | nixpkgs@cvpetegem.be   |
+
+```

--- a/doc/vulnxscan.md
+++ b/doc/vulnxscan.md
@@ -67,6 +67,11 @@ Vulnix matches vulnerabilities based on [heuristic](https://github.com/nix-commu
 This example shows how to use `vulnxscan` to summarize vulnerabilities impacting the given target or any of its runtime dependencies.
 
 ```bash
+# Target can be specified with flakeref too, e.g.:
+# vulnxscan .
+# vulnxscan github:tiiuae/sbomnix
+# vulnxscan nixpkgs#git
+# Ref: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#flake-references
 $ vulnxscan /nix/store/ay9sn71cssl4wd7s6bd8xah0zcwqiq2q-git-2.41.0.drv
 
 INFO     Generating SBOM for target '/nix/store/ay9sn71cssl4wd7s6bd8xah0zcwqiq2q-git-2.41.0.drv'

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -30,6 +30,12 @@
         program = "${sbomnix}/bin/nixgraph";
       };
 
+      # nix run .#nixmeta
+      nixmeta = {
+        type = "app";
+        program = "${sbomnix}/bin/nixmeta";
+      };
+
       # nix run .#vulnxscan
       vulnxscan = {
         type = "app";

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -12,7 +12,9 @@
 
       packages =
         (with pkgs; [
+          black
           coreutils
+          csvkit
           curl
           gnugrep
           gnused
@@ -20,7 +22,7 @@
           grype
           gzip
           nix
-          black
+          pylint
           reuse
         ])
         ++ (with self'.packages; [

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -12,6 +12,32 @@
     packages = rec {
       default = sbomnix;
 
+      # https://github.com/thombashi/df-diskcache
+      dfdiskcache = pp.buildPythonPackage rec {
+        version = "0.0.2";
+        pname = "df-diskcache";
+        format = "setuptools";
+
+        src = pkgs.fetchFromGitHub {
+          owner = "thombashi";
+          repo = "df-diskcache";
+          rev = "v${version}";
+          hash = "sha256-s+sqEPXw6tbEz9mnG+qeUSF6BmDssYhaDYOmraFaRbw=";
+        };
+
+        propagatedBuildInputs =
+          [
+            simplesqlite
+          ]
+          ++ [
+            pp.pandas
+            pp.typing-extensions
+          ];
+
+        pythonImportsCheck = ["dfdiskcache"];
+        doCheck = false;
+      };
+
       # requests-ratelimiter currently does not support pyrate-limiter v3,
       # see: https://github.com/JWCook/requests-ratelimiter/issues/78
       pyrate-limiter = pp.buildPythonPackage rec {
@@ -92,6 +118,58 @@
         ];
       };
 
+      # Required due to dfdiskcache
+      simplesqlite = pp.buildPythonPackage rec {
+        version = "1.5.2";
+        pname = "SimpleSQLite";
+        format = "setuptools";
+
+        src = pkgs.fetchFromGitHub {
+          owner = "thombashi";
+          repo = "SimpleSQLite";
+          rev = "v${version}";
+          hash = "sha256-Yr17T0/EwVaOjG+mzdxopivj0fuvQdZdX1bFj8vq0MM=";
+        };
+
+        propagatedBuildInputs =
+          [
+            sqliteschema
+          ]
+          ++ [
+            pp.dataproperty
+            pp.mbstrdecoder
+            pp.pathvalidate
+            pp.tabledata
+            pp.typepy
+          ];
+
+        pythonImportsCheck = ["simplesqlite"];
+        doCheck = false;
+      };
+
+      # Required due to dfdiskcache
+      sqliteschema = pp.buildPythonPackage rec {
+        version = "1.4.0";
+        pname = "sqliteschema";
+        format = "setuptools";
+
+        src = pkgs.fetchFromGitHub {
+          owner = "thombashi";
+          repo = "sqliteschema";
+          rev = "v${version}";
+          hash = "sha256-IzHdYBnh6udVsanWTPSsX4p4PG934YCdzs9Ow/NW86E=";
+        };
+
+        propagatedBuildInputs = [
+          pp.mbstrdecoder
+          pp.tabledata
+          pp.typepy
+        ];
+
+        pythonImportsCheck = ["sqliteschema"];
+        doCheck = false;
+      };
+
       # We use vulnix from 'https://github.com/henrirosten/vulnix' to get
       # vulnix support for runtime-only scan ('-C' command-line option)
       # which is currently not available in released version of vulnix.
@@ -112,6 +190,7 @@
 
         propagatedBuildInputs =
           [
+            dfdiskcache
             pyrate-limiter
             requests-ratelimiter
             reuse
@@ -168,7 +247,7 @@
           jsonschema
           pytest
         ])
-        ++ [reuse]);
+        ++ [dfdiskcache reuse]);
     };
   };
 }

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setuptools.setup(
         "console_scripts": [
             "sbomnix  = sbomnix.main:main",
             "nixgraph = nixgraph.main:main",
+            "nixmeta = nixmeta.main:main",
             "nix_outdated = nixupdate.nix_outdated:main",
             "vulnxscan = vulnxscan.vulnxscan_cli:main",
             "repology_cli = repology.repology_cli:main",

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -14,6 +14,9 @@ import csv
 import logging
 import subprocess
 import importlib.metadata
+import pathlib
+import tempfile
+import urllib.error
 from shutil import which
 
 import packaging.version
@@ -29,6 +32,9 @@ from requests_ratelimiter import LimiterMixin
 
 LOG_SPAM = logging.DEBUG - 1
 LOG = logging.getLogger(os.path.abspath(__file__))
+
+# DataFrameDiskCache cache local path
+DFCACHE_PATH = pathlib.Path(tempfile.gettempdir()) / "sbomnix_df_cache"
 
 ###############################################################################
 
@@ -88,7 +94,11 @@ def df_from_csv_file(name, exit_on_error=True):
         df = pd.read_csv(name, keep_default_na=False, dtype=str)
         df.reset_index(drop=True, inplace=True)
         return df
-    except (pd.errors.EmptyDataError, pd.errors.ParserError) as error:
+    except (
+        pd.errors.EmptyDataError,
+        pd.errors.ParserError,
+        urllib.error.HTTPError,
+    ) as error:
         if exit_on_error:
             LOG.fatal("Error reading csv file '%s':\n%s", name, error)
             sys.exit(1)

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -112,12 +112,18 @@ def df_log(df, loglevel, tablefmt="presto"):
         LOG.log(loglevel, "\n%s\n", table)
 
 
-def exec_cmd(cmd, raise_on_error=True, return_error=False, loglevel=logging.DEBUG):
+def exec_cmd(
+    cmd, raise_on_error=True, return_error=False, loglevel=logging.DEBUG, stdout=None
+):
     """Run shell command cmd"""
     command_str = " ".join(cmd)
     LOG.log(loglevel, "Running: %s", command_str)
     try:
-        return subprocess.run(cmd, capture_output=True, encoding="utf-8", check=True)
+        if stdout:
+            ret = subprocess.run(cmd, encoding="utf-8", check=True, stdout=stdout)
+        else:
+            ret = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=True)
+        return ret
     except subprocess.CalledProcessError as error:
         LOG.debug(
             "Error running shell command:\n cmd:   '%s'\n stdout: %s\n stderr: %s",

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -14,6 +14,8 @@ import csv
 import logging
 import subprocess
 import importlib.metadata
+from shutil import which
+
 import packaging.version
 from tabulate import tabulate
 from colorlog import ColoredFormatter, default_log_colors
@@ -136,6 +138,14 @@ def exec_cmd(
         if return_error:
             return error
         return None
+
+
+def exit_unless_command_exists(name):
+    """Check if `name` is an executable in PATH"""
+    name_is_in_path = which(name) is not None
+    if not name_is_in_path:
+        LOG.fatal("command '%s' is not in PATH", name)
+        sys.exit(1)
 
 
 def exit_unless_nix_artifact(path, force_realise=False):

--- a/src/nixmeta/__init__.py
+++ b/src/nixmeta/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/src/nixmeta/main.py
+++ b/src/nixmeta/main.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+""" Python script for summarizing nixpkgs meta-attributes """
+
+import sys
+import argparse
+import pathlib
+import shutil
+from nixmeta.scanner import NixMetaScanner
+from common.utils import LOG, set_log_verbosity
+
+
+################################################################################
+
+
+def _getargs():
+    """Parse command line arguments"""
+    desc = (
+        "Summarize nixpkgs meta-attributes from the given nixpkgs version "
+        "to a csv output file."
+    )
+    epil = "Example: nixmeta --flakeref=github:NixOS/nixpkgs?ref=master"
+    parser = argparse.ArgumentParser(description=desc, epilog=epil)
+    helps = (
+        "Flake reference specifying the location of the flake "
+        "from which the pinned nixpkgs target version is read. "
+        "The default value is the "
+        "current nixpkgs version in its 'nixos-unstable' branch. "
+        "For more details, see: "
+        "https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake"
+        "#flake-references and "
+        "https://nixos.wiki/wiki/Nix_channels "
+        "(default: --flakeref=github:NixOS/nixpkgs?ref=nixos-unstable)."
+    )
+    parser.add_argument(
+        "-f",
+        "--flakeref",
+        help=helps,
+        type=str,
+        default="github:NixOS/nixpkgs?ref=nixos-unstable",
+    )
+    helps = "Path to output file (default: --out=nixmeta.csv)."
+    parser.add_argument(
+        "-o",
+        "--out",
+        help=helps,
+        type=pathlib.Path,
+        default="nixmeta.csv",
+    )
+    helps = (
+        "Append to output file - removing duplicate entries - instead of "
+        "completely overwriting possible earlier output file."
+    )
+    parser.add_argument(
+        "-a",
+        "--append",
+        help=helps,
+        action="store_true",
+    )
+    helps = "Set the debug verbosity level between 0-3 (default: --verbose=1)."
+    parser.add_argument("-v", "--verbose", help=helps, type=int, default=1)
+    return parser.parse_args()
+
+
+###############################################################################
+
+
+def _exit_unless_command_exists(name):
+    """Check if `name` is an executable in PATH"""
+    name_is_in_path = shutil.which(name) is not None
+    if not name_is_in_path:
+        LOG.fatal("command '%s' is not in PATH", name)
+        sys.exit(1)
+
+
+###############################################################################
+
+
+def main():
+    """main entry point"""
+    args = _getargs()
+    set_log_verbosity(args.verbose)
+    # Fail early if the following commands are not in PATH
+    _exit_unless_command_exists("nix")
+    _exit_unless_command_exists("nix-env")
+    # Scan metadata from the flakeref pinned nixpkgs
+    scanner = NixMetaScanner()
+    scanner.scan(args.flakeref)
+    # Output to csv file
+    scanner.to_csv(args.out, args.append)
+
+
+################################################################################
+
+if __name__ == "__main__":
+    main()
+
+################################################################################

--- a/src/nixmeta/main.py
+++ b/src/nixmeta/main.py
@@ -5,12 +5,10 @@
 
 """ Python script for summarizing nixpkgs meta-attributes """
 
-import sys
 import argparse
 import pathlib
-import shutil
 from nixmeta.scanner import NixMetaScanner
-from common.utils import LOG, set_log_verbosity
+from common.utils import set_log_verbosity, exit_unless_command_exists
 
 
 ################################################################################
@@ -68,24 +66,13 @@ def _getargs():
 ###############################################################################
 
 
-def _exit_unless_command_exists(name):
-    """Check if `name` is an executable in PATH"""
-    name_is_in_path = shutil.which(name) is not None
-    if not name_is_in_path:
-        LOG.fatal("command '%s' is not in PATH", name)
-        sys.exit(1)
-
-
-###############################################################################
-
-
 def main():
     """main entry point"""
     args = _getargs()
     set_log_verbosity(args.verbose)
     # Fail early if the following commands are not in PATH
-    _exit_unless_command_exists("nix")
-    _exit_unless_command_exists("nix-env")
+    exit_unless_command_exists("nix")
+    exit_unless_command_exists("nix-env")
     # Scan metadata from the flakeref pinned nixpkgs
     scanner = NixMetaScanner()
     scanner.scan(args.flakeref)

--- a/src/nixmeta/scanner.py
+++ b/src/nixmeta/scanner.py
@@ -7,6 +7,7 @@
 
 """ Summarize nixpkgs meta-attributes """
 
+import re
 import pathlib
 import json
 from tempfile import NamedTemporaryFile
@@ -28,25 +29,14 @@ class NixMetaScanner:
     def __init__(self):
         self.df_meta = None
 
-    def scan(self, flakeref):
-        """Scan nixpkgs meta-info using nixpkgs version pinned in flakeref"""
-        LOG.info("Finding meta-info for nixpkgs pinned in flake: %s", flakeref)
-        meta_json = _get_flake_metadata(flakeref)
-        if not _is_nixpkgs_metadata(meta_json):
-            # If flakeref is not nixpkgs flake, try finding the nixpkgs
-            # revision pinned by the given flakeref
-            LOG.debug("non-nixpkgs flakeref: %s", flakeref)
-            rev = _get_flake_nixpkgs_pin(meta_json)
-            if not rev:
-                LOG.warning("Failed reading nixpkgs pin: %s", flakeref)
-                return
-            nixpkgs_flakeref = f"github:NixOS/nixpkgs?ref={rev}"
-            LOG.log(LOG_SPAM, "using nixpkgs_flakeref: %s", nixpkgs_flakeref)
-            meta_json = _get_flake_metadata(nixpkgs_flakeref)
-            if not _is_nixpkgs_metadata(meta_json):
-                LOG.warning("Failed reading nixpkgs metadata: %s", flakeref)
-                return
-        nixpkgs_path = pathlib.Path(meta_json["path"]).absolute()
+    def scan(self, nixref):
+        """
+        Scan nixpkgs meta-info using nixpkgs version pinned in nixref;
+        nixref can be a nix store path or flakeref.
+        """
+        nixpkgs_path = nixref_to_nixpkgs_path(nixref)
+        if not nixpkgs_path:
+            return
         if not nixpkgs_path.exists():
             LOG.warning("Nixpkgs not in nix store: %s", nixpkgs_path.as_posix())
             return
@@ -58,12 +48,30 @@ class NixMetaScanner:
         csv_path = pathlib.Path(csv_path)
         if append and csv_path.exists():
             df = df_from_csv_file(csv_path)
-            self.df_meta = pd.concat(
-                [self.df_meta.astype(str), df.astype(str)], ignore_index=True
-            )
+            self.df_meta = pd.concat([self.df_meta, df], ignore_index=True)
+            self._drop_duplicates()
         if self.df_meta is None or self.df_meta.empty:
             LOG.info("Nothing to output")
             return
+        csv_path.parent.mkdir(parents=True, exist_ok=True)
+        df_to_csv_file(self.df_meta, csv_path.absolute().as_posix())
+
+    def to_df(self):
+        """Return meta-info as dataframe"""
+        return self.df_meta
+
+    def _read_nixpkgs_meta(self, nixpkgs_path):
+        prefix = "nixmeta_"
+        suffix = ".json"
+        with NamedTemporaryFile(delete=True, prefix=prefix, suffix=suffix) as f:
+            cmd = f"nix-env -qa --meta --json -f {nixpkgs_path.as_posix()}"
+            exec_cmd(cmd.split(), stdout=f)
+            LOG.debug("Generated meta.json: %s", f.name)
+            self.df_meta = _parse_json_metadata(f.name)
+            self._drop_duplicates()
+
+    def _drop_duplicates(self):
+        self.df_meta = self.df_meta.astype(str)
         self.df_meta.fillna("", inplace=True)
         uids = [
             "name",
@@ -74,20 +82,37 @@ class NixMetaScanner:
         ]
         self.df_meta.sort_values(by=uids, inplace=True)
         self.df_meta.drop_duplicates(subset=uids, keep="last", inplace=True)
-        csv_path.parent.mkdir(parents=True, exist_ok=True)
-        df_to_csv_file(self.df_meta, csv_path.absolute().as_posix())
-
-    def _read_nixpkgs_meta(self, nixpkgs_path):
-        prefix = "nixmeta_"
-        suffix = ".json"
-        with NamedTemporaryFile(delete=True, prefix=prefix, suffix=suffix) as f:
-            cmd = f"nix-env -qa --meta --json -f {nixpkgs_path.as_posix()}"
-            exec_cmd(cmd.split(), stdout=f)
-            LOG.debug("Generated meta.json: %s", f.name)
-            self.df_meta = _parse_json_metadata(f.name)
 
 
 ###############################################################################
+
+
+def nixref_to_nixpkgs_path(flakeref):
+    """Return the store path of the nixpkgs pinned by flakeref"""
+    if not flakeref:
+        return None
+    LOG.debug("Finding meta-info for nixpkgs pinned in nixref: %s", flakeref)
+    # Strip possible target specifier from flakeref (i.e. everything after '#')
+    m_flakeref = re.match(r"([^#]+)#", flakeref)
+    if m_flakeref:
+        flakeref = m_flakeref.group(1)
+        LOG.debug("Stripped target specifier: %s", flakeref)
+    meta_json = _get_flake_metadata(flakeref)
+    if not _is_nixpkgs_metadata(meta_json):
+        # If flakeref is not nixpkgs flake, try finding the nixpkgs
+        # revision pinned by the given flakeref
+        LOG.debug("non-nixpkgs flakeref: %s", flakeref)
+        rev = _get_flake_nixpkgs_pin(meta_json)
+        if not rev:
+            LOG.warning("Failed reading nixpkgs pin: %s", flakeref)
+            return None
+        nixpkgs_flakeref = f"github:NixOS/nixpkgs?ref={rev}"
+        LOG.log(LOG_SPAM, "using nixpkgs_flakeref: %s", nixpkgs_flakeref)
+        meta_json = _get_flake_metadata(nixpkgs_flakeref)
+        if not _is_nixpkgs_metadata(meta_json):
+            LOG.warning("Failed reading nixpkgs metadata: %s", flakeref)
+            return None
+    return pathlib.Path(meta_json["path"]).absolute()
 
 
 def _get_flake_metadata(flakeref):
@@ -97,9 +122,9 @@ def _get_flake_metadata(flakeref):
     """
     # Strip possible nixpkgs= prefix to support cases where flakeref is
     # given the NIX_PATH environment variable
-    prefix = "nixpkgs="
-    if flakeref.startswith(prefix):
-        flakeref = flakeref[len(prefix):]  # fmt: skip
+    m_nixpkgs = re.match(r"nixpkgs=([^:\s]+)", flakeref)
+    if m_nixpkgs:
+        flakeref = m_nixpkgs.group(1)
     # Read nix flake metadata as json
     cmd = f"nix flake metadata {flakeref} --json"
     ret = exec_cmd(cmd.split(), raise_on_error=False, return_error=True)

--- a/src/nixmeta/scanner.py
+++ b/src/nixmeta/scanner.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=invalid-name
+
+""" Summarize nixpkgs meta-attributes """
+
+import pathlib
+import json
+from tempfile import NamedTemporaryFile
+import pandas as pd
+from common.utils import (
+    LOG,
+    LOG_SPAM,
+    df_from_csv_file,
+    df_to_csv_file,
+    exec_cmd,
+)
+
+###############################################################################
+
+
+class NixMetaScanner:
+    """Scan nixpkgs meta-info"""
+
+    def __init__(self):
+        self.df_meta = None
+
+    def scan(self, flakeref):
+        """Scan nixpkgs meta-info using nixpkgs version pinned in flakeref"""
+        LOG.info("Finding meta-info for nixpkgs pinned in flake: %s", flakeref)
+        meta_json = _get_flake_metadata(flakeref)
+        if not _is_nixpkgs_metadata(meta_json):
+            # If flakeref is not nixpkgs flake, try finding the nixpkgs
+            # revision pinned by the given flakeref
+            LOG.debug("non-nixpkgs flakeref: %s", flakeref)
+            rev = _get_flake_nixpkgs_pin(meta_json)
+            if not rev:
+                LOG.warning("Failed reading nixpkgs pin: %s", flakeref)
+                return
+            nixpkgs_flakeref = f"github:NixOS/nixpkgs?ref={rev}"
+            LOG.log(LOG_SPAM, "using nixpkgs_flakeref: %s", nixpkgs_flakeref)
+            meta_json = _get_flake_metadata(nixpkgs_flakeref)
+            if not _is_nixpkgs_metadata(meta_json):
+                LOG.warning("Failed reading nixpkgs metadata: %s", flakeref)
+                return
+        nixpkgs_path = pathlib.Path(meta_json["path"]).absolute()
+        if not nixpkgs_path.exists():
+            LOG.warning("Nixpkgs not in nix store: %s", nixpkgs_path.as_posix())
+            return
+        LOG.debug("nixpkgs: %s", nixpkgs_path)
+        self._read_nixpkgs_meta(nixpkgs_path)
+
+    def to_csv(self, csv_path, append=False):
+        """Export meta-info to a csv file"""
+        csv_path = pathlib.Path(csv_path)
+        if append and csv_path.exists():
+            df = df_from_csv_file(csv_path)
+            self.df_meta = pd.concat(
+                [self.df_meta.astype(str), df.astype(str)], ignore_index=True
+            )
+        if self.df_meta is None or self.df_meta.empty:
+            LOG.info("Nothing to output")
+            return
+        self.df_meta.fillna("", inplace=True)
+        uids = [
+            "name",
+            "version",
+            "meta_license_short",
+            "meta_license_spdxid",
+            "meta_homepage",
+        ]
+        self.df_meta.sort_values(by=uids, inplace=True)
+        self.df_meta.drop_duplicates(subset=uids, keep="last", inplace=True)
+        csv_path.parent.mkdir(parents=True, exist_ok=True)
+        df_to_csv_file(self.df_meta, csv_path.absolute().as_posix())
+
+    def _read_nixpkgs_meta(self, nixpkgs_path):
+        prefix = "nixmeta_"
+        suffix = ".json"
+        with NamedTemporaryFile(delete=True, prefix=prefix, suffix=suffix) as f:
+            cmd = f"nix-env -qa --meta --json -f {nixpkgs_path.as_posix()}"
+            exec_cmd(cmd.split(), stdout=f)
+            LOG.debug("Generated meta.json: %s", f.name)
+            self.df_meta = _parse_json_metadata(f.name)
+
+
+###############################################################################
+
+
+def _get_flake_metadata(flakeref):
+    """
+    Return json object detailing the output of nix flake metadata
+    for given flakeref
+    """
+    # Strip possible nixpkgs= prefix to support cases where flakeref is
+    # given the NIX_PATH environment variable
+    prefix = "nixpkgs="
+    if flakeref.startswith(prefix):
+        flakeref = flakeref[len(prefix):]  # fmt: skip
+    # Read nix flake metadata as json
+    cmd = f"nix flake metadata {flakeref} --json"
+    ret = exec_cmd(cmd.split(), raise_on_error=False, return_error=True)
+    if ret is None or ret.returncode != 0:
+        LOG.warning("Failed reading flake metadata: %s", flakeref)
+        return None
+    meta_json = json.loads(ret.stdout)
+    LOG.log(LOG_SPAM, meta_json)
+    return meta_json
+
+
+def _is_nixpkgs_metadata(meta_json):
+    """Return true if meta_json describes nixpkgs flakeref"""
+    try:
+        # Needed to support cases where flakeref is a nix store path
+        # to nixpkgs-source directory
+        if (
+            "path" in meta_json
+            and "description" in meta_json
+            and meta_json["description"]
+            == "A collection of packages for the Nix package manager"
+        ):
+            return True
+        if (
+            "path" in meta_json
+            and meta_json["locked"]["owner"] == "NixOS"
+            and meta_json["locked"]["repo"] == "nixpkgs"
+        ):
+            return True
+    except (KeyError, TypeError):
+        return False
+    return False
+
+
+def _get_flake_nixpkgs_pin(meta_json):
+    """Given nixpkgs flake metadata, return the pinned revision"""
+    try:
+        return meta_json["locks"]["nodes"]["nixpkgs"]["locked"]["rev"]
+    except (KeyError, TypeError):
+        return None
+
+
+def _parse_meta_entry(meta, key):
+    """Parse the given key from the metadata entry"""
+    items = []
+    if isinstance(meta, dict):
+        items.extend([_parse_meta_entry(meta.get(key, ""), key)])
+    elif isinstance(meta, list):
+        items.extend([_parse_meta_entry(x, key) for x in meta])
+    else:
+        return str(meta)
+    return ";".join(list(filter(None, items)))
+
+
+def _parse_json_metadata(json_filename):
+    """Parse package metadata from the specified json file"""
+    with open(json_filename, "r", encoding="utf-8") as inf:
+        LOG.debug('Loading meta-info from "%s"', json_filename)
+        json_dict = json.loads(inf.read())
+        dict_selected = {}
+        setcol = dict_selected.setdefault
+        for _, pkg in json_dict.items():
+            # generic package info
+            setcol("name", []).append(pkg.get("name", ""))
+            setcol("pname", []).append(pkg.get("pname", ""))
+            setcol("version", []).append(pkg.get("version", ""))
+            # meta
+            meta = pkg.get("meta", {})
+            homepage = _parse_meta_entry(meta, key="homepage")
+            setcol("meta_homepage", []).append(homepage)
+            setcol("meta_unfree", []).append(meta.get("unfree", ""))
+            setcol("meta_description", []).append(meta.get("description", ""))
+            # meta.license
+            meta_license = meta.get("license", {})
+            license_short = _parse_meta_entry(meta_license, key="shortName")
+            setcol("meta_license_short", []).append(license_short)
+            license_spdx = _parse_meta_entry(meta_license, key="spdxId")
+            setcol("meta_license_spdxid", []).append(license_spdx)
+            # meta.maintainers
+            meta_maintainers = meta.get("maintainers", {})
+            emails = _parse_meta_entry(meta_maintainers, key="email")
+            setcol("meta_maintainers_email", []).append(emails)
+        return pd.DataFrame(dict_selected).astype(str)
+
+
+###############################################################################

--- a/src/nixupdate/nix_outdated.py
+++ b/src/nixupdate/nix_outdated.py
@@ -77,7 +77,7 @@ def getargs():
 
 def _generate_sbom(target_path, buildtime=False):
     LOG.info("Generating SBOM for target '%s'", target_path)
-    sbomdb = SbomDb(target_path, buildtime, meta_path=None)
+    sbomdb = SbomDb(target_path, buildtime)
     prefix = "nixdeps_"
     suffix = ".cdx.json"
     with NamedTemporaryFile(delete=False, prefix=prefix, suffix=suffix) as f:

--- a/src/sbomnix/cpe.py
+++ b/src/sbomnix/cpe.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# pylint: disable=invalid-name, protected-access, too-few-public-methods
+# pylint: disable=invalid-name, too-few-public-methods
 
 """ Generate CPE (Common Platform Enumeration) identifiers"""
 
@@ -27,17 +27,8 @@ _CPE_CSV_CACHE_TTL = 60 * 60 * 24
 ###############################################################################
 
 
-def CPE():
-    """Return CPE instance"""
-    if _CPE._instance is None:
-        _CPE._instance = _CPE()
-    return _CPE._instance
-
-
-class _CPE:
+class CPE:
     """Generate Common Platform Enumeration identifiers"""
-
-    _instance = None
 
     def __init__(self):
         self.cache = DataFrameDiskCache(cache_dir_path=DFCACHE_PATH)

--- a/src/sbomnix/cpe.py
+++ b/src/sbomnix/cpe.py
@@ -37,8 +37,13 @@ class CPE:
             LOG.debug("read CPE dictionary from cache")
         else:
             LOG.debug("CPE cache miss, downloading: %s", _CPE_CSV_URL)
-            self.df_cpedict = df_from_csv_file(_CPE_CSV_URL)
-            self.cache.set(_CPE_CSV_URL, self.df_cpedict, ttl=_CPE_CSV_CACHE_TTL)
+            self.df_cpedict = df_from_csv_file(_CPE_CSV_URL, exit_on_error=False)
+            if self.df_cpedict is None or self.df_cpedict.empty:
+                LOG.warning(
+                    "Failed downloading cpedict: CPE information might not be accurate"
+                )
+            else:
+                self.cache.set(_CPE_CSV_URL, self.df_cpedict, ttl=_CPE_CSV_CACHE_TTL)
         if self.df_cpedict is not None:
             # Verify the loaded cpedict contains at least the following columns
             required_cols = {"vendor", "product"}

--- a/src/sbomnix/derivation.py
+++ b/src/sbomnix/derivation.py
@@ -22,11 +22,10 @@ from common.utils import LOG, LOG_SPAM
 
 def load(path):
     """Load derivation from path"""
-    LOG.debug("")
     with open(path, encoding="utf-8") as f:
         d_obj = eval(f.read(), {"__builtins__": {}, "Derive": Derive}, {})
     d_obj.store_path = path
-    LOG.debug("load derivation: %s", d_obj)
+    LOG.log(LOG_SPAM, "load derivation: %s", d_obj)
     LOG.log(LOG_SPAM, "deivation attrs: %s", d_obj.to_dict())
     return d_obj
 
@@ -96,7 +95,7 @@ class Derive:
     def add_output_path(self, path):
         """Add an output path to derivation"""
         if path not in self.outputs and path != self.store_path:
-            LOG.debug("adding outpath to %s:%s", self, path)
+            LOG.log(LOG_SPAM, "adding outpath to %s:%s", self, path)
             bisect.insort(self.outputs, path)
 
     def to_dict(self):

--- a/src/sbomnix/derivation.py
+++ b/src/sbomnix/derivation.py
@@ -12,7 +12,6 @@
 import json
 import bisect
 from packageurl import PackageURL
-from sbomnix.cpe import CPE
 
 from common.utils import LOG, LOG_SPAM
 
@@ -83,7 +82,6 @@ class Derive:
         self.cpe = ""
         self.purl = ""
         if self.pname != "source":
-            self.cpe = CPE().generate(self.pname, self.version)
             self.purl = str(
                 PackageURL(type="nix", name=self.pname, version=self.version)
             )
@@ -91,6 +89,11 @@ class Derive:
 
     def __repr__(self):
         return f"<Derive({repr(self.name)})>"
+
+    def set_cpe(self, cpe_generator):
+        """Generate cpe identifier"""
+        if self.pname != "source" and cpe_generator is not None:
+            self.cpe = cpe_generator.generate(self.pname, self.version)
 
     def add_output_path(self, path):
         """Add an output path to derivation"""

--- a/src/sbomnix/meta.py
+++ b/src/sbomnix/meta.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=too-few-public-methods, invalid-name
+
+"""Cache nixpkgs meta information"""
+
+import os
+import re
+import logging
+
+import pandas as pd
+from dfdiskcache import DataFrameDiskCache
+from nixmeta.scanner import NixMetaScanner, nixref_to_nixpkgs_path
+from common.utils import LOG, df_from_csv_file, df_to_csv_file, DFCACHE_PATH
+
+###############################################################################
+
+_NIXMETA_CSV_URL = "https://github.com/henrirosten/nixmeta/raw/main/data/nixmeta.csv"
+# Update local cached version of _NIXMETA_CSV_URL once a day or when local cache
+# is cleaned:
+_NIXMETA_CSV_URL_TTL = 60 * 60 * 24
+
+# Update locally generated nixpkgs meta-info every 30 days or when local cache
+# is cleaned.
+_NIXMETA_NIXPKGS_TTL = 60 * 60 * 24 * 30
+
+###############################################################################
+
+
+class Meta:
+    """Cache nixpkgs meta information"""
+
+    def __init__(self):
+        self.cache = DataFrameDiskCache(cache_dir_path=DFCACHE_PATH)
+        # df_nixmeta includes the meta-info from _NIXMETA_CSV_URL
+        self.df_nixmeta = self.cache.get(_NIXMETA_CSV_URL)
+        if self.df_nixmeta is not None and not self.df_nixmeta.empty:
+            LOG.debug("read nixmeta from cache")
+        else:
+            LOG.debug("nixmeta cache miss, downloading: %s", _NIXMETA_CSV_URL)
+            self.df_nixmeta = df_from_csv_file(_NIXMETA_CSV_URL, exit_on_error=False)
+            if self.df_nixmeta is None or self.df_nixmeta.empty:
+                LOG.warning(
+                    "Failed downloading nixmeta: meta information might not be accurate"
+                )
+            else:
+                # Nix meta dictionary stored at _NIXMETA_CSV_URL is
+                # regularly updated upstream, we want the local cache
+                # to be updated roughly on same schedule (once a day)
+                self.cache.set(
+                    key=_NIXMETA_CSV_URL,
+                    value=self.df_nixmeta,
+                    ttl=_NIXMETA_CSV_URL_TTL,
+                )
+
+    def get_nixpkgs_meta(self, nixref=None):
+        """
+        Return nixpkgs meta pinned in `nixref`. `nixref` can point to a
+        nix store path or flake reference. If nixref is None, attempt to
+        read the nixpkgs store path from NIX_PATH environment variable.
+        """
+        nixpkgs_path = None
+        if nixref:
+            # Read meta from nixpkgs pinned by nixref
+            LOG.debug("Reading nixpkgs path from nixref: %s", nixref)
+            nixpkgs_path = nixref_to_nixpkgs_path(nixref).as_posix()
+        elif "NIX_PATH" in os.environ:
+            # Read meta from nipxkgs referenced in NIX_PATH
+            LOG.debug("Reading nixpkgs path from NIX_PATH environment")
+            nix_path = os.environ["NIX_PATH"]
+            m_nixpkgs = re.match(r"nixpkgs=([^:\s]+)", nix_path)
+            if m_nixpkgs:
+                nixpkgs_path = m_nixpkgs.group(1)
+        df = None
+        if nixpkgs_path:
+            LOG.debug("Scanning meta-info using nixpkgs path: %s", nixpkgs_path)
+            df = self._scan(nixpkgs_path)
+        # Supplement the nix meta info from self.df_nixmeta with the
+        # meta information extracted either from nixref or NIX_PATH
+        df_concat = pd.concat([df, self.df_nixmeta]).astype(str)
+        df_concat = df_concat.drop_duplicates().reset_index(drop=True)
+        if LOG.level <= logging.DEBUG:
+            if df is not None:
+                df_to_csv_file(df, "df_nixref.csv")
+            if self.df_nixmeta is not None:
+                df_to_csv_file(self.df_nixmeta, "df_nixmeta.csv")
+            if df_concat is not None:
+                df_to_csv_file(df_concat, "df_concat.csv")
+        return df_concat
+
+    def _scan(self, nixpkgs_path):
+        df = self.cache.get(nixpkgs_path)
+        if df is not None and not df.empty:
+            LOG.debug("found from cache: %s", nixpkgs_path)
+            return df
+        LOG.debug("cache miss, scanning: %s", nixpkgs_path)
+        scanner = NixMetaScanner()
+        scanner.scan(nixpkgs_path)
+        df = scanner.to_df()
+        if df is None or df.empty:
+            LOG.warning("Failed scanning nixmeta: %s", nixpkgs_path)
+            return None
+        # Cache requires some TTL, so we set it to some value here.
+        # Although, we could as well store it indefinitely as it should
+        # not change given the same key (nixpkgs store path).
+        self.cache.set(key=nixpkgs_path, value=df, ttl=_NIXMETA_NIXPKGS_TTL)
+        return df
+
+
+###############################################################################

--- a/src/sbomnix/nix.py
+++ b/src/sbomnix/nix.py
@@ -12,6 +12,7 @@ import pandas as pd
 
 from common.utils import LOG, LOG_SPAM, exec_cmd
 from sbomnix.derivation import load
+from sbomnix.cpe import CPE
 
 ###############################################################################
 
@@ -22,6 +23,7 @@ class Store:
     def __init__(self, buildtime=False):
         self.buildtime = buildtime
         self.derivations = {}
+        self.cpe_generator = CPE()
 
     def _add_cached(self, path, drv):
         LOG.log(LOG_SPAM, "caching path - %s:%s", path, drv)
@@ -51,6 +53,7 @@ class Store:
         drv_obj = self._get_cached(drv_path)
         if not drv_obj:
             drv_obj = load(drv_path)
+            drv_obj.set_cpe(self.cpe_generator)
             self._add_cached(drv_path, drv=drv_obj)
         assert drv_obj.store_path == drv_path, f"unexpected drv_path: {drv_path}"
         if nixpath:

--- a/src/sbomnix/nix.py
+++ b/src/sbomnix/nix.py
@@ -99,7 +99,7 @@ def find_deriver(path):
     if path.endswith(".drv"):
         return path
     # Deriver from QueryValidDerivers
-    ret = exec_cmd(["nix", "show-derivation", path], raise_on_error=False)
+    ret = exec_cmd(["nix", "derivation", "show", path], raise_on_error=False)
     if not ret:
         LOG.debug("Deriver not found for '%s'", path)
         return None

--- a/src/sbomnix/sbomdb.py
+++ b/src/sbomnix/sbomdb.py
@@ -20,7 +20,7 @@ from reuse._licenses import LICENSE_MAP as SPDX_LICENSES
 from nixgraph.graph import NixDependencies
 from sbomnix.nix import Store, find_deriver
 from sbomnix.meta import Meta
-from common.utils import LOG, df_to_csv_file, get_py_pkg_version
+from common.utils import LOG, LOG_SPAM, df_to_csv_file, get_py_pkg_version
 
 ###############################################################################
 
@@ -359,7 +359,7 @@ def _cdx_component_add_licenses(component, drv):
         licenses = _drv_to_cdx_licenses_entry(drv, "meta_license_short", "name")
     # Give up if package does not have license information associated
     if not licenses:
-        LOG.debug("No license info found for '%s'", drv.name)
+        LOG.log(LOG_SPAM, "No license info found for '%s'", drv.name)
         return
     # Otherwise, add the licenses entry
     component["licenses"] = licenses

--- a/src/vulnxscan/vulnxscan_cli.py
+++ b/src/vulnxscan/vulnxscan_cli.py
@@ -22,7 +22,6 @@ import re
 import time
 import urllib.parse
 from tempfile import NamedTemporaryFile
-from shutil import which
 
 import pandas as pd
 import numpy as np
@@ -42,6 +41,7 @@ from common.utils import (
     df_from_csv_file,
     df_log,
     exit_unless_nix_artifact,
+    exit_unless_command_exists,
     nix_to_repology_pkg_name,
     parse_version,
     version_distance,
@@ -761,14 +761,6 @@ def _is_json(path):
         return False
 
 
-def _exit_unless_command_exists(name):
-    """Check if `name` is an executable in PATH"""
-    name_is_in_path = which(name) is not None
-    if not name_is_in_path:
-        LOG.fatal("command '%s' is not in PATH", name)
-        sys.exit(1)
-
-
 ################################################################################
 
 # Whitelist
@@ -868,8 +860,8 @@ def main():
     set_log_verbosity(args.verbose)
 
     # Fail early if following commands are not in path
-    _exit_unless_command_exists("grype")
-    _exit_unless_command_exists("vulnix")
+    exit_unless_command_exists("grype")
+    exit_unless_command_exists("vulnix")
 
     target_path_abs = args.TARGET.resolve().as_posix()
     scanner = VulnScan()

--- a/src/vulnxscan/vulnxscan_cli.py
+++ b/src/vulnxscan/vulnxscan_cli.py
@@ -736,7 +736,7 @@ def _is_patched(row):
 
 def _generate_sbom(target_path, buildtime=False):
     LOG.info("Generating SBOM for target '%s'", target_path)
-    sbomdb = SbomDb(target_path, buildtime, meta_path=None)
+    sbomdb = SbomDb(target_path, buildtime)
     prefix = "vulnxscan_"
     cdx_suffix = ".json"
     csv_suffix = ".csv"

--- a/tests/test_sbomnix.py
+++ b/tests/test_sbomnix.py
@@ -41,6 +41,7 @@ SRCDIR = REPOROOT / "src"
 # pass arguments to.
 SBOMNIX = SRCDIR / "sbomnix" / "main.py"
 NIXGRAPH = SRCDIR / "nixgraph" / "main.py"
+NIXMETA = SRCDIR / "nixmeta" / "main.py"
 NIX_OUTDATED = SRCDIR / "nixupdate" / "nix_outdated.py"
 VULNXSCAN = SRCDIR / "vulnxscan" / "vulnxscan_cli.py"
 REPOLOGY_CLI = SRCDIR / "repology" / "repology_cli.py"
@@ -581,6 +582,36 @@ def test_nix_outdated_result():
         ]
     )
     assert out_path_nix_outdated.exists()
+
+
+################################################################################
+
+
+def test_nixmeta_help():
+    """
+    Test nixmeta command line argument: '-h'
+    """
+    _run_python_script([NIXMETA, "-h"])
+
+
+def test_nixmeta_sbomnix_flakeref():
+    """Test nixmeta with sbomnix flakeref"""
+    out_path = TEST_WORK_DIR / "nixmeta.csv"
+    _run_python_script(
+        [
+            NIXMETA,
+            "--out",
+            out_path.as_posix(),
+            "--flakeref",
+            REPOROOT,
+        ]
+    )
+    assert out_path.exists()
+    # Quick sanity checks for the output data
+    df_meta = df_from_csv_file(out_path)
+    assert df_meta is not None
+    entries = df_meta.shape[0]
+    assert entries > 50000
 
 
 ################################################################################


### PR DESCRIPTION
This change improves the way sbomnix reads nixpkgs metadata:
- Adds command-line tool and python library `nixmeta`, which allows summarizing nixpkgs meta-attributes from the given nixpkgs version.
- Start using local nix metadata cache generated with `nixmeta` based on the given sbomnix target. Additionally, if available, pre-populate the meta cache from an online database, maintained and daily-updated on github.

Made possible by the above changes, this PR removes the `sbomnix` command-line argument `--meta`: meta-information is now automatically added for all sbomnix SBOMs. 

Also worth noting is that this PR changes `sbomnix`, `nixgraph`, `vulnxscan`, and `nix_outdated` so each tool allows specifying the target as [Nix flake reference](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#flake-references) in addition to the earlier nix store path (which is still also supported).

Other smaller changes:
- Start using https://github.com/thombashi/df-diskcache to implement local dataframe cache
- Start using the new meta info in release-asset generation
-  Adds pylint and csvkit to nix devshell

Once this PR is merged, we can close the issue: https://github.com/tiiuae/sbomnix/issues/62.