### PR TITLE
Harden subprocess argv handling and flakeref error propagation

### DIFF
--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -8,49 +8,35 @@
       apps =
         let
           inherit (self'.packages) sbomnix;
+          mkApp = program: description: {
+            type = "app";
+            inherit program;
+            meta = {
+              inherit description;
+            };
+          };
         in
         {
           # nix run .#repology_cli
-          repology_cli = {
-            type = "app";
-            program = "${sbomnix}/bin/repology_cli";
-          };
+          repology_cli = mkApp "${sbomnix}/bin/repology_cli" "Query Repology using an SBOM as input";
 
           # nix run .#repology_cve
-          repology_cve = {
-            type = "app";
-            program = "${sbomnix}/bin/repology_cve";
-          };
+          repology_cve = mkApp "${sbomnix}/bin/repology_cve" "Find CVEs for packages known to Repology";
 
           # nix run .#nix_outdated
-          nix_outdated = {
-            type = "app";
-            program = "${sbomnix}/bin/nix_outdated";
-          };
+          nix_outdated = mkApp "${sbomnix}/bin/nix_outdated" "List outdated nix dependencies in priority order";
 
           # nix run .#nixgraph
-          nixgraph = {
-            type = "app";
-            program = "${sbomnix}/bin/nixgraph";
-          };
+          nixgraph = mkApp "${sbomnix}/bin/nixgraph" "Visualize nix package dependencies";
 
           # nix run .#nixmeta
-          nixmeta = {
-            type = "app";
-            program = "${sbomnix}/bin/nixmeta";
-          };
+          nixmeta = mkApp "${sbomnix}/bin/nixmeta" "Summarize nixpkgs meta-attributes";
 
           # nix run .#vulnxscan
-          vulnxscan = {
-            type = "app";
-            program = "${sbomnix}/bin/vulnxscan";
-          };
+          vulnxscan = mkApp "${sbomnix}/bin/vulnxscan" "Scan nix artifacts or SBOMs for vulnerabilities";
 
           # nix run .#provenance
-          provenance = {
-            type = "app";
-            program = "${sbomnix}/bin/provenance";
-          };
+          provenance = mkApp "${sbomnix}/bin/provenance" "Generate SLSA provenance for a nix target";
         };
     };
 }

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -22,7 +22,10 @@
           deadnix.enable = true; # removes dead nix code https://github.com/astro/deadnix
           isort.enable = true; # sort python imports https://github.com/PyCQA/isort
           shellcheck.enable = true; # lints shell scripts https://github.com/koalaman/shellcheck
-          nixfmt.enable = true; # nix formatter https://github.com/NixOS/nixfmt
+          nixfmt = {
+            enable = true; # nix formatter https://github.com/NixOS/nixfmt
+            package = pkgs.nixfmt;
+          };
           ruff-check.enable = true; # lints python https://github.com/astral-sh/ruff
           ruff-format.enable = true; # format python https://github.com/astral-sh/ruff
           statix.enable = true; # prevents use of nix anti-patterns https://github.com/nerdypepper/statix

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -11,6 +11,7 @@ import csv
 import importlib.metadata
 import logging
 import os
+import pathlib
 import re
 import shlex
 import subprocess
@@ -32,16 +33,23 @@ LOG_SPAM = logging.DEBUG - 1
 LOG = logging.getLogger(os.path.abspath(__file__))
 
 
-class FlakeRefRealisationError(RuntimeError):
-    """Raised when a flakeref resolves but cannot be force-realised."""
+class FlakeRefResolutionError(RuntimeError):
+    """Raised when an input looks like a flakeref but cannot be resolved."""
 
-    def __init__(self, flakeref, stderr=""):
+    def __init__(self, flakeref, stderr="", action="evaluating"):
         self.flakeref = flakeref
         self.stderr = (stderr or "").strip()
-        message = f"Failed force-realising flakeref '{flakeref}'"
+        message = f"Failed {action} flakeref '{flakeref}'"
         if self.stderr:
             message += f": {self.stderr}"
         super().__init__(message)
+
+
+class FlakeRefRealisationError(FlakeRefResolutionError):
+    """Raised when a flakeref resolves but cannot be force-realised."""
+
+    def __init__(self, flakeref, stderr=""):
+        super().__init__(flakeref, stderr=stderr, action="force-realising")
 
 
 def set_log_verbosity(verbosity=1):
@@ -188,14 +196,16 @@ def try_resolve_flakeref(flakeref, force_realise=False, impure=False):
     """
     Resolve flakeref to out-path, force-realising the output if `force_realise`
     is True. Returns resolved path if flakeref can be resolved to out-path.
-    Returns None if `flakeref` is not understood by `nix eval`.
+    Returns None if the input does not appear to be a flakeref.
     Raises FlakeRefRealisationError if the flakeref resolves but realisation
     fails.
     """
     LOG.info("Evaluating '%s'", flakeref)
     cmd = nix_cmd("eval", "--raw", flakeref, impure=impure)
-    ret = exec_cmd(cmd, raise_on_error=False, log_error=False)
-    if not ret:
+    ret = exec_cmd(cmd, raise_on_error=False, return_error=True, log_error=False)
+    if ret is None or ret.returncode != 0:
+        if _looks_like_flakeref(flakeref):
+            raise FlakeRefResolutionError(flakeref, ret.stderr if ret else "")
         LOG.debug("not a flakeref: '%s'", flakeref)
         return None
     nixpath = ret.stdout.strip()
@@ -223,6 +233,24 @@ def nix_cmd(*args, impure=False):
     if impure:
         cmd.append("--impure")
     return cmd
+
+
+def _looks_like_flakeref(flakeref):
+    """Return true if the input is likely intended as a flake reference."""
+    if not flakeref:
+        return False
+    if flakeref.startswith("nixpkgs="):
+        return True
+    if "#" in flakeref or "?" in flakeref:
+        return True
+    if re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", flakeref):
+        return True
+    path = pathlib.Path(flakeref)
+    if path.exists():
+        return path.is_dir() and (path / "flake.nix").exists()
+    return re.fullmatch(
+        r"[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?", flakeref
+    ) is not None and not flakeref.endswith(".drv")
 
 
 def regex_match(regex, string):

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -31,6 +31,19 @@ from tabulate import tabulate
 LOG_SPAM = logging.DEBUG - 1
 LOG = logging.getLogger(os.path.abspath(__file__))
 
+
+class FlakeRefRealisationError(RuntimeError):
+    """Raised when a flakeref resolves but cannot be force-realised."""
+
+    def __init__(self, flakeref, stderr=""):
+        self.flakeref = flakeref
+        self.stderr = (stderr or "").strip()
+        message = f"Failed force-realising flakeref '{flakeref}'"
+        if self.stderr:
+            message += f": {self.stderr}"
+        super().__init__(message)
+
+
 def set_log_verbosity(verbosity=1):
     """Set logging verbosity"""
     log_levels = [logging.NOTSET, logging.INFO, logging.DEBUG, LOG_SPAM]
@@ -174,8 +187,10 @@ def exit_unless_nix_artifact(path, force_realise=False):
 def try_resolve_flakeref(flakeref, force_realise=False, impure=False):
     """
     Resolve flakeref to out-path, force-realising the output if `force_realise`
-    is True. Returns resolved path if flakeref can be resolved to out-path,
-    otherwise, returns None.
+    is True. Returns resolved path if flakeref can be resolved to out-path.
+    Returns None if `flakeref` is not understood by `nix eval`.
+    Raises FlakeRefRealisationError if the flakeref resolves but realisation
+    fails.
     """
     LOG.info("Evaluating '%s'", flakeref)
     cmd = nix_cmd("eval", "--raw", flakeref, impure=impure)
@@ -189,7 +204,9 @@ def try_resolve_flakeref(flakeref, force_realise=False, impure=False):
         return nixpath
     LOG.info("Try force-realising flakeref '%s'", flakeref)
     cmd = nix_cmd("build", "--no-link", flakeref, impure=impure)
-    exec_cmd(cmd, raise_on_error=False, return_error=True, log_error=False)
+    ret = exec_cmd(cmd, raise_on_error=False, return_error=True, log_error=False)
+    if ret is None or ret.returncode != 0:
+        raise FlakeRefRealisationError(flakeref, ret.stderr if ret else "")
     return nixpath
 
 

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -38,10 +38,11 @@ class FlakeRefResolutionError(RuntimeError):
 
     def __init__(self, flakeref, stderr="", action="evaluating"):
         self.flakeref = flakeref
-        self.stderr = (stderr or "").strip()
+        self.stderr = "" if stderr is None else str(stderr)
         message = f"Failed {action} flakeref '{flakeref}'"
-        if self.stderr:
-            message += f": {self.stderr}"
+        stderr_summary = self.stderr.strip()
+        if stderr_summary:
+            message += f": {stderr_summary}"
         super().__init__(message)
 
 
@@ -140,6 +141,8 @@ def df_log(df, loglevel, tablefmt="presto"):
 
 def exec_cmd(cmd, raise_on_error=True, return_error=False, log_error=True, stdout=None):
     """Run shell command cmd"""
+    if isinstance(cmd, (str, bytes, os.PathLike)):
+        raise TypeError("cmd must be an argv sequence, not a string-like value")
     cmd = [os.fspath(part) for part in cmd]
     command_str = shlex.join(cmd)
     LOG.debug("Running: %s", command_str)
@@ -237,20 +240,21 @@ def nix_cmd(*args, impure=False):
 
 def _looks_like_flakeref(flakeref):
     """Return true if the input is likely intended as a flake reference."""
-    if not flakeref:
-        return False
-    if flakeref.startswith("nixpkgs="):
-        return True
-    if "#" in flakeref or "?" in flakeref:
-        return True
-    if re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", flakeref):
-        return True
-    path = pathlib.Path(flakeref)
-    if path.exists():
-        return path.is_dir() and (path / "flake.nix").exists()
-    return re.fullmatch(
-        r"[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?", flakeref
-    ) is not None and not flakeref.endswith(".drv")
+    looks_like = False
+    if flakeref:
+        path = pathlib.Path(flakeref)
+        if path.exists():
+            looks_like = path.is_dir() and (path / "flake.nix").exists()
+        else:
+            # Keep the heuristic to explicit flake syntax so missing local paths
+            # such as ./result or foo/bar still fall back to store-path handling.
+            looks_like = (
+                flakeref.startswith("nixpkgs=")
+                or "#" in flakeref
+                or "?" in flakeref
+                or re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", flakeref) is not None
+            )
+    return looks_like
 
 
 def regex_match(regex, string):

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -12,6 +12,7 @@ import importlib.metadata
 import logging
 import os
 import re
+import shlex
 import subprocess
 import sys
 import urllib.error
@@ -29,9 +30,6 @@ from tabulate import tabulate
 
 LOG_SPAM = logging.DEBUG - 1
 LOG = logging.getLogger(os.path.abspath(__file__))
-
-###############################################################################
-
 
 def set_log_verbosity(verbosity=1):
     """Set logging verbosity"""
@@ -121,7 +119,8 @@ def df_log(df, loglevel, tablefmt="presto"):
 
 def exec_cmd(cmd, raise_on_error=True, return_error=False, log_error=True, stdout=None):
     """Run shell command cmd"""
-    command_str = " ".join(cmd)
+    cmd = [os.fspath(part) for part in cmd]
+    command_str = shlex.join(cmd)
     LOG.debug("Running: %s", command_str)
     try:
         if stdout:
@@ -179,26 +178,34 @@ def try_resolve_flakeref(flakeref, force_realise=False, impure=False):
     otherwise, returns None.
     """
     LOG.info("Evaluating '%s'", flakeref)
-    exp = "--extra-experimental-features flakes "
-    exp += "--extra-experimental-features nix-command"
-    extra_args = "--impure" if impure else ""
-    cmd = f"nix eval --raw {flakeref} {exp} {extra_args}"
-    ret = exec_cmd(cmd.split(), raise_on_error=False, log_error=False)
+    cmd = nix_cmd("eval", "--raw", flakeref, impure=impure)
+    ret = exec_cmd(cmd, raise_on_error=False, log_error=False)
     if not ret:
         LOG.debug("not a flakeref: '%s'", flakeref)
         return None
-    nixpath = ret.stdout
+    nixpath = ret.stdout.strip()
     LOG.debug("flakeref='%s' maps to path='%s'", flakeref, nixpath)
     if not force_realise:
         return nixpath
     LOG.info("Try force-realising flakeref '%s'", flakeref)
-    cmd = f"nix build --no-link {flakeref} {exp} {extra_args}"
-    ret = exec_cmd(
-        cmd.split(), raise_on_error=False, return_error=True, log_error=False
-    )
-    if not ret:
-        LOG.fatal("Failed force_realising %s: %s", flakeref, ret.stderr)
+    cmd = nix_cmd("build", "--no-link", flakeref, impure=impure)
+    exec_cmd(cmd, raise_on_error=False, return_error=True, log_error=False)
     return nixpath
+
+
+def nix_cmd(*args, impure=False):
+    """Build argv for nix commands that require flakes + nix-command support."""
+    cmd = [
+        "nix",
+        *args,
+        "--extra-experimental-features",
+        "flakes",
+        "--extra-experimental-features",
+        "nix-command",
+    ]
+    if impure:
+        cmd.append("--impure")
+    return cmd
 
 
 def regex_match(regex, string):

--- a/src/nixgraph/main.py
+++ b/src/nixgraph/main.py
@@ -11,7 +11,7 @@ import pathlib
 
 from common.utils import (
     LOG,
-    FlakeRefRealisationError,
+    FlakeRefResolutionError,
     check_positive,
     exit_unless_nix_artifact,
     get_py_pkg_version,
@@ -91,7 +91,7 @@ def main():
     runtime = args.buildtime is False
     try:
         target_path = try_resolve_flakeref(args.NIXREF, force_realise=runtime)
-    except FlakeRefRealisationError as error:
+    except FlakeRefResolutionError as error:
         LOG.fatal("%s", error)
         raise SystemExit(1) from error
     if not target_path:

--- a/src/nixgraph/main.py
+++ b/src/nixgraph/main.py
@@ -10,6 +10,8 @@ import argparse
 import pathlib
 
 from common.utils import (
+    LOG,
+    FlakeRefRealisationError,
     check_positive,
     exit_unless_nix_artifact,
     get_py_pkg_version,
@@ -87,7 +89,11 @@ def main():
     args = getargs()
     set_log_verbosity(args.verbose)
     runtime = args.buildtime is False
-    target_path = try_resolve_flakeref(args.NIXREF, force_realise=runtime)
+    try:
+        target_path = try_resolve_flakeref(args.NIXREF, force_realise=runtime)
+    except FlakeRefRealisationError as error:
+        LOG.fatal("%s", error)
+        raise SystemExit(1) from error
     if not target_path:
         target_path = pathlib.Path(args.NIXREF).resolve().as_posix()
         exit_unless_nix_artifact(args.NIXREF, force_realise=runtime)

--- a/src/nixmeta/scanner.py
+++ b/src/nixmeta/scanner.py
@@ -143,9 +143,8 @@ def _get_flake_metadata(flakeref):
     """
     # Strip possible nixpkgs= prefix to support cases where flakeref is
     # given the NIX_PATH environment variable
-    m_nixpkgs = re.match(r"nixpkgs=([^:\s]+)", flakeref)
-    if m_nixpkgs:
-        flakeref = m_nixpkgs.group(1)
+    if flakeref.startswith("nixpkgs="):
+        flakeref = flakeref.removeprefix("nixpkgs=")
     # Read nix flake metadata as json
     cmd = nix_cmd("flake", "metadata", flakeref, "--json")
     ret = exec_cmd(cmd, raise_on_error=False, return_error=True, log_error=False)

--- a/src/nixmeta/scanner.py
+++ b/src/nixmeta/scanner.py
@@ -12,7 +12,14 @@ from tempfile import NamedTemporaryFile
 
 import pandas as pd
 
-from common.utils import LOG, LOG_SPAM, df_from_csv_file, df_to_csv_file, exec_cmd
+from common.utils import (
+    LOG,
+    LOG_SPAM,
+    df_from_csv_file,
+    df_to_csv_file,
+    exec_cmd,
+    nix_cmd,
+)
 
 ###############################################################################
 
@@ -140,12 +147,8 @@ def _get_flake_metadata(flakeref):
     if m_nixpkgs:
         flakeref = m_nixpkgs.group(1)
     # Read nix flake metadata as json
-    exp = "--extra-experimental-features flakes "
-    exp += "--extra-experimental-features nix-command"
-    cmd = f"nix flake metadata {flakeref} --json {exp}"
-    ret = exec_cmd(
-        cmd.split(), raise_on_error=False, return_error=True, log_error=False
-    )
+    cmd = nix_cmd("flake", "metadata", flakeref, "--json")
+    ret = exec_cmd(cmd, raise_on_error=False, return_error=True, log_error=False)
     if ret is None or ret.returncode != 0:
         LOG.warning("Failed reading flake metadata: %s", flakeref)
         return None

--- a/src/nixupdate/nix_outdated.py
+++ b/src/nixupdate/nix_outdated.py
@@ -18,7 +18,7 @@ import repology.repology_cli
 from common.utils import (
     LOG,
     LOG_SPAM,
-    FlakeRefRealisationError,
+    FlakeRefResolutionError,
     df_from_csv_file,
     df_log,
     df_to_csv_file,
@@ -257,7 +257,7 @@ def main():
     runtime = args.buildtime is False
     try:
         target_path = try_resolve_flakeref(args.NIXREF, force_realise=runtime)
-    except FlakeRefRealisationError as error:
+    except FlakeRefResolutionError as error:
         LOG.fatal("%s", error)
         raise SystemExit(1) from error
     if not target_path:

--- a/src/nixupdate/nix_outdated.py
+++ b/src/nixupdate/nix_outdated.py
@@ -18,6 +18,7 @@ import repology.repology_cli
 from common.utils import (
     LOG,
     LOG_SPAM,
+    FlakeRefRealisationError,
     df_from_csv_file,
     df_log,
     df_to_csv_file,
@@ -254,7 +255,11 @@ def main():
     args = getargs()
     set_log_verbosity(args.verbose)
     runtime = args.buildtime is False
-    target_path = try_resolve_flakeref(args.NIXREF, force_realise=runtime)
+    try:
+        target_path = try_resolve_flakeref(args.NIXREF, force_realise=runtime)
+    except FlakeRefRealisationError as error:
+        LOG.fatal("%s", error)
+        raise SystemExit(1) from error
     if not target_path:
         target_path = pathlib.Path(args.NIXREF).resolve().as_posix()
         exit_unless_nix_artifact(args.NIXREF, force_realise=runtime)

--- a/src/nixupdate/nix_outdated.py
+++ b/src/nixupdate/nix_outdated.py
@@ -106,8 +106,8 @@ def _run_nix_visualize(target_path):
     prefix = "nix-visualize_"
     suffix = ".csv"
     with NamedTemporaryFile(delete=False, prefix=prefix, suffix=suffix) as f:
-        cmd = f"nix-visualize --output={f.name} {target_path}"
-        exec_cmd(cmd.split())
+        cmd = ["nix-visualize", f"--output={f.name}", target_path]
+        exec_cmd(cmd)
         return pathlib.Path(f.name)
 
 

--- a/src/provenance/main.py
+++ b/src/provenance/main.py
@@ -13,7 +13,7 @@ import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-from common.utils import LOG, exec_cmd, set_log_verbosity
+from common.utils import LOG, exec_cmd, nix_cmd, set_log_verbosity
 
 
 @dataclass
@@ -170,10 +170,8 @@ def provenance(target: str, metadata: BuildMeta, recursive: bool = False) -> dic
 
     LOG.info("Generating provenance file for '%s'", target)
 
-    exp = "--extra-experimental-features flakes "
-    exp += "--extra-experimental-features nix-command"
-    cmd = f"nix derivation show {target} {exp}"
-    drv_json = json.loads(exec_cmd(cmd.split()).stdout)
+    cmd = nix_cmd("derivation", "show", target)
+    drv_json = json.loads(exec_cmd(cmd).stdout)
     drv_path = next(iter(drv_json))
     drv_json = drv_json[drv_path]
 

--- a/src/sbomnix/main.py
+++ b/src/sbomnix/main.py
@@ -10,6 +10,8 @@ import argparse
 import pathlib
 
 from common.utils import (
+    LOG,
+    FlakeRefRealisationError,
     check_positive,
     exit_unless_nix_artifact,
     get_py_pkg_version,
@@ -82,9 +84,13 @@ def main():
     set_log_verbosity(args.verbose)
     runtime = args.buildtime is False
     flakeref = None
-    target_path = try_resolve_flakeref(
-        args.NIXREF, force_realise=runtime, impure=args.impure
-    )
+    try:
+        target_path = try_resolve_flakeref(
+            args.NIXREF, force_realise=runtime, impure=args.impure
+        )
+    except FlakeRefRealisationError as error:
+        LOG.fatal("%s", error)
+        raise SystemExit(1) from error
     if target_path:
         flakeref = args.NIXREF
     else:

--- a/src/sbomnix/main.py
+++ b/src/sbomnix/main.py
@@ -11,7 +11,7 @@ import pathlib
 
 from common.utils import (
     LOG,
-    FlakeRefRealisationError,
+    FlakeRefResolutionError,
     check_positive,
     exit_unless_nix_artifact,
     get_py_pkg_version,
@@ -88,7 +88,7 @@ def main():
         target_path = try_resolve_flakeref(
             args.NIXREF, force_realise=runtime, impure=args.impure
         )
-    except FlakeRefRealisationError as error:
+    except FlakeRefResolutionError as error:
         LOG.fatal("%s", error)
         raise SystemExit(1) from error
     if target_path:

--- a/src/sbomnix/meta.py
+++ b/src/sbomnix/meta.py
@@ -54,7 +54,7 @@ class Meta:
             # Read meta from nipxkgs referenced in NIX_PATH
             LOG.debug("Reading nixpkgs path from NIX_PATH environment")
             nix_path = os.environ["NIX_PATH"]
-            m_nixpkgs = re.match(r".*nixpkgs=([^:\s]+)", nix_path)
+            m_nixpkgs = re.search(r"(?:^|:)nixpkgs=([^:]+)", nix_path)
             if m_nixpkgs:
                 nixpkgs_path = m_nixpkgs.group(1)
         df = None

--- a/src/sbomnix/nix.py
+++ b/src/sbomnix/nix.py
@@ -11,7 +11,7 @@ import os
 
 import pandas as pd
 
-from common.utils import LOG, LOG_SPAM, exec_cmd
+from common.utils import LOG, LOG_SPAM, exec_cmd, nix_cmd
 from sbomnix.cpe import CPE
 from sbomnix.derivation import load
 
@@ -94,10 +94,8 @@ def find_deriver(path):
     if path.endswith(".drv"):
         return path
     # Deriver from QueryValidDerivers
-    exp = "--extra-experimental-features flakes "
-    exp += "--extra-experimental-features nix-command"
-    cmd = f"nix derivation show {path} {exp}"
-    ret = exec_cmd(cmd.split(), raise_on_error=False, log_error=False)
+    cmd = nix_cmd("derivation", "show", path)
+    ret = exec_cmd(cmd, raise_on_error=False, log_error=False)
     if not ret:
         LOG.log(LOG_SPAM, "Deriver not found for '%s'", path)
         return None

--- a/src/vulnxscan/vulnscan.py
+++ b/src/vulnxscan/vulnscan.py
@@ -73,10 +73,10 @@ class VulnScan:
         """Run vulnix scan for nix artifact at target_path"""
         LOG.info("Running vulnix scan")
         self.df_vulnix = pd.DataFrame()
-        extra_opts = "-C --json"
+        extra_opts = ["-C", "--json"]
         if buildtime:
-            extra_opts = "--json"
-        cmd = ["vulnix", target_path] + extra_opts.split()
+            extra_opts = ["--json"]
+        cmd = ["vulnix", target_path, *extra_opts]
         # vulnix exit status is non-zero if it found vulnerabilities.
         # Therefore, we need to set the raise_on_error=False and
         # return_error=True to be able to read the vulnerabilities

--- a/src/vulnxscan/vulnxscan_cli.py
+++ b/src/vulnxscan/vulnxscan_cli.py
@@ -17,6 +17,7 @@ from tempfile import NamedTemporaryFile
 
 from common.utils import (
     LOG,
+    FlakeRefRealisationError,
     exit_unless_command_exists,
     exit_unless_nix_artifact,
     set_log_verbosity,
@@ -151,7 +152,11 @@ def main():
         sbom_cdx_path = target_path
     else:
         runtime = args.buildtime is False
-        target_path = try_resolve_flakeref(args.TARGET, force_realise=runtime)
+        try:
+            target_path = try_resolve_flakeref(args.TARGET, force_realise=runtime)
+        except FlakeRefRealisationError as error:
+            LOG.fatal("%s", error)
+            raise SystemExit(1) from error
         if not target_path:
             target_path = pathlib.Path(args.TARGET).resolve().as_posix()
             exit_unless_nix_artifact(args.TARGET, force_realise=runtime)

--- a/src/vulnxscan/vulnxscan_cli.py
+++ b/src/vulnxscan/vulnxscan_cli.py
@@ -17,7 +17,7 @@ from tempfile import NamedTemporaryFile
 
 from common.utils import (
     LOG,
-    FlakeRefRealisationError,
+    FlakeRefResolutionError,
     exit_unless_command_exists,
     exit_unless_nix_artifact,
     set_log_verbosity,
@@ -154,7 +154,7 @@ def main():
         runtime = args.buildtime is False
         try:
             target_path = try_resolve_flakeref(args.TARGET, force_realise=runtime)
-        except FlakeRefRealisationError as error:
+        except FlakeRefResolutionError as error:
             LOG.fatal("%s", error)
             raise SystemExit(1) from error
         if not target_path:

--- a/tests/test_small_correctness_fixes.py
+++ b/tests/test_small_correctness_fixes.py
@@ -13,7 +13,7 @@ from types import SimpleNamespace
 import pandas as pd
 import pytest
 
-from common.utils import FlakeRefRealisationError
+from common.utils import FlakeRefRealisationError, FlakeRefResolutionError
 from nixgraph import main as nixgraph_main
 from nixupdate import nix_outdated
 from sbomnix import main as sbomnix_main
@@ -135,7 +135,97 @@ def test_cli_exits_on_flakeref_realisation_failure_without_store_fallback(
         module.main()
 
     assert excinfo.value.code == 1
-    assert artifact_checks == []
+    assert not artifact_checks
+
+
+@pytest.mark.parametrize(
+    ("module", "args", "prep"),
+    [
+        (
+            sbomnix_main,
+            SimpleNamespace(
+                NIXREF=".#broken",
+                buildtime=False,
+                depth=None,
+                verbose=1,
+                include_vulns=False,
+                exclude_meta=False,
+                exclude_cpe_matching=False,
+                csv=None,
+                cdx=None,
+                spdx=None,
+                impure=False,
+            ),
+            lambda monkeypatch: None,
+        ),
+        (
+            nixgraph_main,
+            SimpleNamespace(
+                NIXREF=".#broken",
+                buildtime=False,
+                depth=1,
+                inverse=None,
+                out="graph.png",
+                colorize=None,
+                until=None,
+                pathnames=False,
+                verbose=1,
+            ),
+            lambda monkeypatch: None,
+        ),
+        (
+            nix_outdated,
+            SimpleNamespace(
+                NIXREF=".#broken",
+                buildtime=False,
+                local=False,
+                out="nix_outdated.csv",
+                verbose=1,
+            ),
+            lambda monkeypatch: None,
+        ),
+        (
+            vulnxscan_cli,
+            SimpleNamespace(
+                TARGET=".#broken",
+                verbose=1,
+                out="vulns.csv",
+                buildtime=False,
+                sbom=False,
+                whitelist=None,
+                triage=False,
+                nixprs=False,
+            ),
+            lambda monkeypatch: monkeypatch.setattr(
+                vulnxscan_cli, "exit_unless_command_exists", lambda _command: None
+            ),
+        ),
+    ],
+)
+def test_cli_exits_on_flakeref_eval_failure_without_store_fallback(
+    monkeypatch, module, args, prep
+):
+    """Flakeref eval failures should not be misreported as invalid store paths."""
+    artifact_checks = []
+
+    def raise_resolution_error(*_args, **_kwargs):
+        raise FlakeRefResolutionError(".#broken", "attribute missing")
+
+    prep(monkeypatch)
+    monkeypatch.setattr(module, "getargs", lambda: args)
+    monkeypatch.setattr(module, "set_log_verbosity", lambda _verbosity: None)
+    monkeypatch.setattr(module, "try_resolve_flakeref", raise_resolution_error)
+    monkeypatch.setattr(
+        module,
+        "exit_unless_nix_artifact",
+        lambda path, force_realise=False: artifact_checks.append((path, force_realise)),
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        module.main()
+
+    assert excinfo.value.code == 1
+    assert not artifact_checks
 
 
 def test_vulnxscan_cleans_generated_tempfiles_on_failure(tmp_path, monkeypatch):

--- a/tests/test_small_correctness_fixes.py
+++ b/tests/test_small_correctness_fixes.py
@@ -13,6 +13,10 @@ from types import SimpleNamespace
 import pandas as pd
 import pytest
 
+from common.utils import FlakeRefRealisationError
+from nixgraph import main as nixgraph_main
+from nixupdate import nix_outdated
+from sbomnix import main as sbomnix_main
 from sbomnix.sbomdb import SbomDb
 from vulnxscan import vulnxscan_cli
 
@@ -42,6 +46,96 @@ def test_vulnxscan_invalid_sbom_exits_nonzero(tmp_path, monkeypatch):
         vulnxscan_cli.main()
 
     assert excinfo.value.code == 1
+
+
+@pytest.mark.parametrize(
+    ("module", "args", "prep"),
+    [
+        (
+            sbomnix_main,
+            SimpleNamespace(
+                NIXREF=".#broken",
+                buildtime=False,
+                depth=None,
+                verbose=1,
+                include_vulns=False,
+                exclude_meta=False,
+                exclude_cpe_matching=False,
+                csv=None,
+                cdx=None,
+                spdx=None,
+                impure=False,
+            ),
+            lambda monkeypatch: None,
+        ),
+        (
+            nixgraph_main,
+            SimpleNamespace(
+                NIXREF=".#broken",
+                buildtime=False,
+                depth=1,
+                inverse=None,
+                out="graph.png",
+                colorize=None,
+                until=None,
+                pathnames=False,
+                verbose=1,
+            ),
+            lambda monkeypatch: None,
+        ),
+        (
+            nix_outdated,
+            SimpleNamespace(
+                NIXREF=".#broken",
+                buildtime=False,
+                local=False,
+                out="nix_outdated.csv",
+                verbose=1,
+            ),
+            lambda monkeypatch: None,
+        ),
+        (
+            vulnxscan_cli,
+            SimpleNamespace(
+                TARGET=".#broken",
+                verbose=1,
+                out="vulns.csv",
+                buildtime=False,
+                sbom=False,
+                whitelist=None,
+                triage=False,
+                nixprs=False,
+            ),
+            lambda monkeypatch: monkeypatch.setattr(
+                vulnxscan_cli, "exit_unless_command_exists", lambda _command: None
+            ),
+        ),
+    ],
+)
+def test_cli_exits_on_flakeref_realisation_failure_without_store_fallback(
+    monkeypatch, module, args, prep
+):
+    """Flakeref build failures should not be misreported as invalid store paths"""
+    artifact_checks = []
+
+    def raise_realisation_error(*_args, **_kwargs):
+        raise FlakeRefRealisationError(".#broken", "build failed")
+
+    prep(monkeypatch)
+    monkeypatch.setattr(module, "getargs", lambda: args)
+    monkeypatch.setattr(module, "set_log_verbosity", lambda _verbosity: None)
+    monkeypatch.setattr(module, "try_resolve_flakeref", raise_realisation_error)
+    monkeypatch.setattr(
+        module,
+        "exit_unless_nix_artifact",
+        lambda path, force_realise=False: artifact_checks.append((path, force_realise)),
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        module.main()
+
+    assert excinfo.value.code == 1
+    assert artifact_checks == []
 
 
 def test_vulnxscan_cleans_generated_tempfiles_on_failure(tmp_path, monkeypatch):

--- a/tests/test_subprocess_argv.py
+++ b/tests/test_subprocess_argv.py
@@ -15,6 +15,7 @@ from common import utils
 from nixmeta import scanner
 from nixupdate import nix_outdated
 from sbomnix import nix as sbomnix_nix
+from sbomnix.meta import Meta
 from vulnxscan.vulnscan import VulnScan
 
 
@@ -47,7 +48,7 @@ def test_try_resolve_flakeref_uses_argv_lists(monkeypatch):
                 "nix-command",
                 "--impure",
             ],
-            {"raise_on_error": False, "log_error": False},
+            {"raise_on_error": False, "return_error": True, "log_error": False},
         ),
         (
             [
@@ -76,6 +77,31 @@ def test_try_resolve_flakeref_raises_on_failed_force_realise(monkeypatch):
 
     with pytest.raises(utils.FlakeRefRealisationError, match="build failed"):
         utils.try_resolve_flakeref("/tmp/my flake#pkg", force_realise=True)
+
+
+def test_try_resolve_flakeref_raises_on_failed_eval_for_flakeref(monkeypatch):
+    def fake_exec_cmd(_cmd, **_kwargs):
+        return SimpleNamespace(stdout="", stderr="attribute missing", returncode=1)
+
+    monkeypatch.setattr(utils, "exec_cmd", fake_exec_cmd)
+
+    with pytest.raises(utils.FlakeRefResolutionError, match="attribute missing"):
+        utils.try_resolve_flakeref(".#missing")
+
+
+def test_try_resolve_flakeref_returns_none_for_non_flake_path(monkeypatch):
+    def fake_exec_cmd(_cmd, **_kwargs):
+        return SimpleNamespace(
+            stdout="",
+            stderr="does not contain a 'flake.nix'",
+            returncode=1,
+        )
+
+    monkeypatch.setattr(utils, "exec_cmd", fake_exec_cmd)
+
+    resolved = utils.try_resolve_flakeref("/nix/store/not-a-flake-output")
+
+    assert resolved is None
 
 
 def test_flakeref_realisation_error_accepts_none_stderr():
@@ -184,6 +210,32 @@ def test_run_nix_visualize_uses_argv_list(tmp_path, monkeypatch):
             {},
         )
     ]
+
+
+def test_get_flake_metadata_strips_nixpkgs_prefix_without_splitting_spaces(monkeypatch):
+    calls = []
+
+    def fake_exec_cmd(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return SimpleNamespace(stdout='{"path": "/nix/store/nixpkgs"}', returncode=0)
+
+    monkeypatch.setattr(scanner, "exec_cmd", fake_exec_cmd)
+
+    scanner._get_flake_metadata("nixpkgs=/tmp/my flake")
+
+    assert calls[0][0][3] == "/tmp/my flake"
+
+
+def test_meta_reads_nix_path_entry_with_spaces(monkeypatch):
+    scanned = []
+
+    monkeypatch.setenv("NIX_PATH", "foo=/tmp/other:nixpkgs=/tmp/my flake")
+    monkeypatch.setattr(Meta, "_scan", lambda self, path: scanned.append(path) or path)
+
+    resolved = Meta().get_nixpkgs_meta()
+
+    assert resolved == "/tmp/my flake"
+    assert scanned == ["/tmp/my flake"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_subprocess_argv.py
+++ b/tests/test_subprocess_argv.py
@@ -104,11 +104,54 @@ def test_try_resolve_flakeref_returns_none_for_non_flake_path(monkeypatch):
     assert resolved is None
 
 
+@pytest.mark.parametrize("path", ["missing", "./missing", "foo/bar"])
+def test_try_resolve_flakeref_returns_none_for_missing_relative_paths(
+    monkeypatch, path
+):
+    def fake_exec_cmd(_cmd, **_kwargs):
+        return SimpleNamespace(stdout="", stderr="dummy eval failure", returncode=1)
+
+    monkeypatch.setattr(utils, "exec_cmd", fake_exec_cmd)
+
+    resolved = utils.try_resolve_flakeref(path)
+
+    assert resolved is None
+
+
+@pytest.mark.parametrize("name", ["artifact#1", "artifact?1"])
+def test_try_resolve_flakeref_returns_none_for_existing_non_flake_path_with_fragment_chars(
+    tmp_path, monkeypatch, name
+):
+    artifact = tmp_path / name
+    artifact.write_text("not a flake", encoding="utf-8")
+
+    def fake_exec_cmd(_cmd, **_kwargs):
+        return SimpleNamespace(stdout="", stderr="attribute missing", returncode=1)
+
+    monkeypatch.setattr(utils, "exec_cmd", fake_exec_cmd)
+
+    resolved = utils.try_resolve_flakeref(artifact.as_posix())
+
+    assert resolved is None
+
+
 def test_flakeref_realisation_error_accepts_none_stderr():
     error = utils.FlakeRefRealisationError("/tmp/my flake#pkg", None)
 
     assert error.stderr == ""
     assert str(error) == "Failed force-realising flakeref '/tmp/my flake#pkg'"
+
+
+def test_flake_ref_resolution_error_preserves_stderr_verbatim():
+    error = utils.FlakeRefResolutionError(".#missing", "attribute missing\n")
+
+    assert error.stderr == "attribute missing\n"
+    assert str(error) == "Failed evaluating flakeref '.#missing': attribute missing"
+
+
+def test_exec_cmd_rejects_string_commands():
+    with pytest.raises(TypeError, match="argv sequence"):
+        utils.exec_cmd("nix build .#sbomnix")
 
 
 def test_find_deriver_uses_argv_list(monkeypatch):

--- a/tests/test_subprocess_argv.py
+++ b/tests/test_subprocess_argv.py
@@ -65,6 +65,26 @@ def test_try_resolve_flakeref_uses_argv_lists(monkeypatch):
         ),
     ]
 
+
+def test_try_resolve_flakeref_raises_on_failed_force_realise(monkeypatch):
+    def fake_exec_cmd(cmd, **_kwargs):
+        if cmd[1] == "eval":
+            return SimpleNamespace(stdout="/nix/store/resolved\n", returncode=0)
+        return SimpleNamespace(stdout="", stderr="build failed", returncode=1)
+
+    monkeypatch.setattr(utils, "exec_cmd", fake_exec_cmd)
+
+    with pytest.raises(utils.FlakeRefRealisationError, match="build failed"):
+        utils.try_resolve_flakeref("/tmp/my flake#pkg", force_realise=True)
+
+
+def test_flakeref_realisation_error_accepts_none_stderr():
+    error = utils.FlakeRefRealisationError("/tmp/my flake#pkg", None)
+
+    assert error.stderr == ""
+    assert str(error) == "Failed force-realising flakeref '/tmp/my flake#pkg'"
+
+
 def test_find_deriver_uses_argv_list(monkeypatch):
     calls = []
     drv_path = "/nix/store/my drv.drv"

--- a/tests/test_subprocess_argv.py
+++ b/tests/test_subprocess_argv.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+# pylint: disable=missing-class-docstring,missing-function-docstring,protected-access
+
+"""Unit tests for whitespace-safe subprocess argv construction."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from common import utils
+from nixmeta import scanner
+from nixupdate import nix_outdated
+from sbomnix import nix as sbomnix_nix
+from vulnxscan.vulnscan import VulnScan
+
+
+def test_try_resolve_flakeref_uses_argv_lists(monkeypatch):
+    calls = []
+
+    def fake_exec_cmd(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[1] == "eval":
+            return SimpleNamespace(stdout="/nix/store/resolved\n", returncode=0)
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(utils, "exec_cmd", fake_exec_cmd)
+
+    resolved = utils.try_resolve_flakeref(
+        "/tmp/my flake#pkg", force_realise=True, impure=True
+    )
+
+    assert resolved == "/nix/store/resolved"
+    assert calls == [
+        (
+            [
+                "nix",
+                "eval",
+                "--raw",
+                "/tmp/my flake#pkg",
+                "--extra-experimental-features",
+                "flakes",
+                "--extra-experimental-features",
+                "nix-command",
+                "--impure",
+            ],
+            {"raise_on_error": False, "log_error": False},
+        ),
+        (
+            [
+                "nix",
+                "build",
+                "--no-link",
+                "/tmp/my flake#pkg",
+                "--extra-experimental-features",
+                "flakes",
+                "--extra-experimental-features",
+                "nix-command",
+                "--impure",
+            ],
+            {"raise_on_error": False, "return_error": True, "log_error": False},
+        ),
+    ]
+
+def test_find_deriver_uses_argv_list(monkeypatch):
+    calls = []
+    drv_path = "/nix/store/my drv.drv"
+
+    def fake_exec_cmd(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return SimpleNamespace(stdout=json.dumps({drv_path: {}}))
+
+    monkeypatch.setattr(sbomnix_nix, "exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(sbomnix_nix.os.path, "exists", lambda path: path == drv_path)
+
+    resolved = sbomnix_nix.find_deriver("/nix/store/my output")
+
+    assert resolved == drv_path
+    assert calls == [
+        (
+            [
+                "nix",
+                "derivation",
+                "show",
+                "/nix/store/my output",
+                "--extra-experimental-features",
+                "flakes",
+                "--extra-experimental-features",
+                "nix-command",
+            ],
+            {"raise_on_error": False, "log_error": False},
+        )
+    ]
+
+
+def test_get_flake_metadata_uses_argv_list(monkeypatch):
+    calls = []
+
+    def fake_exec_cmd(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return SimpleNamespace(stdout='{"path": "/nix/store/nixpkgs"}', returncode=0)
+
+    monkeypatch.setattr(scanner, "exec_cmd", fake_exec_cmd)
+
+    meta = scanner._get_flake_metadata("/tmp/my flake")
+
+    assert meta == {"path": "/nix/store/nixpkgs"}
+    assert calls == [
+        (
+            [
+                "nix",
+                "flake",
+                "metadata",
+                "/tmp/my flake",
+                "--json",
+                "--extra-experimental-features",
+                "flakes",
+                "--extra-experimental-features",
+                "nix-command",
+            ],
+            {"raise_on_error": False, "return_error": True, "log_error": False},
+        )
+    ]
+
+
+def test_run_nix_visualize_uses_argv_list(tmp_path, monkeypatch):
+    calls = []
+    output_path = tmp_path / "graph output.csv"
+
+    class FakeTempFile:
+        def __init__(self, path):
+            self.name = path.as_posix()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    def fake_exec_cmd(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return SimpleNamespace(stdout="", returncode=0)
+
+    monkeypatch.setattr(
+        nix_outdated,
+        "NamedTemporaryFile",
+        lambda **_kwargs: FakeTempFile(output_path),
+    )
+    monkeypatch.setattr(nix_outdated, "exec_cmd", fake_exec_cmd)
+
+    returned_path = nix_outdated._run_nix_visualize("/nix/store/my target")
+
+    assert returned_path == output_path
+    assert calls == [
+        (
+            [
+                "nix-visualize",
+                f"--output={output_path.as_posix()}",
+                "/nix/store/my target",
+            ],
+            {},
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("buildtime", "expected_cmd"),
+    [
+        (False, ["vulnix", "/nix/store/my target", "-C", "--json"]),
+        (True, ["vulnix", "/nix/store/my target", "--json"]),
+    ],
+)
+def test_scan_vulnix_uses_argv_lists(monkeypatch, buildtime, expected_cmd):
+    calls = []
+    parsed = []
+
+    def fake_exec_cmd(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return SimpleNamespace(stdout="[]", stderr="", returncode=0)
+
+    monkeypatch.setattr("vulnxscan.vulnscan.exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(
+        VulnScan, "_parse_vulnix", lambda self, stdout: parsed.append(stdout)
+    )
+
+    scanner_obj = VulnScan()
+    scanner_obj.scan_vulnix("/nix/store/my target", buildtime=buildtime)
+
+    assert parsed == ["[]"]
+    assert calls == [
+        (
+            expected_cmd,
+            {"raise_on_error": False, "return_error": True, "log_error": False},
+        )
+    ]


### PR DESCRIPTION
- Replace `"cmd ...".split()` subprocess construction with explicit argv lists so paths containing whitespace are handled safely. Centralize `--extra-experimental-features` flags in a `nix_cmd()` helper, and make `exec_cmd()` reject string/bytes/PathLike inputs so argv mistakes fail fast.
- Propagate flakeref failures through new `FlakeRefResolutionError` / `FlakeRefRealisationError` exceptions. The four CLIs (`sbomnix`, `nixgraph`, `nix_outdated`, `vulnxscan`) now exit with the actual nix error instead of silently swallowing it or misreporting it as "not a nix artifact". A conservative heuristic keeps non-flake paths (including ones with `#`/`?` in their names) on the store-path fallback.
- Anchor the `NIX_PATH` nixpkgs regex to entry boundaries and strip trailing whitespace from `nix eval --raw` output.
- Add `meta.description` to each exported app and pin treefmt's nix formatter to `pkgs.nixfmt` to silence `nix flake check` warnings.