### PR TITLE
Stop using nixmeta csv, ensure no aliases in meta

### DIFF
--- a/src/nixmeta/scanner.py
+++ b/src/nixmeta/scanner.py
@@ -58,8 +58,18 @@ class NixMetaScanner:
         prefix = "nixmeta_"
         suffix = ".json"
         with NamedTemporaryFile(delete=True, prefix=prefix, suffix=suffix) as f:
-            cmd = f"nix-env -qa --meta --json -f {nixpkgs_path.as_posix()}"
-            exec_cmd(cmd.split(), stdout=f)
+            cmd = [
+                "nix-env",
+                "-qa",
+                "--meta",
+                "--json",
+                "-f",
+                f"{nixpkgs_path.as_posix()}",
+                "--arg",
+                "config",
+                "{allowAliases=false;}",
+            ]
+            exec_cmd(cmd, stdout=f)
             LOG.debug("Generated meta.json: %s", f.name)
             self.df_meta = _parse_json_metadata(f.name)
             self._drop_duplicates()


### PR DESCRIPTION
- Do not attempt to read the nix meta info from `_NIXMETA_CSV_URL`; instead, always generate the meta with `nix-env` caching it locally
- When running `nix-env`, use `--arg config {allowAliases=false};` to ensure no aliases are in the results. This gets rid of the evaluation warnings that earlier occurred when the local meta cache was updated.