### PR TITLE
Avoid double wrapping

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -210,23 +210,11 @@
 
         pythonImportsCheck = ["sbomnix"];
 
-        postInstall = ''
-
-          wrapProgram $out/bin/sbomnix \
-              --prefix PATH : ${lib.makeBinPath [pkgs.git pkgs.nix pkgs.graphviz]}
-
-          wrapProgram $out/bin/nixgraph \
-              --prefix PATH : ${lib.makeBinPath [pkgs.nix pkgs.graphviz]}
-
-          wrapProgram $out/bin/nix_outdated \
-              --prefix PATH : ${lib.makeBinPath [pkgs.git nix-visualize]}
-
-          wrapProgram $out/bin/vulnxscan \
-              --prefix PATH : ${lib.makeBinPath [pkgs.git pkgs.grype pkgs.nix vulnix]}
-
-          wrapProgram $out/bin/provenance \
-              --prefix PATH : ${lib.makeBinPath [pkgs.nix]}
-        '';
+        makeWrapperArgs = [
+          "--prefix PATH : ${lib.makeBinPath (with pkgs; [
+            git nix graphviz nix-visualize vulnix grype
+          ])}"
+        ];
       };
       # a python with all python packages imported by sbomnix itself
       python = pkgs.python3.withPackages (ps:

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -212,7 +212,12 @@
 
         makeWrapperArgs = [
           "--prefix PATH : ${lib.makeBinPath (with pkgs; [
-            git nix graphviz nix-visualize vulnix grype
+            git
+            nix
+            graphviz
+            nix-visualize
+            vulnix
+            grype
           ])}"
         ];
       };


### PR DESCRIPTION
`buildPythonPackage` already [accepts makeWrapperArgs](https://github.com/NixOS/nixpkgs/blob/8ef21e88b600a3a2f7403da0275d54dab1400fef/pkgs/development/interpreters/python/mk-python-derivation.nix#L111-L113) which then get applied as part of the [wrap python scripts shell hook](https://github.com/NixOS/nixpkgs/blob/8c116c6112f09a538b8b20db8938a42942a6d88b/pkgs/development/interpreters/python/wrap.sh#L82-L94)

Cleans up the bin directory a bit:
```
# After
[23:20:01] jringer@jringer-5560-nixos ~/work/sbomnix (avoid-double-wrapping)
$ ls -a ./result/bin/
.nix_outdated-wrapped  .provenance-wrapped    .sbomnix-wrapped    nixgraph    repology_cli  vulnxscan
.nixgraph-wrapped      .repology_cli-wrapped  .vulnxscan-wrapped  nixmeta     repology_cve  
.nixmeta-wrapped       .repology_cve-wrapped  nix_outdated        provenance  sbomnix   

# Before
[23:20:55] jringer@jringer-5560-nixos ~/work/sbomnix (main)
$ ls -a ./result/bin/
..nix_outdated-wrapped-wrapped  .nix_outdated-wrapped  .repology_cve-wrapped  nixmeta       vulnxscan
..nixgraph-wrapped-wrapped      .nixgraph-wrapped      .sbomnix-wrapped       provenance    
..provenance-wrapped-wrapped    .nixmeta-wrapped       .vulnxscan-wrapped     repology_cli  
..sbomnix-wrapped-wrapped       .provenance-wrapped    nix_outdated           repology_cve  
..vulnxscan-wrapped-wrapped     .repology_cli-wrapped  nixgraph               sbomnix 
```