### PR TITLE
vulnxscan: Skip osv parse if vulns is missing

### DIFF
--- a/src/vulnxscan/osv.py
+++ b/src/vulnxscan/osv.py
@@ -57,6 +57,8 @@ class OSV:
                 continue
             LOG.debug("package: %s", package)
             LOG.debug("vulns: %s", vulns)
+            if "vulns" not in vulns:
+                continue
             self._parse_vulns(package, vulns)
 
     def _post_batch_query(self, query):


### PR DESCRIPTION
Skip osv parse if 'vulns' is missing from the batch query response.