### PR TITLE
sbomnix: expose `--include-vulns` flag

### DIFF
--- a/src/sbomnix/main.py
+++ b/src/sbomnix/main.py
@@ -48,6 +48,8 @@ def getargs():
     parser.add_argument("--version", action="version", version=get_py_pkg_version())
     helps = "Set the debug verbosity level between 0-3 (default: --verbose=1)"
     parser.add_argument("--verbose", help=helps, type=int, default=1)
+    helps = "Include vulnerabilities in the output of CyloneDX SBOM"
+    parser.add_argument("--include-vulns", help=helps, action="store_true")
 
     group = parser.add_argument_group("output arguments")
     helps = "Path to csv output file (default: ./sbom.csv)"
@@ -80,7 +82,7 @@ def main():
         buildtime=args.buildtime,
         depth=args.depth,
         flakeref=flakeref,
-        include_vulns=True,
+        include_vulns=args.include_vulns,
     )
     if args.cdx:
         sbomdb.to_cdx(args.cdx)


### PR DESCRIPTION
Exposes `--include-vulns` flag in the `sbomnix` cli so users can enable/disable including vulnerabilities in CycloneDX SBOMs