### PR TITLE
support different nixpkgs locked types

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -213,16 +213,16 @@
         postInstall = ''
 
           wrapProgram $out/bin/sbomnix \
-              --prefix PATH : ${lib.makeBinPath [pkgs.nix pkgs.graphviz]}
+              --prefix PATH : ${lib.makeBinPath [pkgs.git pkgs.nix pkgs.graphviz]}
 
           wrapProgram $out/bin/nixgraph \
               --prefix PATH : ${lib.makeBinPath [pkgs.nix pkgs.graphviz]}
 
           wrapProgram $out/bin/nix_outdated \
-              --prefix PATH : ${lib.makeBinPath [nix-visualize]}
+              --prefix PATH : ${lib.makeBinPath [pkgs.git nix-visualize]}
 
           wrapProgram $out/bin/vulnxscan \
-              --prefix PATH : ${lib.makeBinPath [pkgs.grype pkgs.nix vulnix]}
+              --prefix PATH : ${lib.makeBinPath [pkgs.git pkgs.grype pkgs.nix vulnix]}
 
           wrapProgram $out/bin/provenance \
               --prefix PATH : ${lib.makeBinPath [pkgs.nix]}


### PR DESCRIPTION
Avoid hard-coding the `nixpkgs` flakeref to `github:NixOS/nixpkgs` in order to handle alternate `nixpkgs` locations.