### PR TITLE
Skip OSV scan due to false positives

### DIFF
--- a/src/sbomnix/sbomdb.py
+++ b/src/sbomnix/sbomdb.py
@@ -241,11 +241,10 @@ class SbomDb:
             ) as fcdx:
                 self._write_json(fcdx.name, cdx, printinfo=False)
                 scanner.scan_grype(fcdx.name)
-                scanner.scan_osv(fcdx.name)
             cdx["vulnerabilities"] = []
             # Union all scans into a single dataframe
             df_vulns = pd.concat(
-                [scanner.df_grype, scanner.df_osv, scanner.df_vulnix],
+                [scanner.df_grype, scanner.df_vulnix],
                 ignore_index=True,
             )
         if df_vulns is not None and not df_vulns.empty:

--- a/src/vulnxscan/utils.py
+++ b/src/vulnxscan/utils.py
@@ -59,7 +59,7 @@ def _vuln_sortcol(row):
 def _vuln_url(row):
     osv_url = "https://osv.dev/"
     nvd_url = "https://nvd.nist.gov/vuln/detail/"
-    if "cve" in row.vuln_id.lower():
+    if row.vuln_id.lower().startswith("cve"):
         return f"{nvd_url}{row.vuln_id}"
     if getattr(row, "osv", False) or ("osv" in getattr(row, "scanner", [])):
         return f"{osv_url}{row.vuln_id}"
@@ -67,7 +67,7 @@ def _vuln_url(row):
 
 
 def _vuln_source(row):
-    if "cve" in row.vuln_id.lower():
+    if row.vuln_id.lower().startswith("cve"):
         return "NVD"
     if getattr(row, "osv", False) or ("osv" in getattr(row, "scanner", [])):
         return "OSV"

--- a/src/vulnxscan/vulnxscan_cli.py
+++ b/src/vulnxscan/vulnxscan_cli.py
@@ -148,7 +148,6 @@ def main():
         LOG.debug("Using csv SBOM '%s'", sbom_csv_path)
         scanner.scan_vulnix(target_path, args.buildtime)
     scanner.scan_grype(sbom_cdx_path)
-    scanner.scan_osv(sbom_cdx_path)
     scanner.report(args, sbom_csv_path)
     if not args.sbom and LOG.level > logging.DEBUG:
         # Remove generated temp files unless verbosity is DEBUG or more verbose


### PR DESCRIPTION
OSV scan currently returns many false positives. This PR makes vulnxscan (and sbomnix --include-vulns) completely skip the OSV scan until we come up with a better way to limit the OSV scan results to make the OSV results meaningful again.