### PR TITLE
sbomnix: Do not assume out output is always used

### DIFF
--- a/src/sbomnix/nix.py
+++ b/src/sbomnix/nix.py
@@ -52,7 +52,7 @@ class Store:
             return
         drv_obj = self._get_cached(drv_path)
         if not drv_obj:
-            drv_obj = load(drv_path)
+            drv_obj = load(drv_path, nixpath)
             drv_obj.set_cpe(self.cpe_generator)
             self._add_cached(drv_path, drv=drv_obj)
         assert drv_obj.store_path == drv_path, f"unexpected drv_path: {drv_path}"


### PR DESCRIPTION
Do not assume the derivation's `out` output should always be in the `derivation.py:Derive` outputs list. Instead, only add the outputs of the actually-used outputs.

This change fixes: https://github.com/tiiuae/sbomnix/issues/108.