### PR TITLE
Add extra-experimental-features to nix commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test-ci: check  ## Run CI tests
 	$(call target_success,$@)
 
 check: clean
-	nix --extra-experimental-features flakes flake check
+	nix --extra-experimental-features 'flakes nix-command' flake check
 
 test: ## Run tests
 	pytest -vx tests/
@@ -40,11 +40,11 @@ format: clean ## Reformat with black
 
 release-asset: clean ## Build release asset
 	mkdir -p build/
-	nix run .#sbomnix -- . \
+	nix run --extra-experimental-features 'flakes nix-command' .#sbomnix -- . \
         --cdx=./build/sbom.runtime.cdx.json \
         --spdx=./build/sbom.runtime.spdx.json \
         --csv=./build/sbom.runtime.csv
-	nix run .#sbomnix -- --buildtime . \
+	nix run --extra-experimental-features 'flakes nix-command' .#sbomnix -- --buildtime . \
         --cdx=./build/sbom.buildtime.cdx.json \
         --spdx=./build/sbom.buildtime.spdx.json \
         --csv=./build/sbom.buildtime.csv

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -185,7 +185,9 @@ def try_resolve_flakeref(flakeref, force_realise=False):
     otherwise, returns None.
     """
     LOG.info("Evaluating '%s'", flakeref)
-    cmd = f"nix eval --raw {flakeref}"
+    exp = "--extra-experimental-features flakes "
+    exp += "--extra-experimental-features nix-command"
+    cmd = f"nix eval --raw {flakeref} {exp}"
     ret = exec_cmd(cmd.split(), raise_on_error=False)
     if not ret:
         LOG.debug("not a flakeref: '%s'", flakeref)
@@ -195,7 +197,7 @@ def try_resolve_flakeref(flakeref, force_realise=False):
     if not force_realise:
         return nixpath
     LOG.info("Try force-realising flakeref '%s'", flakeref)
-    cmd = f"nix build --no-link {flakeref}"
+    cmd = f"nix build --no-link {flakeref} {exp}"
     ret = exec_cmd(cmd.split(), raise_on_error=False, return_error=True)
     if not ret:
         LOG.fatal("Failed force_realising %s: %s", flakeref, ret.stderr)

--- a/src/nixmeta/scanner.py
+++ b/src/nixmeta/scanner.py
@@ -126,7 +126,9 @@ def _get_flake_metadata(flakeref):
     if m_nixpkgs:
         flakeref = m_nixpkgs.group(1)
     # Read nix flake metadata as json
-    cmd = f"nix flake metadata {flakeref} --json"
+    exp = "--extra-experimental-features flakes "
+    exp += "--extra-experimental-features nix-command"
+    cmd = f"nix flake metadata {flakeref} --json {exp}"
     ret = exec_cmd(cmd.split(), raise_on_error=False, return_error=True)
     if ret is None or ret.returncode != 0:
         LOG.warning("Failed reading flake metadata: %s", flakeref)

--- a/src/sbomnix/nix.py
+++ b/src/sbomnix/nix.py
@@ -101,9 +101,10 @@ def find_deriver(path):
     if path.endswith(".drv"):
         return path
     # Deriver from QueryValidDerivers
-    ret = exec_cmd(
-        ["nix", "derivation", "show", path], raise_on_error=False, loglevel=LOG_SPAM
-    )
+    exp = "--extra-experimental-features flakes "
+    exp += "--extra-experimental-features nix-command"
+    cmd = f"nix derivation show {path} {exp}"
+    ret = exec_cmd(cmd.split(), raise_on_error=False, loglevel=LOG_SPAM)
     if not ret:
         LOG.log(LOG_SPAM, "Deriver not found for '%s'", path)
         return None


### PR DESCRIPTION
Add `extra-experimental-features` into executed nix commands to support running sbomnix tools on nix installations where flakes and nix-command are not enabled.