### PR TITLE
Improve exec_cmd logging

### DIFF
--- a/src/nixmeta/scanner.py
+++ b/src/nixmeta/scanner.py
@@ -132,7 +132,9 @@ def _get_flake_metadata(flakeref):
     exp = "--extra-experimental-features flakes "
     exp += "--extra-experimental-features nix-command"
     cmd = f"nix flake metadata {flakeref} --json {exp}"
-    ret = exec_cmd(cmd.split(), raise_on_error=False, return_error=True)
+    ret = exec_cmd(
+        cmd.split(), raise_on_error=False, return_error=True, log_error=False
+    )
     if ret is None or ret.returncode != 0:
         LOG.warning("Failed reading flake metadata: %s", flakeref)
         return None

--- a/src/sbomnix/nix.py
+++ b/src/sbomnix/nix.py
@@ -101,7 +101,7 @@ def find_deriver(path):
     exp = "--extra-experimental-features flakes "
     exp += "--extra-experimental-features nix-command"
     cmd = f"nix derivation show {path} {exp}"
-    ret = exec_cmd(cmd.split(), raise_on_error=False, loglevel=LOG_SPAM)
+    ret = exec_cmd(cmd.split(), raise_on_error=False, log_error=False)
     if not ret:
         LOG.log(LOG_SPAM, "Deriver not found for '%s'", path)
         return None

--- a/src/vulnxscan/vulnscan.py
+++ b/src/vulnxscan/vulnscan.py
@@ -81,7 +81,7 @@ class VulnScan:
         # Therefore, we need to set the raise_on_error=False and
         # return_error=True to be able to read the vulnerabilities
         # from vulnix stdout even if the exit status indicates failure.
-        ret = exec_cmd(cmd, raise_on_error=False, return_error=True)
+        ret = exec_cmd(cmd, raise_on_error=False, return_error=True, log_error=False)
         if ret and hasattr(ret, "stderr") and ret.stderr:
             LOG.warning(ret)
             LOG.warning(ret.stderr)


### PR DESCRIPTION
Change `utils.exec_cmd()` to log error by default, still making it possible for the caller to explicitly ask to not log errors to cover cases where errors are expected. Before this PR, the error was only logged if verbosity was set to DEBUG or more verbose which hid important details on unexpected errors.