### PR TITLE
Improve pytest test execution time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,14 @@ pre-push: test check  ## Run tests and flake checks
 	$(call target_success,$@)
 
 test-ci: check  ## Run CI tests
-	pytest -vx -k "not skip_in_ci" tests/
+	pytest -n auto -vx -k "not skip_in_ci" tests/
 	$(call target_success,$@)
 
 check: clean
 	nix --extra-experimental-features 'flakes nix-command' flake check
 
 test: ## Run tests
-	pytest -vx tests/
+	pytest -n auto -vx tests/
 	$(call target_success,$@)
 
 release-asset: clean ## Build release asset

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ test-ci: check  ## Run CI tests
 check: clean
 	nix --extra-experimental-features 'flakes nix-command' flake check
 
+test-smoke: ## Run smoke tests
+	pytest -n auto -vx -k "not slow" tests/
+	$(call target_success,$@)
+
 test: ## Run tests
 	pytest -n auto -vx tests/
 	$(call target_success,$@)

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -35,6 +35,7 @@
             [
               jsonschema
               pytest
+              pytest-xdist
             ]
             ++ prefix_path;
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,4 @@
 pythonpath = .
 markers =
     skip_in_ci: indicates test should not be run in ci.
+    slow: indicates a slow tests.

--- a/tests/test_sbomnix.py
+++ b/tests/test_sbomnix.py
@@ -123,6 +123,7 @@ def test_sbomnix_type_runtime():
     validate_json(out_path_spdx.as_posix(), spdx_schema_path)
 
 
+@pytest.mark.slow
 def test_sbomnix_type_buildtime():
     """Test sbomnix generates valid CycloneDX json with buildtime dependencies"""
     out_path_cdx = TEST_WORK_DIR / "sbom_cdx_test.json"
@@ -301,6 +302,7 @@ def test_compare_deps_runtime():
     )
 
 
+@pytest.mark.slow
 def test_compare_deps_buildtime():
     """Compare nixgraph vs sbom buildtime dependencies"""
     graph_csv_out = TEST_WORK_DIR / "graph.csv"
@@ -339,6 +341,7 @@ def test_compare_deps_buildtime():
     )
 
 
+@pytest.mark.slow
 def test_compare_subsequent_cdx_sboms():
     """Compare two sbomnix runs with same target produce the same cdx sbom"""
     out_path_cdx_1 = TEST_WORK_DIR / "sbom_cdx_test_1.json"
@@ -374,6 +377,7 @@ def test_compare_subsequent_cdx_sboms():
     )
 
 
+@pytest.mark.slow
 def test_compare_subsequent_spdx_sboms():
     """Compare two sbomnix runs with same target produce the same spdx sbom"""
     out_path_spdx_1 = TEST_WORK_DIR / "sbom_spdx_test_1.json"
@@ -409,6 +413,7 @@ def test_compare_subsequent_spdx_sboms():
     )
 
 
+@pytest.mark.slow
 def test_compare_spdx_and_cdx_sboms():
     """Compare spdx and cdx sboms from the same sbomnix invocation"""
     out_path_spdx = TEST_WORK_DIR / "sbom_spdx_test.json"
@@ -531,6 +536,7 @@ def test_repology_cli_help():
     _run_python_script([REPOLOGY_CLI, "-h"])
 
 
+@pytest.mark.slow
 def test_repology_cli_sbom():
     """Test repology_cli with SBOM as input"""
     out_path_cdx = TEST_WORK_DIR / "sbom_cdx_test.json"
@@ -569,6 +575,7 @@ def test_nix_outdated_help():
     _run_python_script([NIX_OUTDATED, "-h"])
 
 
+@pytest.mark.slow
 def test_nix_outdated_result():
     """Test nix_outdated with TEST_NIX_RESULT as input"""
     out_path_nix_outdated = TEST_WORK_DIR / "nix_outdated.csv"
@@ -593,6 +600,7 @@ def test_nixmeta_help():
     _run_python_script([NIXMETA, "-h"])
 
 
+@pytest.mark.slow
 def test_nixmeta_sbomnix_flakeref():
     """Test nixmeta with sbomnix flakeref"""
     out_path = TEST_WORK_DIR / "nixmeta.csv"


### PR DESCRIPTION
Improve pytest test execution time:
- Run pytest tests in parallel
- Add a Makefile target `test-smoke` to allow running a quick test against sbomnix tools

Should be merged after https://github.com/tiiuae/sbomnix/pull/146.