### PR TITLE
osv: Skip osv query if package version is unknown

### DIFF
--- a/src/vulnxscan/osv.py
+++ b/src/vulnxscan/osv.py
@@ -97,6 +97,9 @@ class OSV:
         batchquery = {}
         batchquery["queries"] = []
         for drv in df_sbom.itertuples():
+            if not drv.version:
+                LOG.debug("skipping osv query (unknown version): %s", drv.name)
+                continue
             query = {}
             query["version"] = drv.version
             query["package"] = {}


### PR DESCRIPTION
OSV API now requires the package version and would return an error status in case the package version is missing.