### PR TITLE
Fix sbomnix --depth with buildtime dependencies

### DIFF
--- a/src/sbomnix/nix.py
+++ b/src/sbomnix/nix.py
@@ -81,10 +81,6 @@ class Store:
             self._add_cached(nixpath, drv=None)
             return
         self._update(drv_path, nixpath)
-        if self.buildtime:
-            ret = exec_cmd(["nix-store", "-qR", drv_path])
-            for candidate in ret.stdout.splitlines():
-                self._update(candidate)
 
     def to_dataframe(self):
         """Return store derivations as pandas dataframe"""


### PR DESCRIPTION
Remove unnecessary optimization from sbomnix, which broke the `sbomnix` command line option `--depth` when used together with `--buildtime` option.

The removed optimization caused `--buildtime` sboms to always include the full closure (all buildtime dependencies) even if `--depth` was specified, requesting dependencies only up until specified depth in the dependency graph.