### PR TITLE
Replace reuse dep5 with REUSE.toml

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,9 +1,0 @@
-Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-
-Copyright: 2023 Technology Innovation Institute (TII)
-License: CC-BY-3.0
-Files: doc/img/*
-
-Copyright: 2023 Technology Innovation Institute (TII)
-License: Apache-2.0
-Files: *.lock *.csv *.json VERSION

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+version = 1
+SPDX-PackageName = "sbomnix"
+SPDX-PackageSupplier = "Technology Innovation Institute <https://tii.ae>"
+SPDX-PackageDownloadLocation = "https://github.com/tiiuae/sbomnix"
+
+[[annotations]]
+SPDX-License-Identifier = "CC-BY-3.0"
+SPDX-FileCopyrightText = "2022-2025 Technology Innovation Institute (TII)"
+precedence = "closest"
+path = [
+  "doc/img/*",
+]
+
+[[annotations]]
+SPDX-License-Identifier = "Apache-2.0"
+SPDX-FileCopyrightText = "2022-2025 Technology Innovation Institute (TII)"
+precedence = "closest"
+path = [
+  "flake.lock",
+  "VERSION",
+  "tests/resources/**",
+]


### PR DESCRIPTION
Reuse dep5 is [deprecated](https://reuse.software/spec-3.2/#dep5-deprecated): replace reuse dep5 with [REUSE.toml](https://reuse.software/spec-3.2/#reusetoml)