### PR TITLE
Fix DataFrameDiskCache locking

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -198,6 +198,7 @@
           ++ (with pp; [
             beautifulsoup4
             colorlog
+            filelock
             graphviz
             numpy
             packageurl-python
@@ -226,6 +227,7 @@
         (with ps; [
           beautifulsoup4
           colorlog
+          filelock
           graphviz
           numpy
           packageurl-python

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ with open(project_path("VERSION"), encoding="utf-8") as f:
 requires = [
     "beautifulsoup4",
     "colorlog",
+    "filelock",
     "graphviz",
     "numpy",
     "pandas",

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -14,8 +14,6 @@ import csv
 import logging
 import subprocess
 import importlib.metadata
-import pathlib
-import tempfile
 import urllib.error
 from shutil import which
 
@@ -32,9 +30,6 @@ from requests_ratelimiter import LimiterMixin
 
 LOG_SPAM = logging.DEBUG - 1
 LOG = logging.getLogger(os.path.abspath(__file__))
-
-# DataFrameDiskCache cache local path
-DFCACHE_PATH = pathlib.Path(tempfile.gettempdir()) / "sbomnix_df_cache"
 
 ###############################################################################
 

--- a/src/sbomnix/dfcache.py
+++ b/src/sbomnix/dfcache.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2022-2024 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=too-few-public-methods
+
+"""Thread-safe DataFrameDiskCache"""
+
+import pathlib
+import tempfile
+from getpass import getuser
+
+from filelock import FileLock
+from dfdiskcache import DataFrameDiskCache
+
+###############################################################################
+
+# DataFrameDiskCache cache local path and lock file
+DFCACHE_PATH = pathlib.Path(tempfile.gettempdir()) / f"{getuser()}_sbomnix_df_cache"
+DFCACHE_LOCK = DFCACHE_PATH / "dfcache.lock"
+
+################################################################################
+
+
+class LockedDfCache:
+    """Thread-safe (and process-safe) wrapper for DataFrameDiskCache"""
+
+    def __init__(self):
+        self.dflock = FileLock(DFCACHE_LOCK)
+
+    def __getattr__(self, name):
+
+        def wrap(*a, **k):
+            with self.dflock:
+                # We intentionally do not store the dfcache as object variable
+                # but re-instantiate it every time any LockedDfCache method
+                # is called. DataFrameDiskCache internally makes use of sqlite
+                # which does not allow concurrent connections to the database.
+                # Having the dfcache initiated once in __init__() and then
+                # re-used here would mean the connection would remain reserved
+                # for the first thread making other threads throw with
+                # 'database locked' etc. even if we otherwise protect
+                # concurrent writes.
+                dfcache = DataFrameDiskCache(cache_dir_path=DFCACHE_PATH)
+                return getattr(dfcache, name)(*a, **k)
+
+        return wrap
+
+
+###############################################################################


### PR DESCRIPTION
Use [FileLock](https://github.com/tox-dev/filelock) to synchronize access to the shared dataframe cache to allow running sbomnix concurrently.
Remove retry logic introduced in https://github.com/tiiuae/sbomnix/pull/118 as it's now unnecessary.