### PR TITLE
Normalize nix derivation JSON and canonicalize provenance digests

### DIFF
--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -9,6 +9,7 @@
 import argparse
 import csv
 import importlib.metadata
+import json
 import logging
 import os
 import pathlib
@@ -31,6 +32,8 @@ from tabulate import tabulate
 
 LOG_SPAM = logging.DEBUG - 1
 LOG = logging.getLogger(os.path.abspath(__file__))
+RE_NIX_STORE_PATH_BASENAME = re.compile(r"^[0-9a-z]{32}-.+")
+RE_NIX_STORE_PATH = re.compile(r"(?P<store_path>/(?:[^/\s:]+/)+[0-9a-z]{32}-[^/\s:]+)")
 
 
 class FlakeRefResolutionError(RuntimeError):
@@ -236,6 +239,131 @@ def nix_cmd(*args, impure=False):
     if impure:
         cmd.append("--impure")
     return cmd
+
+
+def get_nix_store_dir(path=None, default="/nix/store"):
+    """Infer the nix store directory from an absolute store path-like string."""
+    if path:
+        match = RE_NIX_STORE_PATH.search(str(path))
+        if match:
+            return os.path.dirname(match.group("store_path"))
+    return default
+
+
+def normalize_nix_store_path(path, store_dir="/nix/store"):
+    """Return an absolute store path for basename-only store path strings."""
+    if not isinstance(path, str) or not path:
+        return path
+    if os.path.isabs(path) or not RE_NIX_STORE_PATH_BASENAME.match(path):
+        return path
+    return os.path.join(store_dir, path)
+
+
+def _iter_nix_store_dir_candidates(value):
+    """Yield strings that may reveal the nix store directory."""
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _iter_nix_store_dir_candidates(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _iter_nix_store_dir_candidates(item)
+
+
+def _infer_nix_store_dir(drv_info, default="/nix/store"):
+    """Infer the nix store directory from derivation fields when keys are relative."""
+    if not isinstance(drv_info, dict):
+        return default
+    for candidate in _iter_nix_store_dir_candidates(
+        {
+            "builder": drv_info.get("builder"),
+            "outputs": drv_info.get("outputs"),
+            "env": drv_info.get("env"),
+        }
+    ):
+        store_dir = get_nix_store_dir(candidate, default=None)
+        if store_dir:
+            return store_dir
+    return default
+
+
+def _normalize_nix_derivation_info(drv_info, store_dir):
+    """Normalize basename-only store paths within derivation info."""
+    if not isinstance(drv_info, dict):
+        return drv_info
+
+    normalized = dict(drv_info)
+
+    outputs = normalized.get("outputs")
+    if isinstance(outputs, dict):
+        normalized["outputs"] = {}
+        for name, output in outputs.items():
+            if isinstance(output, dict):
+                output = dict(output)
+                if output.get("path"):
+                    output["path"] = normalize_nix_store_path(output["path"], store_dir)
+            normalized["outputs"][name] = output
+
+    env = normalized.get("env")
+    if isinstance(env, dict):
+        normalized["env"] = {
+            key: normalize_nix_store_path(value, store_dir)
+            for key, value in env.items()
+        }
+
+    inputs = normalized.get("inputs")
+    if isinstance(inputs, dict):
+        normalized_inputs = dict(inputs)
+        srcs = normalized_inputs.get("srcs")
+        if isinstance(srcs, list):
+            normalized_inputs["srcs"] = [
+                normalize_nix_store_path(src, store_dir) for src in srcs
+            ]
+        drvs = normalized_inputs.get("drvs")
+        if isinstance(drvs, dict):
+            normalized_inputs["drvs"] = {
+                normalize_nix_store_path(path, store_dir): outputs
+                for path, outputs in drvs.items()
+            }
+        normalized["inputs"] = normalized_inputs
+
+    input_srcs = normalized.get("inputSrcs")
+    if isinstance(input_srcs, list):
+        normalized["inputSrcs"] = [
+            normalize_nix_store_path(src, store_dir) for src in input_srcs
+        ]
+
+    input_drvs = normalized.get("inputDrvs")
+    if isinstance(input_drvs, dict):
+        normalized["inputDrvs"] = {
+            normalize_nix_store_path(path, store_dir): outputs
+            for path, outputs in input_drvs.items()
+        }
+
+    return normalized
+
+
+def parse_nix_derivation_show(stdout, store_path_hint=None):
+    """Normalize `nix derivation show` JSON across legacy and wrapped formats."""
+    payload = json.loads(stdout)
+    derivations = (
+        payload.get("derivations", payload) if isinstance(payload, dict) else {}
+    )
+    if not isinstance(derivations, dict):
+        return {}
+
+    normalized = {}
+    fallback_store_dir = get_nix_store_dir(store_path_hint)
+    for drv_path, drv_info in derivations.items():
+        store_dir = get_nix_store_dir(drv_path, default=None)
+        if not store_dir:
+            store_dir = _infer_nix_store_dir(drv_info, default=fallback_store_dir)
+        normalized_drv_path = normalize_nix_store_path(drv_path, store_dir)
+        normalized[normalized_drv_path] = _normalize_nix_derivation_info(
+            drv_info, store_dir
+        )
+    return normalized
 
 
 def _looks_like_flakeref(flakeref):

--- a/src/provenance/main.py
+++ b/src/provenance/main.py
@@ -7,9 +7,12 @@
 """Python script that generates SLSA v1.0 provenance file for a nix target"""
 
 import argparse
+import base64
+import binascii
 import errno
 import json
 import os
+import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
@@ -20,6 +23,16 @@ from common.utils import (
     parse_nix_derivation_show,
     set_log_verbosity,
 )
+
+HASH_SIZE_BYTES = {
+    "blake3": 32,
+    "md5": 16,
+    "sha1": 20,
+    "sha256": 32,
+    "sha512": 64,
+}
+NIX32_ALPHABET = "0123456789abcdfghijklmnpqrsvwxyz"
+NIX32_INDEX = {char: index for index, char in enumerate(NIX32_ALPHABET)}
 
 
 @dataclass
@@ -33,6 +46,114 @@ class BuildMeta:
     build_finished_ts: str
     external_parameters: str
     internal_parameters: str
+
+
+def _canonical_hash_algo(hash_algo: str | None) -> str | None:
+    """Normalize legacy hash algorithm labels to plain algorithm names."""
+    if not hash_algo:
+        return None
+    return str(hash_algo).removeprefix("r:")
+
+
+def _hash_size_bytes(hash_algo: str | None) -> int | None:
+    """Return expected digest size for the given algorithm."""
+    return HASH_SIZE_BYTES.get(_canonical_hash_algo(hash_algo))
+
+
+def _decode_nix32(hash_value: str, size_bytes: int) -> bytes | None:
+    """Decode nix base32 digest strings into raw bytes."""
+    try:
+        value = 0
+        for char in hash_value:
+            value = value * 32 + NIX32_INDEX[char]
+    except KeyError:
+        return None
+
+    if value.bit_length() > size_bytes * 8:
+        return None
+
+    encoded_size = (len(hash_value) * 5 + 7) // 8
+    raw = value.to_bytes(encoded_size, "little")
+    return raw[:size_bytes].ljust(size_bytes, b"\0")
+
+
+def _decode_hash_bytes(hash_value: str, hash_algo: str) -> bytes | None:
+    """Decode known Nix hash encodings into raw bytes."""
+    size_bytes = _hash_size_bytes(hash_algo)
+    if size_bytes is None:
+        return None
+
+    if re.fullmatch(rf"[0-9a-f]{{{size_bytes * 2}}}", hash_value):
+        return bytes.fromhex(hash_value)
+
+    if len(hash_value) == (size_bytes * 8 + 4) // 5:
+        decoded = _decode_nix32(hash_value, size_bytes)
+        if decoded is not None:
+            return decoded
+
+    padding = "=" * (-len(hash_value) % 4)
+    try:
+        decoded = base64.b64decode(hash_value + padding, validate=True)
+    except (ValueError, binascii.Error):
+        return None
+    if len(decoded) != size_bytes:
+        return None
+    return decoded
+
+
+def _split_hash_value(
+    hash_value: str, hash_algo: str | None = None
+) -> tuple[str | None, str]:
+    """Split a typed hash string into canonical algorithm and raw value."""
+    hash_algo = _canonical_hash_algo(hash_algo)
+    hash_value = str(hash_value).strip()
+
+    if hash_algo:
+        for separator in (":", "-"):
+            legacy_prefix = f"r:{hash_algo}{separator}"
+            if hash_value.startswith(legacy_prefix):
+                return hash_algo, hash_value.removeprefix(legacy_prefix)
+            prefix = f"{hash_algo}{separator}"
+            if hash_value.startswith(prefix):
+                return hash_algo, hash_value.removeprefix(prefix)
+
+    match = re.match(
+        r"^(?P<algo>(?:r:)?[A-Za-z0-9]+)(?P<sep>[:-])(?P<rest>.+)$", hash_value
+    )
+    if match:
+        return _canonical_hash_algo(match.group("algo")), match.group("rest")
+
+    return hash_algo, hash_value
+
+
+def _normalize_digest(
+    hash_value: str | None, hash_algo: str | None = None
+) -> dict | None:
+    """Return digest in a canonical base16 representation."""
+    if not hash_value:
+        return None
+    hash_value = str(hash_value).strip()
+    if not hash_value:
+        return None
+
+    hash_algo, raw_hash_value = _split_hash_value(hash_value, hash_algo=hash_algo)
+    if not hash_algo:
+        return None
+
+    decoded = _decode_hash_bytes(raw_hash_value, hash_algo)
+    if decoded is None:
+        return None
+    return {hash_algo: decoded.hex()}
+
+
+def _output_digest(data: dict | None) -> dict | None:
+    """Return digest from derivation output metadata when available."""
+    if not isinstance(data, dict):
+        return None
+    hash_value = data.get("hash")
+    if not hash_value:
+        return None
+    return _normalize_digest(hash_value, hash_algo=data.get("hashAlgo"))
 
 
 def get_env_metadata():
@@ -67,27 +188,41 @@ def get_subjects(outputs: dict, env: dict | None = None) -> list[dict]:
     subjects = []
     for name, data in outputs.items():
         output_path = _output_path(name, data, env)
-        if not output_path:
-            LOG.warning("Cannot determine path for derivation output '%s'", name)
-            continue
-        subject = {
-            "name": name,
-            "uri": output_path,
-        }
-        store_hash = exec_cmd(
-            ["nix-store", "--query", "--hash", output_path],
-            raise_on_error=False,
-        )
-        if store_hash is None:
-            LOG.warning(
-                "Derivation output '%s' was not found in the nix store, "
-                "assuming it was not built.",
-                name,
+        subject = {"name": name}
+        output_digest = _output_digest(data)
+        if output_path:
+            subject["uri"] = output_path
+        if output_digest is not None:
+            subject["digest"] = output_digest
+            LOG.info(
+                "Using derivation metadata hash for fixed-output output '%s'", name
             )
+        elif output_path:
+            store_hash = exec_cmd(
+                ["nix-store", "--query", "--hash", output_path],
+                raise_on_error=False,
+            )
+            if store_hash is None:
+                LOG.warning(
+                    "Derivation output '%s' was not found in the nix store, "
+                    "assuming it was not built.",
+                    name,
+                )
+                continue
+            digest = _normalize_digest(store_hash.stdout.strip())
+            if digest is None:
+                LOG.warning(
+                    "Cannot normalize nix-store hash for derivation output '%s'", name
+                )
+                continue
+            subject["digest"] = digest
         else:
-            hash_type, hash_value = store_hash.stdout.strip().split(":")
-            subject["digest"] = {hash_type: hash_value}
-            subjects.append(subject)
+            LOG.warning(
+                "Cannot determine path or digest for derivation output '%s'", name
+            )
+            continue
+
+        subjects.append(subject)
 
     return subjects
 
@@ -117,6 +252,59 @@ def _output_path(name: str, output: dict | None, env: dict | None = None) -> str
     return env.get(name)
 
 
+def _derivation_outputs_by_path(infos: dict) -> dict[str, tuple[dict, dict]]:
+    """Index derivation info by absolute output path."""
+    outputs_by_path = {}
+    for info in infos.values():
+        if not isinstance(info, dict):
+            continue
+        outputs = info.get("outputs")
+        if not isinstance(outputs, dict):
+            continue
+        env = info.get("env")
+        for name, output in outputs.items():
+            output_path = _output_path(name, output, env)
+            if output_path:
+                outputs_by_path[output_path] = (info, output)
+    return outputs_by_path
+
+
+def _dependency_package(
+    drv: str, output_hash: str, infos: dict, outputs_by_path: dict
+) -> dict | None:
+    """Create a dependency package entry with a normalized digest."""
+    info = infos.get(drv)
+    output_info = outputs_by_path.get(drv)
+    if output_info:
+        info = output_info[0]
+    digest = _output_digest(output_info[1]) if output_info else None
+    if digest is None:
+        digest = _normalize_digest(output_hash)
+    if digest is None and ":" in output_hash:
+        hash_type, hash_value = output_hash.split(":", 1)
+        LOG.warning(
+            "Falling back to non-normalized digest for dependency '%s': %s",
+            drv,
+            output_hash,
+        )
+        digest = {hash_type: hash_value}
+    if digest is None:
+        LOG.warning("Cannot determine digest for dependency '%s'", drv)
+        return None
+
+    package = {
+        "name": drv.split("-", 1)[-1].removesuffix(".drv"),
+        "uri": drv,
+        "digest": digest,
+    }
+
+    if info:
+        package["name"] = info["name"]
+        if version := info["env"].get("version"):
+            package["annotations"] = {"version": version}
+    return package
+
+
 def get_dependencies(drv_path: str, recursive: bool = False) -> list[dict]:
     """Get dependencies of derivation and parse them into ResourceDescriptors"""
 
@@ -132,25 +320,14 @@ def get_dependencies(drv_path: str, recursive: bool = False) -> list[dict]:
         exec_cmd(["nix", "derivation", "show", "-r", drv_path]).stdout,
         store_path_hint=drv_path,
     )
+    outputs_by_path = _derivation_outputs_by_path(infos)
 
     dependencies = []
     for drv, output_hash in zip(references, hashes):
         LOG.debug("Creating dependency entry for %s", drv)
-        hash_type, hash_value = output_hash.split(":")
-
-        package = {
-            "name": drv.split("-", 1)[-1].removesuffix(".drv"),
-            "uri": drv,
-            "digest": {hash_type: hash_value},
-        }
-
-        info = infos.get(drv)
-        if info:
-            package["name"] = info["name"]
-            if version := info["env"].get("version"):
-                package["annotations"] = {"version": version}
-
-        dependencies.append(package)
+        package = _dependency_package(drv, output_hash, infos, outputs_by_path)
+        if package is not None:
+            dependencies.append(package)
 
     return dependencies
 

--- a/src/provenance/main.py
+++ b/src/provenance/main.py
@@ -13,7 +13,13 @@ import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-from common.utils import LOG, exec_cmd, nix_cmd, set_log_verbosity
+from common.utils import (
+    LOG,
+    exec_cmd,
+    nix_cmd,
+    parse_nix_derivation_show,
+    set_log_verbosity,
+)
 
 
 @dataclass
@@ -52,19 +58,24 @@ def get_env_metadata():
     return BuildMeta(*values)
 
 
-def get_subjects(outputs: dict) -> list[dict]:
+def get_subjects(outputs: dict, env: dict | None = None) -> list[dict]:
     """Parse derivation outputs into in-toto subjects"""
 
     LOG.info("Parsing derivation outputs")
 
+    env = env or {}
     subjects = []
     for name, data in outputs.items():
+        output_path = _output_path(name, data, env)
+        if not output_path:
+            LOG.warning("Cannot determine path for derivation output '%s'", name)
+            continue
         subject = {
             "name": name,
-            "uri": data["path"],
+            "uri": output_path,
         }
         store_hash = exec_cmd(
-            ["nix-store", "--query", "--hash", data["path"]],
+            ["nix-store", "--query", "--hash", output_path],
             raise_on_error=False,
         )
         if store_hash is None:
@@ -98,6 +109,14 @@ def query_store_hashes(paths: list[str]) -> list[str]:
         )
 
 
+def _output_path(name: str, output: dict | None, env: dict | None = None) -> str | None:
+    """Return the resolved absolute output path from outputs or env."""
+    if isinstance(output, dict) and output.get("path"):
+        return output["path"]
+    env = env or {}
+    return env.get(name)
+
+
 def get_dependencies(drv_path: str, recursive: bool = False) -> list[dict]:
     """Get dependencies of derivation and parse them into ResourceDescriptors"""
 
@@ -109,7 +128,10 @@ def get_dependencies(drv_path: str, recursive: bool = False) -> list[dict]:
         ["nix-store", "--query", depth, "--include-outputs", drv_path]
     ).stdout.split()
     hashes = query_store_hashes(references)
-    infos = json.loads(exec_cmd(["nix", "derivation", "show", "-r", drv_path]).stdout)
+    infos = parse_nix_derivation_show(
+        exec_cmd(["nix", "derivation", "show", "-r", drv_path]).stdout,
+        store_path_hint=drv_path,
+    )
 
     dependencies = []
     for drv, output_hash in zip(references, hashes):
@@ -171,7 +193,7 @@ def provenance(target: str, metadata: BuildMeta, recursive: bool = False) -> dic
     LOG.info("Generating provenance file for '%s'", target)
 
     cmd = nix_cmd("derivation", "show", target)
-    drv_json = json.loads(exec_cmd(cmd).stdout)
+    drv_json = parse_nix_derivation_show(exec_cmd(cmd).stdout, store_path_hint=target)
     drv_path = next(iter(drv_json))
     drv_json = drv_json[drv_path]
 
@@ -179,7 +201,7 @@ def provenance(target: str, metadata: BuildMeta, recursive: bool = False) -> dic
 
     return {
         "_type": "https://in-toto.io/Statement/v1",
-        "subject": get_subjects(drv_json["outputs"]),
+        "subject": get_subjects(drv_json["outputs"], env=drv_json.get("env")),
         "predicateType": "https://slsa.dev/provenance/v1",
         "predicate": {
             "buildDefinition": {

--- a/src/sbomnix/nix.py
+++ b/src/sbomnix/nix.py
@@ -6,12 +6,11 @@
 
 """Nix store, originally from https://github.com/flyingcircusio/vulnix"""
 
-import json
 import os
 
 import pandas as pd
 
-from common.utils import LOG, LOG_SPAM, exec_cmd, nix_cmd
+from common.utils import LOG, LOG_SPAM, exec_cmd, nix_cmd, parse_nix_derivation_show
 from sbomnix.cpe import CPE
 from sbomnix.derivation import load
 
@@ -99,7 +98,9 @@ def find_deriver(path):
     if not ret:
         LOG.log(LOG_SPAM, "Deriver not found for '%s'", path)
         return None
-    qvd_json_keys = list(json.loads(ret.stdout).keys())
+    qvd_json_keys = list(
+        parse_nix_derivation_show(ret.stdout, store_path_hint=path).keys()
+    )
     if not qvd_json_keys or len(qvd_json_keys) < 1:
         LOG.log(LOG_SPAM, "Not qvd_deriver for '%s'", path)
         return None

--- a/tests/test_subprocess_argv.py
+++ b/tests/test_subprocess_argv.py
@@ -14,6 +14,7 @@ import pytest
 from common import utils
 from nixmeta import scanner
 from nixupdate import nix_outdated
+from provenance import main as provenance_main
 from sbomnix import nix as sbomnix_nix
 from sbomnix.meta import Meta
 from vulnxscan.vulnscan import VulnScan
@@ -288,6 +289,77 @@ def test_parse_nix_derivation_show_infers_store_dir_from_path_like_env_values():
     drv_path = f"/custom/store/{drv_basename}"
     assert list(parsed) == [drv_path]
     assert parsed[drv_path]["env"]["out"] == f"/custom/store/{out_basename}"
+
+
+def test_get_dependencies_supports_nix_2_33_wrapped_json(monkeypatch):
+    drv_path = "/nix/store/0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-root.drv"
+    dep_basename = "1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-dependency.drv"
+    dep_path = f"/nix/store/{dep_basename}"
+    output_hash = "1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s"
+
+    def fake_exec_cmd(cmd, **kwargs):
+        if cmd == [
+            "nix-store",
+            "--query",
+            "--references",
+            "--include-outputs",
+            drv_path,
+        ]:
+            return SimpleNamespace(stdout=f"{dep_path}\n")
+        if cmd[:4] == ["nix", "derivation", "show", "-r"]:
+            return SimpleNamespace(
+                stdout=json.dumps(
+                    {
+                        "derivations": {
+                            dep_basename: {
+                                "name": "dependency",
+                                "env": {"version": "1.2.3"},
+                            }
+                        },
+                        "version": 4,
+                    }
+                )
+            )
+        raise AssertionError(f"unexpected command: {cmd} kwargs={kwargs}")
+
+    monkeypatch.setattr(provenance_main, "exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(
+        provenance_main,
+        "query_store_hashes",
+        lambda paths: [f"sha256:{output_hash}"],
+    )
+
+    assert provenance_main.get_dependencies(drv_path) == [
+        {
+            "name": "dependency",
+            "uri": dep_path,
+            "digest": {"sha256": output_hash},
+            "annotations": {"version": "1.2.3"},
+        }
+    ]
+
+
+def test_get_subjects_falls_back_to_env_output_paths(monkeypatch):
+    output_path = "/custom/store/1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-nghttp2-1.68.1"
+    output_hash = "1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s"
+
+    def fake_exec_cmd(cmd, **_kwargs):
+        if cmd == ["nix-store", "--query", "--hash", output_path]:
+            return SimpleNamespace(stdout=f"sha256:{output_hash}\n")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(provenance_main, "exec_cmd", fake_exec_cmd)
+
+    assert provenance_main.get_subjects(
+        {"out": {"method": "nar"}},
+        env={"out": output_path},
+    ) == [
+        {
+            "name": "out",
+            "uri": output_path,
+            "digest": {"sha256": output_hash},
+        }
+    ]
 
 
 def test_get_flake_metadata_uses_argv_list(monkeypatch):

--- a/tests/test_subprocess_argv.py
+++ b/tests/test_subprocess_argv.py
@@ -185,6 +185,111 @@ def test_find_deriver_uses_argv_list(monkeypatch):
     ]
 
 
+def test_find_deriver_supports_nix_2_33_wrapped_json(monkeypatch):
+    path = "/nix/store/my output"
+    drv_basename = "4rpn9q86mj9sxrfavhz1qgx7a8sdbndw-nghttp2-1.68.1.drv"
+    drv_path = f"/nix/store/{drv_basename}"
+    stale_qpi_deriver = "/nix/store/stale-nghttp2-1.68.1.drv"
+
+    def fake_exec_cmd(cmd, **kwargs):
+        if cmd[:3] == ["nix", "derivation", "show"]:
+            return SimpleNamespace(
+                stdout=json.dumps(
+                    {
+                        "derivations": {drv_basename: {}},
+                        "version": 4,
+                    }
+                )
+            )
+        if cmd == ["nix-store", "-qd", path]:
+            return SimpleNamespace(stdout=f"{stale_qpi_deriver}\n")
+        raise AssertionError(f"unexpected command: {cmd} kwargs={kwargs}")
+
+    monkeypatch.setattr(sbomnix_nix, "exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(
+        sbomnix_nix.os.path,
+        "exists",
+        lambda candidate: candidate == drv_path,
+    )
+
+    assert sbomnix_nix.find_deriver(path) == drv_path
+
+
+def test_parse_nix_derivation_show_normalizes_nix_2_33_store_paths():
+    drv_basename = "4rpn9q86mj9sxrfavhz1qgx7a8sdbndw-nghttp2-1.68.1.drv"
+    out_basename = "1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-nghttp2-1.68.1"
+    src_basename = "2ccccccccccccccccccccccccccccccc-source"
+    dep_basename = "3ddddddddddddddddddddddddddddddd-zlib-1.3.1.drv"
+
+    parsed = utils.parse_nix_derivation_show(
+        json.dumps(
+            {
+                "version": 4,
+                "derivations": {
+                    drv_basename: {
+                        "name": "nghttp2",
+                        "builder": "/custom/store/4eeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-bash/bin/bash",
+                        "outputs": {"out": {"path": out_basename}},
+                        "inputs": {
+                            "srcs": [src_basename],
+                            "drvs": {dep_basename: ["out"]},
+                        },
+                        "env": {"out": out_basename, "name": "nghttp2-1.68.1"},
+                    }
+                },
+            }
+        )
+    )
+
+    drv_path = f"/custom/store/{drv_basename}"
+    assert list(parsed) == [drv_path]
+    assert parsed[drv_path]["outputs"]["out"]["path"] == f"/custom/store/{out_basename}"
+    assert parsed[drv_path]["inputs"]["srcs"] == [f"/custom/store/{src_basename}"]
+    assert list(parsed[drv_path]["inputs"]["drvs"]) == [f"/custom/store/{dep_basename}"]
+    assert parsed[drv_path]["env"]["out"] == f"/custom/store/{out_basename}"
+
+
+def test_get_nix_store_dir_ignores_colon_separated_env_paths():
+    value = (
+        "--prefix PATH : "
+        "/custom/store/4eeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-git/bin:"
+        "/custom/store/5fffffffffffffffffffffffffffffff-graphviz/bin"
+    )
+
+    assert utils.get_nix_store_dir(value, default=None) == "/custom/store"
+
+
+def test_parse_nix_derivation_show_infers_store_dir_from_path_like_env_values():
+    drv_basename = "4rpn9q86mj9sxrfavhz1qgx7a8sdbndw-nghttp2-1.68.1.drv"
+    out_basename = "1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-nghttp2-1.68.1"
+
+    parsed = utils.parse_nix_derivation_show(
+        json.dumps(
+            {
+                "version": 4,
+                "derivations": {
+                    drv_basename: {
+                        "name": "nghttp2",
+                        "outputs": {"out": {"method": "nar"}},
+                        "env": {
+                            "out": out_basename,
+                            "makeWrapperArgs": (
+                                "--prefix PATH : "
+                                "/custom/store/4eeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-git/bin:"
+                                "/custom/store/5fffffffffffffffffffffffffffffff-graphviz/bin"
+                            ),
+                        },
+                    }
+                },
+            }
+        )
+    )
+
+    drv_path = f"/custom/store/{drv_basename}"
+    assert list(parsed) == [drv_path]
+    assert parsed[drv_path]["env"]["out"] == f"/custom/store/{out_basename}"
+
+
 def test_get_flake_metadata_uses_argv_list(monkeypatch):
     calls = []
 

--- a/tests/test_subprocess_argv.py
+++ b/tests/test_subprocess_argv.py
@@ -7,6 +7,7 @@
 """Unit tests for whitespace-safe subprocess argv construction."""
 
 import json
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -295,7 +296,8 @@ def test_get_dependencies_supports_nix_2_33_wrapped_json(monkeypatch):
     drv_path = "/nix/store/0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-root.drv"
     dep_basename = "1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-dependency.drv"
     dep_path = f"/nix/store/{dep_basename}"
-    output_hash = "1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s"
+    digest = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    real_exec_cmd = provenance_main.exec_cmd
 
     def fake_exec_cmd(cmd, **kwargs):
         if cmd == [
@@ -320,20 +322,174 @@ def test_get_dependencies_supports_nix_2_33_wrapped_json(monkeypatch):
                     }
                 )
             )
+        if cmd[:3] == ["nix", "hash", "convert"]:
+            return real_exec_cmd(cmd, **kwargs)
         raise AssertionError(f"unexpected command: {cmd} kwargs={kwargs}")
 
     monkeypatch.setattr(provenance_main, "exec_cmd", fake_exec_cmd)
     monkeypatch.setattr(
         provenance_main,
         "query_store_hashes",
-        lambda paths: [f"sha256:{output_hash}"],
+        lambda paths: ["sha256:1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s"],
     )
 
     assert provenance_main.get_dependencies(drv_path) == [
         {
             "name": "dependency",
             "uri": dep_path,
-            "digest": {"sha256": output_hash},
+            "digest": {"sha256": digest},
+            "annotations": {"version": "1.2.3"},
+        }
+    ]
+
+
+def test_normalize_digest_does_not_shell_out(monkeypatch):
+    def fail_exec_cmd(cmd, **kwargs):
+        raise AssertionError(f"unexpected command: {cmd} kwargs={kwargs}")
+
+    monkeypatch.setattr(provenance_main, "exec_cmd", fail_exec_cmd)
+
+    assert provenance_main._normalize_digest(
+        "sha256:1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s"
+    ) == {"sha256": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"}
+    assert provenance_main._normalize_digest(
+        "sha256-ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0="
+    ) == {"sha256": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"}
+    assert provenance_main._normalize_digest(
+        "77a94a83ccab42a68278ac5d3e340dcefecd736dd4feff1de71dec137b6b44ce",
+        "r:sha256",
+    ) == {"sha256": "77a94a83ccab42a68278ac5d3e340dcefecd736dd4feff1de71dec137b6b44ce"}
+
+
+def test_normalize_digest_rejects_overflowing_nix32_values(monkeypatch):
+    def fail_exec_cmd(cmd, **kwargs):
+        raise AssertionError(f"unexpected command: {cmd} kwargs={kwargs}")
+
+    monkeypatch.setattr(provenance_main, "exec_cmd", fail_exec_cmd)
+
+    assert provenance_main._normalize_digest("sha256:" + ("z" * 52)) is None
+
+
+def test_dependency_package_logs_non_normalized_digest_fallback(caplog):
+    drv_path = "/nix/store/1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-dependency.drv"
+
+    with caplog.at_level(logging.WARNING, logger=provenance_main.LOG.name):
+        package = provenance_main._dependency_package(drv_path, "sha999:abc", {}, {})
+
+    assert package == {
+        "name": "dependency",
+        "uri": drv_path,
+        "digest": {"sha999": "abc"},
+    }
+    assert "Falling back to non-normalized digest" in caplog.text
+
+
+def test_get_dependencies_prefers_fixed_output_digest_for_output_paths(monkeypatch):
+    drv_path = "/nix/store/0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-root.drv"
+    dep_drv_basename = "1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-source.drv"
+    dep_out_basename = "2ccccccccccccccccccccccccccccccc-source"
+    dep_out_path = f"/nix/store/{dep_out_basename}"
+    metadata_digest = "77a94a83ccab42a68278ac5d3e340dcefecd736dd4feff1de71dec137b6b44ce"
+    real_exec_cmd = provenance_main.exec_cmd
+
+    def fake_exec_cmd(cmd, **kwargs):
+        if cmd == [
+            "nix-store",
+            "--query",
+            "--references",
+            "--include-outputs",
+            drv_path,
+        ]:
+            return SimpleNamespace(stdout=f"{dep_out_path}\n")
+        if cmd[:4] == ["nix", "derivation", "show", "-r"]:
+            return SimpleNamespace(
+                stdout=json.dumps(
+                    {
+                        "derivations": {
+                            dep_drv_basename: {
+                                "name": "source",
+                                "outputs": {
+                                    "out": {
+                                        "path": dep_out_basename,
+                                        "hash": metadata_digest,
+                                        "hashAlgo": "r:sha256",
+                                    }
+                                },
+                                "env": {"version": "1.2.3"},
+                            }
+                        },
+                        "version": 4,
+                    }
+                )
+            )
+        if cmd[:3] == ["nix", "hash", "convert"]:
+            return real_exec_cmd(cmd, **kwargs)
+        raise AssertionError(f"unexpected command: {cmd} kwargs={kwargs}")
+
+    monkeypatch.setattr(provenance_main, "exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(
+        provenance_main,
+        "query_store_hashes",
+        lambda paths: ["sha256:09i0w2qz3i5yp7m3yziq4z2n2r2v9s6d3n8j4x1q8k0m5a6b7c8d"],
+    )
+
+    assert provenance_main.get_dependencies(drv_path) == [
+        {
+            "name": "source",
+            "uri": dep_out_path,
+            "digest": {"sha256": metadata_digest},
+            "annotations": {"version": "1.2.3"},
+        }
+    ]
+
+
+def test_get_dependencies_maps_env_only_output_paths_back_to_derivations(monkeypatch):
+    drv_path = "/nix/store/0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-root.drv"
+    dep_out_basename = "2ccccccccccccccccccccccccccccccc-source"
+    dep_out_path = f"/nix/store/{dep_out_basename}"
+    digest = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+
+    def fake_exec_cmd(cmd, **kwargs):
+        if cmd == [
+            "nix-store",
+            "--query",
+            "--references",
+            "--include-outputs",
+            drv_path,
+        ]:
+            return SimpleNamespace(stdout=f"{dep_out_path}\n")
+        if cmd[:4] == ["nix", "derivation", "show", "-r"]:
+            return SimpleNamespace(
+                stdout=json.dumps(
+                    {
+                        "derivations": {
+                            "1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-source.drv": {
+                                "name": "special-source",
+                                "outputs": {"out": {"method": "nar"}},
+                                "env": {
+                                    "out": dep_out_basename,
+                                    "version": "1.2.3",
+                                },
+                            }
+                        },
+                        "version": 4,
+                    }
+                )
+            )
+        raise AssertionError(f"unexpected command: {cmd} kwargs={kwargs}")
+
+    monkeypatch.setattr(provenance_main, "exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(
+        provenance_main,
+        "query_store_hashes",
+        lambda paths: ["sha256:1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s"],
+    )
+
+    assert provenance_main.get_dependencies(drv_path) == [
+        {
+            "name": "special-source",
+            "uri": dep_out_path,
+            "digest": {"sha256": digest},
             "annotations": {"version": "1.2.3"},
         }
     ]
@@ -342,11 +498,15 @@ def test_get_dependencies_supports_nix_2_33_wrapped_json(monkeypatch):
 def test_get_subjects_falls_back_to_env_output_paths(monkeypatch):
     output_path = "/custom/store/1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-nghttp2-1.68.1"
     output_hash = "1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s"
+    digest = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    real_exec_cmd = provenance_main.exec_cmd
 
-    def fake_exec_cmd(cmd, **_kwargs):
+    def fake_exec_cmd(cmd, **kwargs):
         if cmd == ["nix-store", "--query", "--hash", output_path]:
             return SimpleNamespace(stdout=f"sha256:{output_hash}\n")
-        raise AssertionError(f"unexpected command: {cmd}")
+        if cmd[:3] == ["nix", "hash", "convert"]:
+            return real_exec_cmd(cmd, **kwargs)
+        raise AssertionError(f"unexpected command: {cmd} kwargs={kwargs}")
 
     monkeypatch.setattr(provenance_main, "exec_cmd", fake_exec_cmd)
 
@@ -357,7 +517,234 @@ def test_get_subjects_falls_back_to_env_output_paths(monkeypatch):
         {
             "name": "out",
             "uri": output_path,
-            "digest": {"sha256": output_hash},
+            "digest": {"sha256": digest},
+        }
+    ]
+
+
+def test_get_subjects_prefers_derivation_hash_for_realized_flat_outputs(monkeypatch):
+    output_path = "/custom/store/1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-nghttp2-1.68.1"
+    output_hash = "sha256-ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0="
+    digest = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    real_exec_cmd = provenance_main.exec_cmd
+
+    def fake_exec_cmd(cmd, **kwargs):
+        if cmd[:3] == ["nix", "hash", "convert"]:
+            return real_exec_cmd(cmd, **kwargs)
+        raise AssertionError(f"unexpected command: {cmd} kwargs={kwargs}")
+
+    monkeypatch.setattr(provenance_main, "exec_cmd", fake_exec_cmd)
+
+    assert provenance_main.get_subjects(
+        {"out": {"method": "flat", "hash": output_hash}},
+        env={"out": output_path},
+    ) == [
+        {
+            "name": "out",
+            "uri": output_path,
+            "digest": {"sha256": digest},
+        }
+    ]
+
+
+def test_get_subjects_uses_derivation_hash_when_output_is_not_realized(monkeypatch):
+    output_path = "/custom/store/1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-nghttp2-1.68.1"
+    output_hash = "sha256-ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0="
+    digest = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    real_exec_cmd = provenance_main.exec_cmd
+
+    def fake_exec_cmd(cmd, **kwargs):
+        if cmd == ["nix-store", "--query", "--hash", output_path]:
+            return None
+        if cmd[:3] == ["nix", "hash", "convert"]:
+            return real_exec_cmd(cmd, **kwargs)
+        raise AssertionError(f"unexpected command: {cmd} kwargs={kwargs}")
+
+    monkeypatch.setattr(provenance_main, "exec_cmd", fake_exec_cmd)
+
+    assert provenance_main.get_subjects(
+        {"out": {"method": "nar", "hash": output_hash}},
+        env={"out": output_path},
+    ) == [
+        {
+            "name": "out",
+            "uri": output_path,
+            "digest": {"sha256": digest},
+        }
+    ]
+
+
+def test_get_subjects_supports_legacy_r_sha256_metadata(monkeypatch):
+    output_path = "/custom/store/1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-nghttp2-1.68.1"
+    digest = "77a94a83ccab42a68278ac5d3e340dcefecd736dd4feff1de71dec137b6b44ce"
+    real_exec_cmd = provenance_main.exec_cmd
+
+    def fake_exec_cmd(cmd, **kwargs):
+        if cmd[:3] == ["nix", "hash", "convert"]:
+            return real_exec_cmd(cmd, **kwargs)
+        raise AssertionError(f"unexpected command: {cmd} kwargs={kwargs}")
+
+    monkeypatch.setattr(provenance_main, "exec_cmd", fake_exec_cmd)
+
+    assert provenance_main.get_subjects(
+        {
+            "out": {
+                "hash": digest,
+                "hashAlgo": "r:sha256",
+            }
+        },
+        env={"out": output_path},
+    ) == [
+        {
+            "name": "out",
+            "uri": output_path,
+            "digest": {"sha256": digest},
+        }
+    ]
+
+
+def test_get_subjects_skips_unrealized_outputs_without_digest(monkeypatch):
+    output_path = "/custom/store/2ccccccccccccccccccccccccccccccc-nghttp2-doc"
+
+    def fake_exec_cmd(cmd, **_kwargs):
+        assert cmd == ["nix-store", "--query", "--hash", output_path]
+
+    monkeypatch.setattr(provenance_main, "exec_cmd", fake_exec_cmd)
+
+    assert not provenance_main.get_subjects(
+        {"out": {"method": "nar"}},
+        env={"out": output_path},
+    )
+
+
+def test_get_subjects_skip_only_missing_unrealized_outputs(monkeypatch):
+    output_path = "/custom/store/1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-nghttp2-1.68.1"
+    missing_path = "/custom/store/2ccccccccccccccccccccccccccccccc-nghttp2-doc"
+    output_hash = "1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s"
+    digest = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    real_exec_cmd = provenance_main.exec_cmd
+
+    def fake_exec_cmd(cmd, **kwargs):
+        if cmd == ["nix-store", "--query", "--hash", output_path]:
+            return SimpleNamespace(stdout=f"sha256:{output_hash}\n")
+        if cmd == ["nix-store", "--query", "--hash", missing_path]:
+            return None
+        if cmd[:3] == ["nix", "hash", "convert"]:
+            return real_exec_cmd(cmd, **kwargs)
+        raise AssertionError(f"unexpected command: {cmd} kwargs={kwargs}")
+
+    monkeypatch.setattr(provenance_main, "exec_cmd", fake_exec_cmd)
+
+    assert provenance_main.get_subjects(
+        {"out": {"path": output_path}, "doc": {"path": missing_path}},
+    ) == [
+        {
+            "name": "out",
+            "uri": output_path,
+            "digest": {"sha256": digest},
+        }
+    ]
+
+
+def test_provenance_uses_store_path_hint_for_nix_2_33_outputs_without_path(monkeypatch):
+    target = "/custom/store/0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-root.drv"
+    drv_basename = "0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-root.drv"
+    out_basename = "1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-root"
+    output_hash = "sha256-ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0="
+    digest = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    real_exec_cmd = provenance_main.exec_cmd
+
+    def fake_exec_cmd(cmd, **kwargs):
+        if cmd[:3] == ["nix", "derivation", "show"]:
+            assert cmd[3] == target
+            return SimpleNamespace(
+                stdout=json.dumps(
+                    {
+                        "version": 4,
+                        "derivations": {
+                            drv_basename: {
+                                "name": "root",
+                                "outputs": {
+                                    "out": {
+                                        "method": "nar",
+                                        "hash": output_hash,
+                                    }
+                                },
+                                "env": {"out": out_basename},
+                            }
+                        },
+                    }
+                )
+            )
+        if cmd[:3] == ["nix", "hash", "convert"]:
+            return real_exec_cmd(cmd, **kwargs)
+        raise AssertionError(f"unexpected command: {cmd} kwargs={kwargs}")
+
+    monkeypatch.setattr(provenance_main, "exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(
+        provenance_main, "get_dependencies", lambda *_args, **_kwargs: []
+    )
+
+    metadata = provenance_main.BuildMeta("", "", "", "", "", "{}", "{}")
+    provenance = provenance_main.provenance(target, metadata)
+
+    assert provenance["subject"] == [
+        {
+            "name": "out",
+            "uri": f"/custom/store/{out_basename}",
+            "digest": {"sha256": digest},
+        }
+    ]
+
+
+def test_provenance_keeps_fixed_output_subjects_when_output_is_not_realized(
+    monkeypatch,
+):
+    target = "/custom/store/0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-root.drv"
+    drv_basename = "0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-root.drv"
+    out_basename = "1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-root"
+    output_hash = "sha256-ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0="
+    digest = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    real_exec_cmd = provenance_main.exec_cmd
+
+    def fake_exec_cmd(cmd, **kwargs):
+        if cmd[:3] == ["nix", "derivation", "show"]:
+            assert cmd[3] == target
+            return SimpleNamespace(
+                stdout=json.dumps(
+                    {
+                        "version": 4,
+                        "derivations": {
+                            drv_basename: {
+                                "name": "root",
+                                "outputs": {
+                                    "out": {"method": "nar", "hash": output_hash}
+                                },
+                                "env": {"out": out_basename},
+                            }
+                        },
+                    }
+                )
+            )
+        if cmd == ["nix-store", "--query", "--hash", f"/custom/store/{out_basename}"]:
+            return None
+        if cmd[:3] == ["nix", "hash", "convert"]:
+            return real_exec_cmd(cmd, **kwargs)
+        raise AssertionError(f"unexpected command: {cmd} kwargs={kwargs}")
+
+    monkeypatch.setattr(provenance_main, "exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(
+        provenance_main, "get_dependencies", lambda *_args, **_kwargs: []
+    )
+
+    metadata = provenance_main.BuildMeta("", "", "", "", "", "{}", "{}")
+    provenance = provenance_main.provenance(target, metadata)
+
+    assert provenance["subject"] == [
+        {
+            "name": "out",
+            "uri": f"/custom/store/{out_basename}",
+            "digest": {"sha256": digest},
         }
     ]
 


### PR DESCRIPTION
Nix 2.33 changed `nix derivation show` to a wrapped version 4 JSON payload and basename-only store paths. sbomnix's parser assumed the legacy map, which broke provenance generation and made the `nix derivation show` path
in `find_deriver` unreliable on 2.33.

- Add a shared `parse_nix_derivation_show` helper in `common/utils.py` that unwraps v4 payloads, infers the store dir, and restores absolute store paths for derivation keys, output paths, basename-only env store paths, and
input references.
- Route `sbomnix/nix.py:find_deriver` through the helper so deriver lookup works on 2.33.
- Route provenance’s top-level and recursive derivation parsing through the same helper, resolve output paths from `env` when `outputs[*].path` is omitted, and normalize digests to lowercase base16 per in-toto `DigestSet`.
Prefer derivation metadata for fixed-output subjects and dependencies, reject overflowing nix32 digests, and skip unresolved outputs with no digest.

Compatibility: recognized provenance digest strings now change from raw `nix-store` encoding to canonical hex, so consumers diffing digests directly will see churn.

Fixes #267
