### PR TITLE
Allow network-less output, and produce stable output

### DIFF
--- a/src/sbomnix/cpe.py
+++ b/src/sbomnix/cpe.py
@@ -25,7 +25,15 @@ _CPE_CSV_CACHE_TTL = 60 * 60 * 24
 class CPE:
     """Generate Common Platform Enumeration identifiers"""
 
-    def __init__(self):
+    def __init__(
+        self,
+        include_cpe=True,
+    ):
+        # Let's initialize the fields anyway.
+        if not include_cpe:
+            self.df_cpedict = None
+            return
+
         self.cache = LockedDfCache()
         self.df_cpedict = self.cache.get(_CPE_CSV_URL)
         if self.df_cpedict is not None and not self.df_cpedict.empty:

--- a/src/sbomnix/main.py
+++ b/src/sbomnix/main.py
@@ -51,6 +51,10 @@ def getargs():
     parser.add_argument("--verbose", help=helps, type=int, default=1)
     helps = "Include vulnerabilities in the output of CyloneDX SBOM"
     parser.add_argument("--include-vulns", help=helps, action="store_true")
+    helps = "Exclude Nixpkgs metadata information in the output"
+    parser.add_argument(
+        "--exclude-meta", help=helps, action="store_true", default=False
+    )
 
     group = parser.add_argument_group("output arguments")
     helps = "Path to csv output file (default: ./sbom.csv)"
@@ -87,6 +91,7 @@ def main():
         buildtime=args.buildtime,
         depth=args.depth,
         flakeref=flakeref,
+        include_meta=not args.exclude_meta,
         include_vulns=args.include_vulns,
     )
     if args.cdx:

--- a/src/sbomnix/main.py
+++ b/src/sbomnix/main.py
@@ -55,6 +55,10 @@ def getargs():
     parser.add_argument(
         "--exclude-meta", help=helps, action="store_true", default=False
     )
+    helps = "Exclude using heuristics-based CPE matches in the output"
+    parser.add_argument(
+        "--exclude-cpe-matching", help=helps, action="store_true", default=False
+    )
 
     group = parser.add_argument_group("output arguments")
     helps = "Path to csv output file (default: ./sbom.csv)"
@@ -93,6 +97,7 @@ def main():
         flakeref=flakeref,
         include_meta=not args.exclude_meta,
         include_vulns=args.include_vulns,
+        include_cpe=not args.exclude_cpe_matching,
     )
     if args.cdx:
         sbomdb.to_cdx(args.cdx)

--- a/src/sbomnix/nix.py
+++ b/src/sbomnix/nix.py
@@ -21,10 +21,10 @@ from sbomnix.derivation import load
 class Store:
     """Nix store"""
 
-    def __init__(self, buildtime=False):
+    def __init__(self, buildtime=False, include_cpe=True):
         self.buildtime = buildtime
         self.derivations = {}
-        self.cpe_generator = CPE()
+        self.cpe_generator = CPE(include_cpe=include_cpe)
 
     def _add_cached(self, path, drv):
         LOG.log(LOG_SPAM, "caching path - %s:%s", path, drv)

--- a/src/sbomnix/sbomdb.py
+++ b/src/sbomnix/sbomdb.py
@@ -30,6 +30,12 @@ from vulnxscan.vulnscan import VulnScan
 
 ###############################################################################
 
+# Namespace UUID (a UUIDv4) for stable UUIDv5 identifiers.
+# See RFC9562, *6.6.  Namespace ID Usage and Allocation*.
+SBOMNIX_UUID_NAMESPACE = uuid.UUID("136af32e-0d0e-48bc-912c-31b26af294b9")
+
+###############################################################################
+
 
 class SbomDb:
     """Generates SBOMs in various formats"""
@@ -58,7 +64,9 @@ class SbomDb:
         self.meta = None
         self._init_sbomdb(include_meta)
         self.include_vulns = include_vulns
-        self.uuid = uuid.uuid4()
+        # This uses a UUIDv5, which uses the deriver's store path as its input,
+        # resulting in a stable UUID across runs, depending on the SBOM's subject.
+        self.uuid = uuid.uuid5(SBOMNIX_UUID_NAMESPACE, self.target_deriver)
         self.sbom_type = "runtime_and_buildtime"
         if not self.buildtime:
             self.sbom_type = "runtime_only"

--- a/src/sbomnix/sbomdb.py
+++ b/src/sbomnix/sbomdb.py
@@ -64,9 +64,16 @@ class SbomDb:
         self.meta = None
         self._init_sbomdb(include_meta)
         self.include_vulns = include_vulns
-        # This uses a UUIDv5, which uses the deriver's store path as its input,
-        # resulting in a stable UUID across runs, depending on the SBOM's subject.
-        self.uuid = uuid.uuid5(SBOMNIX_UUID_NAMESPACE, self.target_deriver)
+        # Use a random UUID as the serial number when any data source that is
+        # not strictly coming from the target_deriver is used
+        if include_vulns or include_meta:
+            LOG.info("Using random UUIDv4")
+            self.uuid = uuid.uuid4()
+        else:
+            LOG.info("Using stable UUIDv5 for '%s'", self.target_deriver)
+            # This uses a UUIDv5, which uses the deriver's store path as its input,
+            # resulting in a stable UUID across runs, depending on the SBOM's subject.
+            self.uuid = uuid.uuid5(SBOMNIX_UUID_NAMESPACE, self.target_deriver)
         self.sbom_type = "runtime_and_buildtime"
         if not self.buildtime:
             self.sbom_type = "runtime_only"

--- a/src/sbomnix/sbomdb.py
+++ b/src/sbomnix/sbomdb.py
@@ -48,6 +48,7 @@ class SbomDb:
         flakeref=None,
         include_meta=True,
         include_vulns=False,
+        include_cpe=True,
     ):
         # self.uid specifies the attribute that SbomDb uses as unique
         # identifier for the sbom components. See the column names in
@@ -62,11 +63,12 @@ class SbomDb:
         self.df_sbomdb_outputs_exploded = None
         self.flakeref = flakeref
         self.meta = None
+        self.include_cpe = include_cpe
         self._init_sbomdb(include_meta)
         self.include_vulns = include_vulns
         # Use a random UUID as the serial number when any data source that is
         # not strictly coming from the target_deriver is used
-        if include_vulns or include_meta:
+        if include_vulns or include_meta or include_cpe:
             LOG.info("Using random UUIDv4")
             self.uuid = uuid.uuid4()
         else:
@@ -111,7 +113,7 @@ class SbomDb:
             target_paths = self.df_deps["target_path"].unique().tolist()
             paths = set(src_paths + target_paths)
         # Populate store based on the dependencies
-        store = Store(self.buildtime)
+        store = Store(self.buildtime, include_cpe=self.include_cpe)
         for path in paths:
             store.add_path(path)
         self.df_sbomdb = store.to_dataframe()


### PR DESCRIPTION
These two features are somewhat intrinsically linked in that they allow using `sbomnix` from within Nix sandbox builds (with additional careful work). I can split them into discrete PRs if it would be preferred.

This helps with (but does not solve) #139 and #106.

These are the changes that should be considered uncontroversial to enable doing just this.

* * *

### Network-less output

This is pretty self-explanatory: within the Nix sandbox there is no arbitrary network access possible. So these changes make it possible to work without those resources.

Note that there is a subtlety that could easily be missed, and why I chose to *just* disable the features instead of allowing the resources to be provided in some other form: relying on these arbitrary-in-time snapshots produces different outputs for the same input, in time.

That is, if there was a magical `magicallyMakeSbom { input = /* a derivation */; }` function, unless there was a way to rebuild the exact metadata *matched to some moment in time*, it would not be *correct*. Consider what happens when you run `sbomnix` today on a derivation, and in 2 months on the same exact derivation. This is compounded by the fact that those resources end-up applied with mismatched inputs compared to the inputs used for a given store path.

> A simplified example, but if you had `nixos-22.05` and `nixos-24.05` in your inputs, and had a derivation relying on each of their own `hello`, the way the `metadata` matching works, unless I'm mistaken, [would attach *the `nix-env -qa --meta` from a single "ambient" Nixpkgs* to the data](https://github.com/tiiuae/sbomnix/blob/fe4e3fd9f788f493f7d8194840a688fb30447cff/src/sbomnix/meta.py#L53-L59).

I believe the chosen options are forward-facing and even if passing specific data to either meta or CPEs is added, the given flags can be kept.


### Reproducible output

Ignoring the metadata provenance issue (which could be fixed), this PR also removes the last (non-timestamp) source of reproducibility issue.

[The commit introducing the change explains the rationale more](https://github.com/tiiuae/sbomnix/commit/7b63824b35bdb414825dc578ed9ef33865f6819f). The brief version is that we're using the deriver's store path (when available) to generate a stable UUIDv5. The follow-up commits puts back an UUIDv4 hash when arbitrary inputs are used.

This does *slightly* go against the text of the spec for CDX SBOMs, but only because they may have not considered the situation where a given SBOM is naturally stable due to the involved tooling.

It might make sense to review this slightly, and include *another* input in the UUIDv5 hash, so that when `sbomnix` itself changes, the serial identifier changes accordingly. Though I believe that might not be “good” either. It would be ideal if the SBOM did not change when its intent has not changed.

So it might make more sense to produce most of the data, except `sbomnix`'s own `metadata.tools` entry, and ***hash that***. This way, even if `sbomnix` updates to a next version, as long as the data it produced is the same, the serial would be the same. Note that in this case, the `timestamp` would be hashed too. Which means that for a process where the timestamp matters, the stable `UUIDv5` scheme would still produce a new UUID. It would truly stay stable when (1) the data is the exact same, and (2) the timestamp is kept static

Why is reproducible output worthwhile here? First, because it was trivial enough, since only the UUIDv4 differed when the exact same `sbomnix` built the SBOM. But really, because it trivializes verifying the SBOM was made 


### About the timestamp

`libfaketime`.

I thought it didn't make sense to add more complexity to these changes, when an alternative already exists.

If it was to be implemented in the future, using [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/) as the timestamp (when it exists) probably would make the most sense.


* * *

### About using in a sandbox build

This PR is sufficient as far as sbomnix is concerned.

There are other things to do to make the environment sensible for `nix`, which `sbomnix` relies upon. This is out of scope for these changes.