### PR TITLE
Clean up temp SBOM handling in vuln scans

### DIFF
--- a/src/sbomnix/sbomdb.py
+++ b/src/sbomnix/sbomdb.py
@@ -12,6 +12,7 @@
 import argparse
 import json
 import logging
+import pathlib
 import re
 import uuid
 from datetime import datetime, timezone
@@ -236,12 +237,18 @@ class SbomDb:
             scanner = VulnScan()
             scanner.scan_vulnix(self.target_deriver, self.buildtime)
             # Write incomplete sbom to a temporary path, then perform a vulnerability scan
-            with NamedTemporaryFile(
-                delete=False, prefix="vulnxscan_", suffix=".json"
-            ) as fcdx:
-                self._write_json(fcdx.name, cdx, printinfo=False)
-                scanner.scan_grype(fcdx.name)
-                scanner.scan_osv(fcdx.name)
+            temp_cdx_path = None
+            try:
+                with NamedTemporaryFile(
+                    delete=False, prefix="vulnxscan_", suffix=".json"
+                ) as fcdx:
+                    temp_cdx_path = pathlib.Path(fcdx.name)
+                    self._write_json(temp_cdx_path, cdx, printinfo=False)
+                scanner.scan_grype(temp_cdx_path)
+                scanner.scan_osv(temp_cdx_path)
+            finally:
+                if temp_cdx_path is not None:
+                    temp_cdx_path.unlink(missing_ok=True)
             cdx["vulnerabilities"] = []
             # Union all scans into a single dataframe
             df_vulns = pd.concat(

--- a/src/vulnxscan/vulnxscan_cli.py
+++ b/src/vulnxscan/vulnxscan_cli.py
@@ -103,13 +103,24 @@ def _generate_sbom(target_path, buildtime=False):
     prefix = "vulnxscan_"
     cdx_suffix = ".json"
     csv_suffix = ".csv"
-    with (
-        NamedTemporaryFile(delete=False, prefix=prefix, suffix=cdx_suffix) as fcdx,
-        NamedTemporaryFile(delete=False, prefix=prefix, suffix=csv_suffix) as fcsv,
-    ):
-        sbomdb.to_cdx(fcdx.name, printinfo=False)
-        sbomdb.to_csv(fcsv.name, loglevel=logging.DEBUG)
-        return pathlib.Path(fcdx.name), pathlib.Path(fcsv.name)
+    sbom_cdx_path = None
+    sbom_csv_path = None
+    try:
+        with NamedTemporaryFile(delete=False, prefix=prefix, suffix=cdx_suffix) as fcdx:
+            sbom_cdx_path = pathlib.Path(fcdx.name)
+            with NamedTemporaryFile(
+                delete=False, prefix=prefix, suffix=csv_suffix
+            ) as fcsv:
+                sbom_csv_path = pathlib.Path(fcsv.name)
+                sbomdb.to_cdx(sbom_cdx_path, printinfo=False)
+                sbomdb.to_csv(sbom_csv_path, loglevel=logging.DEBUG)
+        return sbom_cdx_path, sbom_csv_path
+    except Exception:
+        if sbom_cdx_path is not None:
+            sbom_cdx_path.unlink(missing_ok=True)
+        if sbom_csv_path is not None:
+            sbom_csv_path.unlink(missing_ok=True)
+        raise
 
 
 ################################################################################
@@ -128,15 +139,16 @@ def main():
     exit_unless_command_exists("vulnix")
 
     scanner = VulnScan()
+    sbom_cdx_path = None
+    sbom_csv_path = None
     if args.sbom:
         target_path = pathlib.Path(args.TARGET).resolve().as_posix()
         if not _is_json(target_path):
             LOG.fatal(
                 "Specified sbom target is not a json file: '%s'", str(args.TARGET)
             )
-            sys.exit(0)
+            sys.exit(1)
         sbom_cdx_path = target_path
-        sbom_csv_path = None
     else:
         runtime = args.buildtime is False
         target_path = try_resolve_flakeref(args.TARGET, force_realise=runtime)
@@ -146,14 +158,17 @@ def main():
         sbom_cdx_path, sbom_csv_path = _generate_sbom(target_path, args.buildtime)
         LOG.debug("Using cdx SBOM '%s'", sbom_cdx_path)
         LOG.debug("Using csv SBOM '%s'", sbom_csv_path)
-        scanner.scan_vulnix(target_path, args.buildtime)
-    scanner.scan_grype(sbom_cdx_path)
-    scanner.scan_osv(sbom_cdx_path)
-    scanner.report(args, sbom_csv_path)
-    if not args.sbom and LOG.level > logging.DEBUG:
-        # Remove generated temp files unless verbosity is DEBUG or more verbose
-        sbom_cdx_path.unlink(missing_ok=True)
-        sbom_csv_path.unlink(missing_ok=True)
+    try:
+        if not args.sbom:
+            scanner.scan_vulnix(target_path, args.buildtime)
+        scanner.scan_grype(sbom_cdx_path)
+        scanner.scan_osv(sbom_cdx_path)
+        scanner.report(args, sbom_csv_path)
+    finally:
+        if not args.sbom and LOG.level > logging.DEBUG:
+            # Remove generated temp files unless verbosity is DEBUG or more verbose
+            sbom_cdx_path.unlink(missing_ok=True)
+            sbom_csv_path.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_sbomnix.py
+++ b/tests/test_sbomnix.py
@@ -11,8 +11,10 @@
 import errno
 import json
 import os
+import re
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 import jsonschema
@@ -93,7 +95,53 @@ def _run_python_script(args, **kwargs):
     # copy, so we don't mutate env for this process, only for the spawned one.
     env = os.environ.copy()
     env["PYTHONPATH"] = f"{env['PYTHONPATH']}:{REPOROOT}"
-    return subprocess.run(args, **kwargs, check=True, env=env)
+    check = kwargs.pop("check", True)
+    return subprocess.run(args, check=check, env=env, **kwargs)
+
+
+def _output_mentions_repology_host(output):
+    patterns = (
+        r"https://repology\.org(?:/|$)",
+        r"host=['\"]repology\.org['\"]",
+        r"HTTPSConnectionPool\(host=['\"]repology\.org['\"]",
+    )
+    return any(re.search(pattern, output) for pattern in patterns)
+
+
+def _run_python_script_retry_on_repology_network_error(args):
+    """Retry transient repology.org connectivity failures before failing"""
+    markers = [
+        "requests.exceptions.ConnectTimeout",
+        "requests.exceptions.ConnectionError",
+        "requests.exceptions.ReadTimeout",
+        "urllib3.exceptions.ConnectTimeoutError",
+        "urllib3.exceptions.ReadTimeoutError",
+        "Max retries exceeded",
+        "Connection timed out",
+        "Temporary failure in name resolution",
+        "Name or service not known",
+    ]
+    retry_delays = [15, 45]
+    last_ret = None
+    for attempt in range(len(retry_delays) + 1):
+        ret = _run_python_script(args, check=False, capture_output=True, text=True)
+        if ret.returncode == 0:
+            return ret
+        last_ret = ret
+        output = "\n".join(filter(None, [ret.stdout, ret.stderr]))
+        is_repology_network_error = _output_mentions_repology_host(output) and any(
+            marker in output for marker in markers
+        )
+        if not is_repology_network_error or attempt >= len(retry_delays):
+            ret.check_returncode()
+        delay = retry_delays[attempt]
+        print(
+            f"repology.org request failed with a transient network error; "
+            f"retrying in {delay}s (attempt {attempt + 2}/{len(retry_delays) + 1})"
+        )
+        time.sleep(delay)
+    last_ret.check_returncode()
+    return last_ret
 
 
 def test_sbomnix_help():
@@ -558,7 +606,7 @@ def test_repology_cli_sbom():
     assert out_path_cdx.exists()
 
     out_path_repology = TEST_WORK_DIR / "repology.csv"
-    _run_python_script(
+    _run_python_script_retry_on_repology_network_error(
         [
             REPOLOGY_CLI,
             "--sbom_cdx",
@@ -586,7 +634,7 @@ def test_nix_outdated_help():
 def test_nix_outdated_result():
     """Test nix_outdated with TEST_NIX_RESULT as input"""
     out_path_nix_outdated = TEST_WORK_DIR / "nix_outdated.csv"
-    _run_python_script(
+    _run_python_script_retry_on_repology_network_error(
         [
             NIX_OUTDATED,
             "--out",

--- a/tests/test_small_correctness_fixes.py
+++ b/tests/test_small_correctness_fixes.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
+"""Targeted unit tests for small correctness fixes"""
+
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from sbomnix.sbomdb import SbomDb
+from vulnxscan import vulnxscan_cli
+
+
+def test_vulnxscan_invalid_sbom_exits_nonzero(tmp_path, monkeypatch):
+    """Invalid SBOM input should terminate with a failing exit code"""
+    invalid_sbom = tmp_path / "invalid.json"
+    invalid_sbom.write_text("not json", encoding="utf-8")
+
+    args = SimpleNamespace(
+        TARGET=invalid_sbom.as_posix(),
+        verbose=1,
+        out="vulns.csv",
+        buildtime=False,
+        sbom=True,
+        whitelist=None,
+        triage=False,
+        nixprs=False,
+    )
+    monkeypatch.setattr(vulnxscan_cli, "getargs", lambda: args)
+    monkeypatch.setattr(vulnxscan_cli, "set_log_verbosity", lambda _verbosity: None)
+    monkeypatch.setattr(
+        vulnxscan_cli, "exit_unless_command_exists", lambda _command: None
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        vulnxscan_cli.main()
+
+    assert excinfo.value.code == 1
+
+
+def test_vulnxscan_cleans_generated_tempfiles_on_failure(tmp_path, monkeypatch):
+    """Generated SBOM temp files should be removed even when scanning fails"""
+    sbom_cdx_path = tmp_path / "generated.cdx.json"
+    sbom_csv_path = tmp_path / "generated.csv"
+    sbom_cdx_path.write_text("{}", encoding="utf-8")
+    sbom_csv_path.write_text("", encoding="utf-8")
+
+    args = SimpleNamespace(
+        TARGET="target",
+        verbose=1,
+        out="vulns.csv",
+        buildtime=False,
+        sbom=False,
+        whitelist=None,
+        triage=False,
+        nixprs=False,
+    )
+
+    class FailingScanner:
+        def scan_vulnix(self, _target_path, _buildtime):
+            return None
+
+        def scan_grype(self, _sbom_path):
+            raise RuntimeError("scan failed")
+
+        def scan_osv(self, _sbom_path):
+            raise AssertionError("scan_osv should not run after grype failure")
+
+        def report(self, _args, _sbom_csv_path):
+            raise AssertionError("report should not run after scan failure")
+
+    monkeypatch.setattr(vulnxscan_cli, "getargs", lambda: args)
+    monkeypatch.setattr(vulnxscan_cli, "set_log_verbosity", lambda _verbosity: None)
+    monkeypatch.setattr(
+        vulnxscan_cli, "exit_unless_command_exists", lambda _command: None
+    )
+    monkeypatch.setattr(
+        vulnxscan_cli,
+        "try_resolve_flakeref",
+        lambda _target, force_realise=False: "/nix/store/target",
+    )
+    monkeypatch.setattr(
+        vulnxscan_cli,
+        "_generate_sbom",
+        lambda _target_path, _buildtime: (sbom_cdx_path, sbom_csv_path),
+    )
+    monkeypatch.setattr(vulnxscan_cli, "VulnScan", FailingScanner)
+
+    with pytest.raises(RuntimeError, match="scan failed"):
+        vulnxscan_cli.main()
+
+    assert not sbom_cdx_path.exists()
+    assert not sbom_csv_path.exists()
+
+
+def test_generate_sbom_cleans_tempfiles_on_generation_failure(tmp_path, monkeypatch):
+    """Temp SBOM artifacts should be removed if SBOM generation fails"""
+    sbom_cdx_path = tmp_path / "generated.cdx.json"
+    sbom_csv_path = tmp_path / "generated.csv"
+
+    class FakeTempFile:
+        def __init__(self, path):
+            self.name = path.as_posix()
+
+        def __enter__(self):
+            Path(self.name).touch()
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    class FailingSbomDb:
+        def __init__(self, _target_path, _buildtime, include_meta=False):
+            assert include_meta is False
+
+        def to_cdx(self, sbom_path, printinfo=False):
+            Path(sbom_path).write_text("{}", encoding="utf-8")
+            assert printinfo is False
+
+        def to_csv(self, sbom_path, loglevel=None):
+            Path(sbom_path).write_text("", encoding="utf-8")
+            assert loglevel is not None
+            raise RuntimeError("sbom csv generation failed")
+
+    monkeypatch.setattr(
+        vulnxscan_cli,
+        "NamedTemporaryFile",
+        lambda **kwargs: FakeTempFile(
+            sbom_cdx_path if kwargs["suffix"] == ".json" else sbom_csv_path
+        ),
+    )
+    monkeypatch.setattr(vulnxscan_cli, "SbomDb", FailingSbomDb)
+
+    with pytest.raises(RuntimeError, match="sbom csv generation failed"):
+        vulnxscan_cli._generate_sbom(  # pylint: disable=protected-access
+            "/nix/store/target", buildtime=False
+        )
+
+    assert not sbom_cdx_path.exists()
+    assert not sbom_csv_path.exists()
+
+
+def test_generate_sbom_cleans_first_tempfile_if_second_creation_fails(
+    tmp_path, monkeypatch
+):
+    """First temp artifact should not leak if creating the second one fails"""
+    sbom_cdx_path = tmp_path / "generated.cdx.json"
+
+    class FakeTempFile:
+        def __init__(self, path):
+            self.name = path.as_posix()
+
+        def __enter__(self):
+            Path(self.name).touch()
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    class DummySbomDb:
+        def __init__(self, _target_path, _buildtime, include_meta=False):
+            assert include_meta is False
+
+        def to_cdx(self, _sbom_path, printinfo=False):
+            raise AssertionError("to_cdx should not run if csv tempfile creation fails")
+
+        def to_csv(self, _sbom_path, loglevel=None):
+            raise AssertionError("to_csv should not run if csv tempfile creation fails")
+
+    def fake_named_temporary_file(**kwargs):
+        if kwargs["suffix"] == ".json":
+            return FakeTempFile(sbom_cdx_path)
+        raise RuntimeError("csv tempfile creation failed")
+
+    monkeypatch.setattr(vulnxscan_cli, "NamedTemporaryFile", fake_named_temporary_file)
+    monkeypatch.setattr(vulnxscan_cli, "SbomDb", DummySbomDb)
+
+    with pytest.raises(RuntimeError, match="csv tempfile creation failed"):
+        vulnxscan_cli._generate_sbom(  # pylint: disable=protected-access
+            "/nix/store/target", buildtime=False
+        )
+
+    assert not sbom_cdx_path.exists()
+
+
+def test_sbomdb_vuln_tempfile_is_removed_on_scan_failure(tmp_path, monkeypatch):
+    """Temporary SBOM used for vulnerability enrichment should not leak"""
+    temp_cdx_path = tmp_path / "vulnscan_temp.json"
+    seen_paths = []
+
+    def no_dependencies(_self, _drv, **_kwargs):
+        return None
+
+    class FakeTempFile:
+        def __init__(self, path):
+            self.name = path.as_posix()
+
+        def __enter__(self):
+            Path(self.name).touch()
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    class FailingScanner:
+        def __init__(self):
+            self.df_grype = pd.DataFrame()
+            self.df_osv = pd.DataFrame()
+            self.df_vulnix = pd.DataFrame()
+
+        def scan_vulnix(self, _target_path, _buildtime):
+            return None
+
+        def scan_grype(self, sbom_path):
+            sbom_path = Path(sbom_path)
+            seen_paths.append(sbom_path)
+            assert sbom_path.exists()
+
+        def scan_osv(self, sbom_path):
+            sbom_path = Path(sbom_path)
+            seen_paths.append(sbom_path)
+            raise RuntimeError("osv scan failed")
+
+    sbomdb = object.__new__(SbomDb)
+    sbomdb.uid = "store_path"
+    sbomdb.buildtime = False
+    sbomdb.target_deriver = "/nix/store/target.drv"
+    sbomdb.depth = None
+    sbomdb.uuid = uuid.uuid4()
+    sbomdb.include_vulns = True
+    sbomdb.sbom_type = "runtime_only"
+    sbomdb.df_sbomdb = pd.DataFrame(
+        [
+            {
+                "store_path": "/nix/store/target.drv",
+                "pname": "target",
+                "name": "target",
+                "version": "1.0",
+                "outputs": ["/nix/store/target"],
+                "out": "/nix/store/target",
+                "purl": "",
+                "cpe": "",
+                "urls": "",
+                "patches": "",
+            }
+        ]
+    )
+
+    monkeypatch.setattr(
+        "sbomnix.sbomdb.NamedTemporaryFile",
+        lambda **_kwargs: FakeTempFile(temp_cdx_path),
+    )
+    monkeypatch.setattr("sbomnix.sbomdb.VulnScan", FailingScanner)
+    monkeypatch.setattr(SbomDb, "_lookup_dependencies", no_dependencies)
+
+    with pytest.raises(RuntimeError, match="osv scan failed"):
+        sbomdb.to_cdx(tmp_path / "out.cdx.json", printinfo=False)
+
+    assert seen_paths == [temp_cdx_path, temp_cdx_path]
+    assert not temp_cdx_path.exists()


### PR DESCRIPTION
Clean up temporary SBOM files on SBOM generation and vulnerability scan failures, make invalid --sbom input exit with status 1, and add regression tests for cleanup and exit-code edge cases.