### PR TITLE
CDX: use library as component default

### DIFF
--- a/src/sbomnix/cdx.py
+++ b/src/sbomnix/cdx.py
@@ -82,7 +82,7 @@ def _cdx_component_add_patches(component, drv):
 def _drv_to_cdx_component(drv, uid="store_path"):
     """Convert one entry from sbomdb (drv) to cdx component"""
     component = {}
-    component["type"] = "application"
+    component["type"] = "library"
     component["bom-ref"] = getattr(drv, uid)
     component["name"] = drv.pname
     component["version"] = drv.version


### PR DESCRIPTION
Library is the preferred default according to the spec: https://cyclonedx.org/docs/1.4/json/#components_items_type