### PR TITLE
CDX: ensure metadata property is a string

### DIFF
--- a/src/sbomnix/sbomdb.py
+++ b/src/sbomnix/sbomdb.py
@@ -183,7 +183,7 @@ class SbomDb:
         if self.depth:
             prop = {}
             prop["name"] = "sbom_dependencies_depth"
-            prop["value"] = self.depth
+            prop["value"] = str(self.depth)
             cdx["metadata"]["properties"].append(prop)
         tool = {}
         tool["vendor"] = "TII"


### PR DESCRIPTION
To match upstream spec https://cyclonedx.org/docs/1.4/json/#metadata_properties_items_value