### PR TITLE
meta: deterministic nixpkgs metadata source selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Table of Contents
    * [Generate SBOM Including Buildtime Dependencies](#generate-sbom-including-buildtime-dependencies)
    * [Generate SBOM Based on Result Symlink](#generate-sbom-based-on-result-symlink)
    * [Generate SBOM Based on Flake Reference](#generate-sbom-based-on-flake-reference)
+   * [Nixpkgs Metadata Source Selection](#nixpkgs-metadata-source-selection)
    * [Visualize Package Dependencies](#visualize-package-dependencies)
 * [Contribute](#contribute)
 * [License](#license)
@@ -173,6 +174,29 @@ $ sbomnix /path/to/result
 ```bash
 $ sbomnix github:NixOS/nixpkgs?ref=nixos-unstable#wget --buildtime
 ```
+
+#### Nixpkgs Metadata Source Selection
+`sbomnix` enriches packages with nixpkgs metadata, such as descriptions,
+licenses, maintainers, and homepage links, when it can select a nixpkgs
+source that is tied to the target.
+
+For flakeref targets, `sbomnix` uses the target flake context. NixOS
+toplevel flakerefs are handled through the selected NixOS package set, so
+overlays, package overrides, nixpkgs config, and system-specific package-set
+changes can be represented.
+
+Store-path targets skip nixpkgs metadata by default; pass `--meta-nixpkgs` to
+choose the source explicitly.
+
+`--meta-nixpkgs <flakeref-or-path>` scans an explicit nixpkgs source.
+`--meta-nixpkgs nix-path` scans the `nixpkgs=` entry from `NIX_PATH` as a
+legacy opt-in source. `--exclude-meta` disables this enrichment and cannot be
+combined with `--meta-nixpkgs`.
+
+CycloneDX and SPDX outputs record the selected metadata source in document
+metadata, including fields such as `nixpkgs:metadata_source_method`,
+`nixpkgs:path`, `nixpkgs:rev`, `nixpkgs:flakeref`, `nixpkgs:version`, and
+`nixpkgs:message`.
 
 #### Visualize Package Dependencies
 `sbomnix` finds the package dependencies using `nixgraph`.

--- a/scripts/release-asset.sh
+++ b/scripts/release-asset.sh
@@ -8,12 +8,14 @@ set -euo pipefail
 
 mkdir -p build/
 
-nix run .#sbomnix -- . \
+release_target=".#sbomnix"
+
+nix run .#sbomnix -- "$release_target" \
   --cdx=./build/sbom.runtime.cdx.json \
   --spdx=./build/sbom.runtime.spdx.json \
   --csv=./build/sbom.runtime.csv
 
-nix run .#sbomnix -- --buildtime . \
+nix run .#sbomnix -- --buildtime "$release_target" \
   --cdx=./build/sbom.buildtime.cdx.json \
   --spdx=./build/sbom.buildtime.spdx.json \
   --csv=./build/sbom.buildtime.csv

--- a/src/common/flakeref.py
+++ b/src/common/flakeref.py
@@ -12,6 +12,19 @@ from common.errors import FlakeRefRealisationError, FlakeRefResolutionError
 from common.log import LOG, LOG_VERBOSE
 from common.proc import ExecCmdFn, exec_cmd, nix_cmd
 
+NIXOS_CONFIGURATION_TOPLEVEL_SUFFIX = ".config.system.build.toplevel"
+_NIXOS_CONFIGURATION_PREFIX_RE = re.compile(
+    r"^(?P<flake>.+)#nixosConfigurations\.(?P<rest>.+)$"
+)
+_UNQUOTED_ATTR_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_'-]+$")
+_NIX_STRING_ESCAPES = {
+    '"': '"',
+    "\\": "\\",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+}
+
 
 def try_resolve_flakeref(
     flakeref: str,
@@ -29,6 +42,27 @@ def try_resolve_flakeref(
     log = LOG if log is None else log
 
     looks_like_flakeref = _looks_like_flakeref(flakeref)
+    if force_realise and looks_like_flakeref:
+        log.info("Realising flakeref '%s'", flakeref)
+        cmd = nix_cmd(
+            "build",
+            "--no-link",
+            "--print-out-paths",
+            flakeref,
+            impure=impure,
+        )
+        ret = exec_cmd_fn(cmd, raise_on_error=False, return_error=True, log_error=False)
+        if ret is None or ret.returncode != 0:
+            raise FlakeRefRealisationError(flakeref, ret.stderr if ret else "")
+        nixpath = _first_output_path(ret.stdout)
+        if not nixpath:
+            raise FlakeRefRealisationError(
+                flakeref,
+                "nix build returned no output path",
+            )
+        log.debug("flakeref='%s' maps to path='%s'", flakeref, nixpath)
+        return nixpath
+
     if looks_like_flakeref:
         log.info("Evaluating flakeref '%s'", flakeref)
     else:
@@ -50,6 +84,122 @@ def try_resolve_flakeref(
     if ret is None or ret.returncode != 0:
         raise FlakeRefRealisationError(flakeref, ret.stderr if ret else "")
     return nixpath
+
+
+def _first_output_path(stdout: str) -> str:
+    """Return the first output path printed by ``nix build --print-out-paths``."""
+    return next((line.strip() for line in stdout.splitlines() if line.strip()), "")
+
+
+def parse_nixos_configuration_ref(
+    flakeref: str,
+    *,
+    suffix: str = "",
+) -> tuple[str, str] | None:
+    """
+    Parse ``<flake>#nixosConfigurations.<name><suffix>``.
+
+    ``name`` may be either an unquoted attr segment or a quoted segment such as
+    ``"host.example.com"``. The returned name is decoded and safe to re-quote.
+    """
+    match = _NIXOS_CONFIGURATION_PREFIX_RE.match(flakeref or "")
+    if not match:
+        return None
+    parsed = _consume_nix_attr_segment(match.group("rest"))
+    if not parsed:
+        return None
+    name, tail = parsed
+    if tail != suffix:
+        return None
+    return match.group("flake"), name
+
+
+def quote_nix_attr_segment(name: str) -> str:
+    """Return a safely quoted Nix attr path segment."""
+    escaped = []
+    idx = 0
+    while idx < len(name):
+        if name.startswith("${", idx):
+            escaped.append(r"\${")
+            idx += 2
+            continue
+        char = name[idx]
+        if char == '"':
+            escaped.append('\\"')
+        elif char == "\\":
+            escaped.append("\\\\")
+        elif char == "\n":
+            escaped.append("\\n")
+        elif char == "\r":
+            escaped.append("\\r")
+        elif char == "\t":
+            escaped.append("\\t")
+        else:
+            escaped.append(char)
+        idx += 1
+    return '"' + "".join(escaped) + '"'
+
+
+def _consume_nix_attr_segment(value: str) -> tuple[str, str] | None:
+    if not value:
+        return None
+    if value.startswith('"'):
+        end = _find_quoted_attr_end(value)
+        if end is None:
+            return None
+        raw_segment = value[: end + 1]
+        segment = _decode_nix_quoted_attr_segment(raw_segment)
+        if segment is None:
+            return None
+        return segment, value[end + 1 :]
+
+    segment, separator, tail = value.partition(".")
+    if not segment or not _UNQUOTED_ATTR_SEGMENT_RE.match(segment):
+        return None
+    return segment, f"{separator}{tail}" if separator else ""
+
+
+def _decode_nix_quoted_attr_segment(value: str) -> str | None:
+    end = len(value) - 1
+    if len(value) < 2 or value[0] != '"' or value[end] != '"':
+        return None
+
+    decoded = []
+    idx = 1
+    while idx < end:
+        char = value[idx]
+        if char == "$" and idx + 1 < end and value[idx + 1] == "{":
+            return None
+        if char != "\\":
+            decoded.append(char)
+            idx += 1
+            continue
+
+        idx += 1
+        if idx >= end:
+            return None
+        escaped = value[idx]
+        if escaped == "$" and idx + 1 < end and value[idx + 1] == "{":
+            decoded.append("${")
+            idx += 2
+            continue
+        decoded.append(_NIX_STRING_ESCAPES.get(escaped, f"\\{escaped}"))
+        idx += 1
+    return "".join(decoded)
+
+
+def _find_quoted_attr_end(value: str) -> int | None:
+    escaped = False
+    for idx, char in enumerate(value[1:], start=1):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == '"':
+            return idx
+    return None
 
 
 def _looks_like_flakeref(flakeref: str) -> bool:

--- a/src/nixmeta/flake_metadata.py
+++ b/src/nixmeta/flake_metadata.py
@@ -48,16 +48,56 @@ def is_nixpkgs_metadata(meta_json):
     return False
 
 
-def _get_flake_nixpkgs_val(meta_json, key):
+def _locked_obj_is_nixpkgs(node_name, locked_obj):
     try:
-        return meta_json["locks"]["nodes"]["nixpkgs"]["locked"][key]
-    except (KeyError, TypeError):
-        return None
+        if locked_obj.get("repo") == "nixpkgs":
+            return True
+        if node_name.startswith("nixpkgs") and locked_obj.get("type") == "path":
+            return True
+    except AttributeError:
+        return False
+    return False
+
+
+def _input_node_names(value):
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list) and value and isinstance(value[-1], str):
+        # Lock-file override chains store the resolved input node as the last item.
+        return [value[-1]]
+    return []
 
 
 def _get_flake_nixpkgs_obj(meta_json):
     try:
-        return meta_json["locks"]["nodes"]["nixpkgs"]["locked"]
+        nodes = meta_json["locks"]["nodes"]
+        root_name = meta_json["locks"]["root"]
+        root_inputs = nodes[root_name].get("inputs", {})
+    except (KeyError, TypeError, AttributeError):
+        return None
+
+    for node_name in _input_node_names(root_inputs.get("nixpkgs")):
+        try:
+            return nodes[node_name]["locked"]
+        except (KeyError, TypeError):
+            continue
+
+    candidates = []
+    for node_name, node in nodes.items():
+        try:
+            locked_obj = node["locked"]
+        except (KeyError, TypeError):
+            continue
+        if _locked_obj_is_nixpkgs(node_name, locked_obj):
+            candidates.append(locked_obj)
+    if len(candidates) == 1:
+        return candidates[0]
+    return None
+
+
+def _get_flake_nixpkgs_val(meta_json, key):
+    try:
+        return _get_flake_nixpkgs_obj(meta_json)[key]
     except (KeyError, TypeError):
         return None
 

--- a/src/nixmeta/scanner.py
+++ b/src/nixmeta/scanner.py
@@ -6,6 +6,7 @@
 """Summarize nixpkgs meta-attributes"""
 
 import pathlib
+import subprocess
 from tempfile import NamedTemporaryFile
 
 import pandas as pd
@@ -17,6 +18,19 @@ from nixmeta.flake_metadata import get_flake_metadata, nixref_to_nixpkgs_path
 from nixmeta.metadata_json import parse_json_metadata
 
 ###############################################################################
+
+
+def _run_nix_env_metadata(cmd, stdout):
+    """Run nix-env metadata scan while keeping successful eval warnings quiet."""
+    ret = subprocess.run(
+        cmd,
+        encoding="utf-8",
+        check=True,
+        stdout=stdout,
+        stderr=subprocess.PIPE,
+    )
+    if ret.stderr:
+        LOG.debug("nix-env metadata stderr:\n%s", ret.stderr.strip())
 
 
 class NixMetaScanner:
@@ -52,13 +66,35 @@ class NixMetaScanner:
             #   NIX_PATH="nixpkgs=/tmp/ownpkgs-special-unstable/ownpkgs-nix-env.nix"
             #   sbomnix /nix/store/outputpath-for-ownpkgs-special-unstable-flake-output
             nixpkgs_path = pathlib.Path(nixref)
-            if not nixpkgs_path.exists():
-                return
+        self.scan_path(nixpkgs_path)
+
+    def scan_path(self, nixpkgs_path):
+        """Scan nixpkgs meta-info using an already resolved nixpkgs path."""
+        nixpkgs_path = pathlib.Path(nixpkgs_path)
         if not nixpkgs_path.exists():
             LOG.warning("Nixpkgs not in nix store: %s", nixpkgs_path.as_posix())
             return
         LOG.debug("nixpkgs: %s", nixpkgs_path)
         self._read_nixpkgs_meta(nixpkgs_path)
+
+    def scan_expression(self, expression, *, impure=False):
+        """Scan nixpkgs meta-info using an expression returning a package set."""
+        prefix = "nixmeta_expr_"
+        suffix = ".nix"
+        with NamedTemporaryFile(
+            mode="w",
+            delete=True,
+            encoding="utf-8",
+            prefix=prefix,
+            suffix=suffix,
+        ) as f:
+            f.write(expression)
+            f.flush()
+            self._read_nixpkgs_meta(
+                pathlib.Path(f.name),
+                enable_flakes=True,
+                impure=impure,
+            )
 
     def to_csv(self, csv_path, append=False):
         """Export meta-info to a csv file"""
@@ -77,7 +113,13 @@ class NixMetaScanner:
         """Return meta-info as dataframe"""
         return self.df_meta
 
-    def _read_nixpkgs_meta(self, nixpkgs_path):
+    def _read_nixpkgs_meta(
+        self,
+        nixpkgs_path,
+        *,
+        enable_flakes=False,
+        impure=False,
+    ):
         prefix = "nixmeta_"
         suffix = ".json"
         with NamedTemporaryFile(delete=True, prefix=prefix, suffix=suffix) as f:
@@ -89,17 +131,21 @@ class NixMetaScanner:
                 "--json",
                 "-f",
                 f"{nixpkgs_path.as_posix()}",
-                "--arg",
-                "config",
-                "{allowAliases=false;}",
             ]
-            exec_cmd(cmd, stdout=f)
+            if enable_flakes:
+                cmd.extend(["--option", "experimental-features", "nix-command flakes"])
+            if impure:
+                cmd.append("--impure")
+            cmd.extend(["--arg", "config", "{allowAliases=false;}"])
+            _run_nix_env_metadata(cmd, stdout=f)
             LOG.debug("Generated meta.json: %s", f.name)
             LOG.info("Parsing nixpkgs metadata")
             self.df_meta = parse_json_metadata(f.name, log=LOG)
             self._drop_duplicates()
 
     def _drop_duplicates(self):
+        if self.df_meta is None or self.df_meta.empty:
+            return
         self.df_meta = self.df_meta.astype(str)
         self.df_meta.fillna("", inplace=True)
         uids = [

--- a/src/sbomnix/cli_utils.py
+++ b/src/sbomnix/cli_utils.py
@@ -11,7 +11,12 @@ import pathlib
 from dataclasses import dataclass
 from tempfile import NamedTemporaryFile
 
-from common.flakeref import try_resolve_flakeref
+from common.flakeref import (
+    NIXOS_CONFIGURATION_TOPLEVEL_SUFFIX,
+    parse_nixos_configuration_ref,
+    quote_nix_attr_segment,
+    try_resolve_flakeref,
+)
 from common.log import LOG
 from common.proc import exit_unless_nix_artifact
 from sbomnix.sbomdb import SbomDb
@@ -23,6 +28,7 @@ class ResolvedNixTarget:
 
     path: str
     flakeref: str | None = None
+    original_ref: str | None = None
 
 
 @dataclass(frozen=True)
@@ -40,15 +46,33 @@ class GeneratedSbom:
 
 
 def resolve_nix_target(nixref, buildtime=False, impure=False):
-    """Resolve a CLI target to a nix path, preserving flakeref provenance."""
+    """Resolve a CLI target to a nix path, preserving flakeref context."""
     runtime = not buildtime
-    target_path = try_resolve_flakeref(nixref, force_realise=runtime, impure=impure)
+    resolved_ref = _normalize_nixos_configuration_ref(nixref)
+    target_path = try_resolve_flakeref(
+        resolved_ref,
+        force_realise=runtime,
+        impure=impure,
+    )
     if target_path:
-        return ResolvedNixTarget(path=target_path, flakeref=nixref)
+        return ResolvedNixTarget(
+            path=target_path,
+            flakeref=resolved_ref,
+            original_ref=nixref,
+        )
 
     target_path = pathlib.Path(nixref).resolve().as_posix()
     exit_unless_nix_artifact(nixref, force_realise=runtime)
-    return ResolvedNixTarget(path=target_path)
+    return ResolvedNixTarget(path=target_path, original_ref=nixref)
+
+
+def _normalize_nixos_configuration_ref(nixref):
+    parsed = parse_nixos_configuration_ref(nixref)
+    if not parsed:
+        return nixref
+    flake, name = parsed
+    attr = quote_nix_attr_segment(name)
+    return f"{flake}#nixosConfigurations.{attr}{NIXOS_CONFIGURATION_TOPLEVEL_SUFFIX}"
 
 
 def generate_temp_sbom(

--- a/src/sbomnix/exporters.py
+++ b/src/sbomnix/exporters.py
@@ -16,6 +16,15 @@ from common.pkgmeta import get_py_pkg_version
 from common.spdx import canonicalize_spdx_license_id
 from sbomnix.cdx import _drv_to_cdx_component, _drv_to_cdx_dependency
 
+_NIXPKGS_META_SOURCE_FIELDS = (
+    ("nixpkgs:metadata_source_method", "method"),
+    ("nixpkgs:path", "path"),
+    ("nixpkgs:rev", "rev"),
+    ("nixpkgs:flakeref", "flakeref"),
+    ("nixpkgs:version", "version"),
+    ("nixpkgs:message", "message"),
+)
+
 
 def write_json(pathname, data, printinfo=False):
     """Write JSON data to a file."""
@@ -24,6 +33,34 @@ def write_json(pathname, data, printinfo=False):
         outfile.write(json_string)
         if printinfo:
             LOG.info("Wrote: %s", outfile.name)
+
+
+def _nixpkgs_meta_source_properties(sbomdb):
+    """Return non-empty document properties for nixpkgs metadata source."""
+    source = getattr(sbomdb, "nixpkgs_meta_source", None)
+    if source is None:
+        return []
+    properties = []
+    for property_name, attr_name in _NIXPKGS_META_SOURCE_FIELDS:
+        value = getattr(source, attr_name)
+        if value:
+            properties.append({"name": property_name, "value": str(value)})
+    return properties
+
+
+def _spdx_nixpkgs_meta_source_comment(sbomdb):
+    """Return a compact SPDX comment line for nixpkgs metadata source."""
+    source = getattr(sbomdb, "nixpkgs_meta_source", None)
+    if source is None:
+        return None
+    fields = []
+    for property_name, attr_name in _NIXPKGS_META_SOURCE_FIELDS:
+        value = getattr(source, attr_name)
+        if value:
+            fields.append(f"{property_name.removeprefix('nixpkgs:')}={value}")
+    if not fields:
+        return None
+    return "nixpkgs metadata source: " + "; ".join(fields)
 
 
 def build_cdx_document(sbomdb):
@@ -45,6 +82,7 @@ def build_cdx_document(sbomdb):
         prop["name"] = "sbom_dependencies_depth"
         prop["value"] = str(sbomdb.depth)
         cdx["metadata"]["properties"].append(prop)
+    cdx["metadata"]["properties"].extend(_nixpkgs_meta_source_properties(sbomdb))
     tool = {}
     tool["vendor"] = "TII"
     tool["name"] = "sbomnix"
@@ -164,7 +202,11 @@ def build_spdx_document(sbomdb):
     creation_info["creators"] = []
     creation_info["creators"].append(f"Tool: sbomnix-{get_py_pkg_version()}")
     spdx["creationInfo"] = creation_info
-    spdx["comment"] = f"included dependencies: '{sbomdb.sbom_type}'"
+    comments = [f"included dependencies: '{sbomdb.sbom_type}'"]
+    source_comment = _spdx_nixpkgs_meta_source_comment(sbomdb)
+    if source_comment:
+        comments.append(source_comment)
+    spdx["comment"] = "\n".join(comments)
     spdx["packages"] = []
     spdx["relationships"] = []
     for drv in sbomdb.df_sbomdb.itertuples():

--- a/src/sbomnix/main.py
+++ b/src/sbomnix/main.py
@@ -50,6 +50,12 @@ def getargs(args=None):
     parser.add_argument(
         "--exclude-meta", help=helps, action="store_true", default=False
     )
+    helps = (
+        "Nixpkgs source used for metadata enrichment. Accepts a nixpkgs "
+        "flakeref, a nixpkgs source path, or nix-path. Overrides automatic "
+        "metadata-source detection."
+    )
+    parser.add_argument("--meta-nixpkgs", help=helps, metavar="META_NIXPKGS")
     helps = "Exclude using heuristics-based CPE matches in the output"
     parser.add_argument(
         "--exclude-cpe-matching", help=helps, action="store_true", default=False
@@ -83,6 +89,8 @@ def main():
 
 
 def _run(args):
+    if args.exclude_meta and args.meta_nixpkgs:
+        raise SbomnixError("--exclude-meta cannot be used with --meta-nixpkgs")
     target = resolve_nix_target(
         args.NIXREF, buildtime=args.buildtime, impure=args.impure
     )
@@ -92,6 +100,9 @@ def _run(args):
         buildtime=args.buildtime,
         depth=args.depth,
         flakeref=target.flakeref,
+        original_ref=target.original_ref,
+        meta_nixpkgs=args.meta_nixpkgs,
+        impure=args.impure,
         include_meta=not args.exclude_meta,
         include_vulns=args.include_vulns,
         include_cpe=not args.exclude_cpe_matching,

--- a/src/sbomnix/meta.py
+++ b/src/sbomnix/meta.py
@@ -2,21 +2,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# pylint: disable=too-few-public-methods
+"""Cache and scan nixpkgs meta information."""
 
-"""Cache nixpkgs meta information"""
-
-import os
 import pathlib
-import re
 import tempfile
+from dataclasses import replace
 from getpass import getuser
 
 from filelock import FileLock
 
 from common.log import LOG
-from nixmeta.scanner import NixMetaScanner, nixref_to_nixpkgs_path
+from nixmeta.scanner import NixMetaScanner
 from sbomnix.dfcache import LockedDfCache
+from sbomnix.meta_source import (
+    META_NIXPKGS_NIX_PATH,
+    SCAN_EXCEPTIONS,
+    NixpkgsMetaSource,
+    NixpkgsMetaSourceResolver,
+    classify_meta_nixpkgs,
+)
 
 ###############################################################################
 
@@ -29,13 +33,21 @@ _FLOCK = pathlib.Path(tempfile.gettempdir()) / f"{getuser()}_sbomnix_meta.lock"
 
 ###############################################################################
 
+__all__ = [
+    "META_NIXPKGS_NIX_PATH",
+    "Meta",
+    "NixpkgsMetaSource",
+    "classify_meta_nixpkgs",
+]
 
-class Meta:
-    """Cache nixpkgs meta information"""
+
+class Meta:  # pylint: disable=too-many-arguments
+    """Cache nixpkgs meta information."""
 
     def __init__(self):
         self.lock = FileLock(_FLOCK)
         self.cache = LockedDfCache()
+        self.source_resolver = NixpkgsMetaSourceResolver()
 
     def get_nixpkgs_meta(self, nixref=None):
         """
@@ -43,30 +55,134 @@ class Meta:
         nix store path or flake reference. If nixref is None, attempt to
         read the nixpkgs store path from NIX_PATH environment variable.
         """
-        nixpkgs_path = None
-        if nixref:
-            # Read meta from nixpkgs pinned by nixref
-            LOG.debug("Reading nixpkgs path from nixref: %s", nixref)
-            nixpath = nixref_to_nixpkgs_path(nixref)
-            if nixpath:
-                nixpkgs_path = nixpath.as_posix()
-        elif "NIX_PATH" in os.environ:
-            # Read meta from nipxkgs referenced in NIX_PATH
-            LOG.debug("Reading nixpkgs path from NIX_PATH environment")
-            nix_path = os.environ["NIX_PATH"]
-            m_nixpkgs = re.search(r"(?:^|:)nixpkgs=([^:]+)", nix_path)
-            if m_nixpkgs:
-                nixpkgs_path = m_nixpkgs.group(1)
-        df = None
-        if nixpkgs_path:
-            LOG.debug("Scanning meta-info using nixpkgs path: %s", nixpkgs_path)
-            df = self._scan(nixpkgs_path)
+        source = self.source_resolver.resolve_legacy_source(nixref)
+        return self._scan_source(source)
+
+    def get_nixpkgs_meta_with_source(
+        self,
+        *,
+        target_path=None,
+        flakeref=None,
+        original_ref=None,
+        explicit_nixpkgs=None,
+        impure=False,
+    ):
+        """Return nixpkgs metadata and selected metadata source."""
+        source = self._resolve_source(
+            target_path=target_path,
+            flakeref=flakeref,
+            original_ref=original_ref,
+            explicit_nixpkgs=explicit_nixpkgs,
+            impure=impure,
+        )
+        return self._scan_source_with_source(source)
+
+    def _resolve_source(
+        self,
+        *,
+        target_path=None,
+        flakeref=None,
+        original_ref=None,
+        explicit_nixpkgs=None,
+        impure=False,
+    ):
+        if explicit_nixpkgs:
+            return self.source_resolver.resolve_meta_nixpkgs_option(
+                explicit_nixpkgs,
+                target_path=target_path,
+            )
+        if flakeref:
+            source = self.source_resolver.resolve_flakeref_target_source(
+                flakeref,
+                impure=impure,
+            )
+            if source and source.path:
+                return source
+            legacy_source = self.source_resolver.resolve_legacy_source(flakeref)
+            if legacy_source.path:
+                return legacy_source
+            # Keep target-specific failure guidance when legacy lookup also fails.
+            if source:
+                return source
+            return legacy_source
+
+        return self.source_resolver.path_target_without_source(
+            target_path=target_path,
+            original_ref=original_ref,
+        )
+
+    def _scan_source(self, source):
+        df, _source = self._scan_source_with_source(source)
         return df
+
+    def _scan_source_with_source(self, source):
+        if not source.path:
+            return None, source
+        if source.expression:
+            LOG.debug("Scanning meta-info using nix expression for: %s", source.path)
+            df = self._scan_expression(
+                source.expression,
+                cache_key=source.expression_cache_key,
+                impure=source.expression_impure,
+            )
+            if df is not None and not df.empty:
+                return df, source
+            LOG.warning(
+                "Failed scanning evaluated package set; falling back to source path: %s",
+                source.path,
+            )
+            source = replace(
+                source,
+                expression=None,
+                expression_cache_key=None,
+                expression_impure=False,
+                message=(
+                    "Evaluated package-set metadata scan failed; fell back to "
+                    "base nixpkgs source metadata. Overlays, package overrides, "
+                    "nixpkgs config, and target system-specific package-set "
+                    "changes may not be represented."
+                ),
+            )
+        LOG.debug("Scanning meta-info using nixpkgs path: %s", source.path)
+        return self._scan(source.path), source
+
+    def _scan_expression(self, expression, *, cache_key=None, impure=False):
+        if cache_key is None:
+            with self.lock:
+                LOG.debug("cache disabled, scanning expression")
+                df = self._try_scan_expression(expression, impure=impure)
+                if df is None or df.empty:
+                    LOG.warning("Failed scanning uncached nixmeta expression")
+                    return None
+                return df
+        cache_key = f"expr:{cache_key}"
+        with self.lock:
+            df = self.cache.get(cache_key)
+            if df is not None and not df.empty:
+                LOG.debug("found from cache: %s", cache_key)
+                return df
+            LOG.debug("cache miss, scanning expression: %s", cache_key)
+            df = self._try_scan_expression(expression, impure=impure)
+            if df is None or df.empty:
+                LOG.warning("Failed scanning nixmeta expression: %s", cache_key)
+                return None
+            self.cache.set(key=cache_key, value=df, ttl=_NIXMETA_NIXPKGS_TTL)
+            return df
+
+    @staticmethod
+    def _try_scan_expression(expression, *, impure=False):
+        try:
+            scanner = NixMetaScanner()
+            scanner.scan_expression(expression, impure=impure)
+            return scanner.to_df()
+        except SCAN_EXCEPTIONS:
+            LOG.debug("Failed scanning nixmeta expression", exc_info=True)
+            return None
 
     def _scan(self, nixpkgs_path):
         # In case sbomnix is run concurrently, we want to make sure there's
-        # only one instance of NixMetaScanner.scan() running at a time.
-        # The reason is, NixMetaScanner.scan() potentially invokes
+        # only one instance of NixMetaScanner.scan_path() running at a time.
+        # The reason is, NixMetaScanner.scan_path() potentially invokes
         # `nix-env -qa --meta --json -f /path/to/nixpkgs` which is very
         # memory intensive. The locking needs to happen here (and not in
         # NixMetaScanner) because this object caches the nixmeta info.
@@ -81,7 +197,7 @@ class Meta:
                 return df
             LOG.debug("cache miss, scanning: %s", nixpkgs_path)
             scanner = NixMetaScanner()
-            scanner.scan(nixpkgs_path)
+            scanner.scan_path(nixpkgs_path)
             df = scanner.to_df()
             if df is None or df.empty:
                 LOG.warning("Failed scanning nixmeta: %s", nixpkgs_path)

--- a/src/sbomnix/meta_source.py
+++ b/src/sbomnix/meta_source.py
@@ -1,0 +1,410 @@
+# SPDX-FileCopyrightText: 2026 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve nixpkgs metadata sources from target context and CLI options."""
+
+import json
+import os
+import pathlib
+import re
+from dataclasses import dataclass, replace
+from subprocess import CalledProcessError
+from urllib.parse import urlencode
+
+from common.errors import SbomnixError
+from common.flakeref import (
+    NIXOS_CONFIGURATION_TOPLEVEL_SUFFIX,
+    parse_nixos_configuration_ref,
+    quote_nix_attr_segment,
+)
+from common.log import LOG
+from common.proc import exec_cmd, nix_cmd
+from nixmeta.scanner import nixref_to_nixpkgs_path
+
+META_NIXPKGS_NIX_PATH = "nix-path"
+
+RESERVED_META_NIXPKGS_MODES = frozenset({META_NIXPKGS_NIX_PATH})
+
+SCAN_EXCEPTIONS = (KeyError, OSError, CalledProcessError, TypeError, ValueError)
+_NIXREF_RESOLUTION_EXCEPTIONS = (AttributeError, *SCAN_EXCEPTIONS)
+
+
+@dataclass(frozen=True)
+class NixpkgsMetaSource:  # pylint: disable=too-many-instance-attributes
+    """Description of the nixpkgs source used for metadata enrichment."""
+
+    method: str
+    path: str | None = None
+    flakeref: str | None = None
+    rev: str | None = None
+    version: str | None = None
+    message: str | None = None
+    expression: str | None = None
+    expression_cache_key: str | None = None
+    expression_impure: bool = False
+
+
+def classify_meta_nixpkgs(value):
+    """Classify a --meta-nixpkgs value as a reserved mode or explicit source."""
+    if value in RESERVED_META_NIXPKGS_MODES:
+        return value
+    return "explicit"
+
+
+def read_nixpkgs_version(nixpkgs_path):
+    """Read nixpkgs version from a source path if available."""
+    try:
+        return (
+            (pathlib.Path(nixpkgs_path) / "lib" / ".version")
+            .read_text(encoding="utf-8")
+            .strip()
+        )
+    except OSError:
+        return None
+
+
+def is_nix_store_path(path):
+    """Return true when path syntactically points into /nix/store."""
+    return pathlib.Path(path).as_posix().startswith("/nix/store/")
+
+
+def nixpkgs_meta_source_with_path(source):
+    """Attach path-local nixpkgs version to a metadata source."""
+    if not source.path:
+        return source
+    return replace(source, version=read_nixpkgs_version(source.path))
+
+
+class NixpkgsMetaSourceResolver:
+    """Resolve a nixpkgs metadata source without scanning metadata."""
+
+    @staticmethod
+    def path_target_without_source(target_path=None, original_ref=None):
+        """Return the no-source result for store-path targets."""
+        LOG.debug(
+            "No automatic nixpkgs metadata source for target path=%s original_ref=%s",
+            target_path,
+            original_ref,
+        )
+        return NixpkgsMetaSource(
+            method="none",
+            message=(
+                "No nixpkgs metadata source was provided for store-path target. "
+                "Skipping nixpkgs metadata. Re-run with "
+                "--meta-nixpkgs <nixpkgs-flakeref-or-path> to include metadata."
+            ),
+        )
+
+    def resolve_meta_nixpkgs_option(self, meta_nixpkgs, *, target_path=None):
+        """Resolve an explicit --meta-nixpkgs source or reserved mode."""
+        LOG.debug(
+            "Resolving explicit nixpkgs metadata source for target path=%s",
+            target_path,
+        )
+        mode = classify_meta_nixpkgs(meta_nixpkgs)
+        if mode == META_NIXPKGS_NIX_PATH:
+            return self.resolve_nix_path_source(
+                message="NIX_PATH metadata source may not match the target",
+                required=True,
+            )
+        return self.resolve_explicit_source(meta_nixpkgs)
+
+    def resolve_flakeref_target_source(self, flakeref, *, impure=False):
+        """Resolve target-specific nixpkgs metadata for known flakeref outputs."""
+        parsed = self._parse_nixos_toplevel_flakeref(flakeref)
+        if not parsed:
+            return None
+        flake, name = parsed
+        name_attr = quote_nix_attr_segment(name)
+        pkgs_path_ref = f"{flake}#nixosConfigurations.{name_attr}.pkgs.path"
+        pkgs_path = self._nix_eval_raw(pkgs_path_ref, impure=impure)
+        if pkgs_path:
+            expression_flake = self._flake_ref_for_expression(
+                flake,
+                impure=impure,
+            )
+            return nixpkgs_meta_source_with_path(
+                NixpkgsMetaSource(
+                    method="flakeref-target",
+                    path=pkgs_path,
+                    flakeref=pkgs_path_ref,
+                    message="Scanning evaluated NixOS package set from flakeref",
+                    expression=self._nixos_pkgs_expression(expression_flake, name),
+                    expression_cache_key=self._nixos_pkgs_expression_cache_key(
+                        expression_flake,
+                        name,
+                        impure=impure,
+                    ),
+                    expression_impure=impure,
+                ),
+            )
+
+        revision_ref = (
+            f"{flake}#nixosConfigurations.{name_attr}.config.system.nixos.revision"
+        )
+        rev = self._nix_eval_raw(revision_ref, impure=impure)
+        if not rev:
+            return self._nixos_toplevel_without_source()
+        nixpkgs_flakeref = f"github:NixOS/nixpkgs?rev={rev}"
+        nixpath = nixref_to_nixpkgs_path(nixpkgs_flakeref)
+        if not nixpath:
+            return self._nixos_toplevel_without_source()
+        return nixpkgs_meta_source_with_path(
+            NixpkgsMetaSource(
+                method="flakeref-target",
+                path=nixpath.as_posix(),
+                flakeref=nixpkgs_flakeref,
+                rev=rev,
+                message=(
+                    "Resolved nixpkgs from NixOS configuration revision as a "
+                    "best-effort fallback; this may not represent forked, patched, "
+                    "dirty, local, or offline nixpkgs inputs"
+                ),
+            ),
+        )
+
+    @staticmethod
+    def _nixos_toplevel_without_source():
+        return NixpkgsMetaSource(
+            method="none",
+            message=(
+                "Failed resolving target-specific nixpkgs metadata source from "
+                "NixOS configuration flakeref. Skipping nixpkgs metadata. Re-run "
+                "with --meta-nixpkgs <nixpkgs-flakeref-or-path> to include metadata."
+            ),
+        )
+
+    @staticmethod
+    def _parse_nixos_toplevel_flakeref(flakeref):
+        return parse_nixos_configuration_ref(
+            flakeref,
+            suffix=NIXOS_CONFIGURATION_TOPLEVEL_SUFFIX,
+        )
+
+    @staticmethod
+    def _nixos_pkgs_expression(flake, name):
+        flake_json = json.dumps(flake)
+        name_attr = quote_nix_attr_segment(name)
+        return (
+            "let\n"
+            f"  flake = builtins.getFlake {flake_json};\n"
+            "in\n"
+            f"  flake.nixosConfigurations.{name_attr}.pkgs\n"
+        )
+
+    def _flake_ref_for_expression(self, flake, *, impure=False):
+        if self._flake_ref_has_stable_lock(flake):
+            return flake
+        if self._should_lock_flake_ref_for_expression(flake):
+            locked_ref = self._locked_flake_ref_from_metadata(flake, impure=impure)
+            if locked_ref:
+                return locked_ref
+        return self._normalize_local_flake_ref_for_expression(flake)
+
+    @staticmethod
+    def _flake_ref_has_stable_lock(flake):
+        return re.search(r"(?:[?&])(?:narHash|rev)=", flake) is not None
+
+    @classmethod
+    def _should_lock_flake_ref_for_expression(cls, flake):
+        if cls._flake_ref_has_stable_lock(flake):
+            return False
+        if cls._is_existing_local_flake_ref(flake):
+            return True
+        return re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", flake or "") is not None
+
+    @staticmethod
+    def _is_existing_local_flake_ref(flake):
+        path_text = flake
+        if flake.startswith("path:"):
+            path_text = flake.removeprefix("path:").partition("?")[0]
+        elif re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", flake or ""):
+            return False
+        return pathlib.Path(path_text).expanduser().exists()
+
+    @staticmethod
+    def _locked_flake_ref_from_metadata(flake, *, impure=False):
+        meta_json = NixpkgsMetaSourceResolver._nix_flake_metadata(
+            flake,
+            impure=impure,
+        )
+        if meta_json is None:
+            return None
+        try:
+            source_path = meta_json["path"]
+            locked = meta_json["locked"]
+            nar_hash = locked["narHash"]
+        except (KeyError, TypeError):
+            return None
+        if not source_path or not nar_hash or not is_nix_store_path(source_path):
+            return None
+        query = {"narHash": nar_hash}
+        locked_dir = locked.get("dir")
+        if locked_dir:
+            query["dir"] = locked_dir
+        return f"path:{source_path}?{urlencode(query, safe='/')}"
+
+    @staticmethod
+    def _nix_flake_metadata(flake, *, impure=False):
+        LOG.debug("Reading flake metadata for nixpkgs metadata expression: %s", flake)
+        ret = exec_cmd(
+            nix_cmd("flake", "metadata", flake, "--json", impure=impure),
+            raise_on_error=False,
+            return_error=True,
+            log_error=False,
+        )
+        if ret is None or ret.returncode != 0:
+            LOG.debug("Failed reading flake metadata for expression: %s", flake)
+            return None
+        try:
+            return json.loads(ret.stdout)
+        except ValueError:
+            LOG.debug("Failed parsing flake metadata for expression: %s", flake)
+            return None
+
+    @staticmethod
+    def _normalize_local_flake_ref_for_expression(flake):
+        if flake.startswith("path:"):
+            path_text, separator, query = flake.removeprefix("path:").partition("?")
+            path = pathlib.Path(path_text).expanduser()
+            if not path.is_absolute():
+                path_text = path.resolve().as_posix()
+            return f"path:{path_text}{separator}{query}"
+        if re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", flake or ""):
+            return flake
+        path = pathlib.Path(flake).expanduser()
+        if path.exists() or flake.startswith((".", "/", "~")):
+            return path.resolve().as_posix()
+        return flake
+
+    @classmethod
+    def _nixos_pkgs_expression_cache_key(cls, flake, name, *, impure=False):
+        if impure:
+            return None
+        stable_ref = cls._stable_flake_ref_for_expression_cache(flake)
+        if not stable_ref:
+            return None
+        cache_parts = json.dumps([stable_ref, name], separators=(",", ":"))
+        return f"nixos-pkgs:{cache_parts}"
+
+    @staticmethod
+    def _stable_flake_ref_for_expression_cache(flake):
+        if flake.startswith("path:/nix/store/"):
+            return flake
+        if flake.startswith("/nix/store/"):
+            return flake
+        if re.search(r"(?:[?&])rev=", flake):
+            return flake
+        return None
+
+    @staticmethod
+    def _nix_eval_raw(flakeref, *, impure=False):
+        LOG.debug("Evaluating nixpkgs metadata helper flakeref '%s'", flakeref)
+        ret = exec_cmd(
+            nix_cmd("eval", "--raw", flakeref, impure=impure),
+            raise_on_error=False,
+            return_error=True,
+            log_error=False,
+        )
+        if ret is None or ret.returncode != 0:
+            LOG.debug(
+                "Failed evaluating nixpkgs metadata helper flakeref: %s", flakeref
+            )
+            return None
+        return ret.stdout.strip() or None
+
+    def resolve_explicit_source(self, meta_nixpkgs):
+        """Resolve an explicit --meta-nixpkgs path or flakeref."""
+        path = pathlib.Path(meta_nixpkgs)
+        if path.exists():
+            resolved_path = path.resolve()
+            if is_nix_store_path(resolved_path):
+                return nixpkgs_meta_source_with_path(
+                    NixpkgsMetaSource(
+                        method="explicit",
+                        path=resolved_path.as_posix(),
+                    ),
+                )
+            nixpath = self._try_normalize_mutable_path(resolved_path)
+            if nixpath:
+                return nixpkgs_meta_source_with_path(
+                    NixpkgsMetaSource(
+                        method="explicit",
+                        path=nixpath.as_posix(),
+                        flakeref=resolved_path.as_posix(),
+                    ),
+                )
+            raise SbomnixError(
+                "Explicit --meta-nixpkgs path must resolve to an immutable "
+                f"/nix/store source before scanning: '{meta_nixpkgs}'"
+            )
+        try:
+            nixpath = nixref_to_nixpkgs_path(meta_nixpkgs)
+        except _NIXREF_RESOLUTION_EXCEPTIONS as error:
+            raise SbomnixError(
+                f"Failed resolving --meta-nixpkgs source: '{meta_nixpkgs}'"
+            ) from error
+        if not nixpath:
+            raise SbomnixError(
+                f"Failed resolving --meta-nixpkgs source: '{meta_nixpkgs}'"
+            )
+        return nixpkgs_meta_source_with_path(
+            NixpkgsMetaSource(
+                method="explicit",
+                path=nixpath.as_posix(),
+                flakeref=meta_nixpkgs,
+            ),
+        )
+
+    @staticmethod
+    def _try_normalize_mutable_path(path):
+        try:
+            nixpath = nixref_to_nixpkgs_path(path.as_posix())
+        except _NIXREF_RESOLUTION_EXCEPTIONS:
+            LOG.debug(
+                "Failed normalizing mutable nixpkgs path: %s",
+                path.as_posix(),
+                exc_info=True,
+            )
+            return None
+        if nixpath and is_nix_store_path(nixpath):
+            return nixpath
+        return None
+
+    def resolve_legacy_source(self, nixref=None):
+        """Return the metadata source selected by the legacy lookup policy."""
+        if nixref:
+            LOG.debug("Reading nixpkgs path from nixref: %s", nixref)
+            nixpath = nixref_to_nixpkgs_path(nixref)
+            if nixpath:
+                return nixpkgs_meta_source_with_path(
+                    NixpkgsMetaSource(
+                        method="flakeref-lock",
+                        path=nixpath.as_posix(),
+                        flakeref=nixref,
+                    ),
+                )
+        elif "NIX_PATH" in os.environ:
+            return self.resolve_nix_path_source()
+        return NixpkgsMetaSource(method="none")
+
+    def resolve_nix_path_source(self, *, message=None, required=False):
+        """Return the nixpkgs source referenced by NIX_PATH."""
+        LOG.debug("Reading nixpkgs path from NIX_PATH environment")
+        nix_path = os.environ.get("NIX_PATH", "")
+        m_nixpkgs = re.search(r"(?:^|:)nixpkgs=([^:]+)", nix_path)
+        if m_nixpkgs:
+            return nixpkgs_meta_source_with_path(
+                NixpkgsMetaSource(
+                    method="nix-path",
+                    path=m_nixpkgs.group(1),
+                    message=message,
+                ),
+            )
+        if required:
+            raise SbomnixError(
+                "NIX_PATH does not contain a nixpkgs= entry required by "
+                "--meta-nixpkgs nix-path"
+            )
+        return NixpkgsMetaSource(method="none")

--- a/src/sbomnix/sbomdb.py
+++ b/src/sbomnix/sbomdb.py
@@ -21,7 +21,7 @@ from common.log import LOG, is_debug_enabled
 from nixgraph.graph import NixDependencies
 from sbomnix.dependency_index import build_dependency_index
 from sbomnix.exporters import build_cdx_document, build_spdx_document, write_json
-from sbomnix.meta import Meta
+from sbomnix.meta import Meta, NixpkgsMetaSource
 from sbomnix.nix import Store, find_deriver
 from sbomnix.vuln_enrichment import enrich_cdx_with_vulnerabilities
 
@@ -43,6 +43,9 @@ class SbomDb:
         buildtime=False,
         depth=None,
         flakeref=None,
+        original_ref=None,
+        meta_nixpkgs=None,
+        impure=False,
         include_meta=True,
         include_vulns=False,
         include_cpe=True,
@@ -61,7 +64,13 @@ class SbomDb:
         self.df_sbomdb_outputs_exploded = None
         self.dependency_index = None
         self.flakeref = flakeref
+        self.original_ref = original_ref
+        self.meta_nixpkgs = meta_nixpkgs
+        self.impure = impure
         self.meta = None
+        # "disabled" records explicit opt-out; "none" means auto-selection
+        # found no source.
+        self.nixpkgs_meta_source = NixpkgsMetaSource(method="disabled")
         self.include_cpe = include_cpe
         self._init_sbomdb(include_meta)
         self.include_vulns = include_vulns
@@ -133,12 +142,27 @@ class SbomDb:
     def _sbomdb_join_meta(self):
         """Join self.df_sbomdb with meta information"""
         self.meta = Meta()
-        df_meta = self.meta.get_nixpkgs_meta(self.flakeref)
+        df_meta, source = self.meta.get_nixpkgs_meta_with_source(
+            target_path=self.nix_path,
+            flakeref=self.flakeref,
+            original_ref=self.original_ref,
+            explicit_nixpkgs=self.meta_nixpkgs,
+            impure=self.impure,
+        )
+        self.nixpkgs_meta_source = source
         if df_meta is None or df_meta.empty:
-            LOG.warning(
-                "Failed reading nix meta information: "
-                "SBOM will include only minimum set of attributes"
-            )
+            if source.message:
+                LOG.info("%s", source.message)
+            if source.path:
+                LOG.warning(
+                    "Failed reading nix meta information: "
+                    "SBOM will include only minimum set of attributes"
+                )
+            else:
+                LOG.info(
+                    "Skipping nix meta information: "
+                    "SBOM will include only minimum set of attributes"
+                )
             return
         if is_debug_enabled():
             df_to_csv_file(df_meta, "meta.csv")

--- a/tests/test_flakeref_resolution.py
+++ b/tests/test_flakeref_resolution.py
@@ -14,7 +14,11 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from common.errors import FlakeRefRealisationError, FlakeRefResolutionError
-from common.flakeref import try_resolve_flakeref
+from common.flakeref import (
+    parse_nixos_configuration_ref,
+    quote_nix_attr_segment,
+    try_resolve_flakeref,
+)
 from common.log import LOG_VERBOSE
 
 
@@ -52,14 +56,31 @@ FLAKE_REFS = st.one_of(
 )
 
 
+@pytest.mark.parametrize(
+    ("name", "quoted"),
+    [
+        ("host${foo}.é", r'"host\${foo}.é"'),
+        ('quote"slash\\tab\tnewline\n', r'"quote\"slash\\tab\tnewline\n"'),
+    ],
+)
+def test_nixos_configuration_attr_segments_use_nix_string_escaping(name, quoted):
+    assert quote_nix_attr_segment(name) == quoted
+    assert parse_nixos_configuration_ref(f"/flake#nixosConfigurations.{quoted}") == (
+        "/flake",
+        name,
+    )
+
+
+def test_nixos_configuration_parser_rejects_unescaped_interpolation():
+    assert parse_nixos_configuration_ref('/flake#nixosConfigurations."${foo}"') is None
+
+
 def test_try_resolve_flakeref_uses_argv_lists():
     calls = []
 
     def fake_exec_cmd(cmd, **kwargs):
         calls.append((cmd, kwargs))
-        if cmd[1] == "eval":
-            return SimpleNamespace(stdout="/nix/store/resolved\n", returncode=0)
-        return SimpleNamespace(stdout="", stderr="", returncode=0)
+        return SimpleNamespace(stdout="/nix/store/resolved\n", stderr="", returncode=0)
 
     resolved = try_resolve_flakeref(
         "/tmp/my flake#pkg",
@@ -73,22 +94,9 @@ def test_try_resolve_flakeref_uses_argv_lists():
         (
             [
                 "nix",
-                "eval",
-                "--raw",
-                "/tmp/my flake#pkg",
-                "--extra-experimental-features",
-                "flakes",
-                "--extra-experimental-features",
-                "nix-command",
-                "--impure",
-            ],
-            {"raise_on_error": False, "return_error": True, "log_error": False},
-        ),
-        (
-            [
-                "nix",
                 "build",
                 "--no-link",
+                "--print-out-paths",
                 "/tmp/my flake#pkg",
                 "--extra-experimental-features",
                 "flakes",
@@ -104,14 +112,12 @@ def test_try_resolve_flakeref_uses_argv_lists():
 def test_try_resolve_flakeref_logs_flake_progress_at_info():
     logger = CapturingLogger()
 
-    def fake_exec_cmd(cmd, **_kwargs):
-        if cmd[1] == "eval":
-            return SimpleNamespace(
-                stdout="/nix/store/resolved\n",
-                stderr="",
-                returncode=0,
-            )
-        return SimpleNamespace(stdout="", stderr="", returncode=0)
+    def fake_exec_cmd(_cmd, **_kwargs):
+        return SimpleNamespace(
+            stdout="/nix/store/resolved\n",
+            stderr="",
+            returncode=0,
+        )
 
     resolved = try_resolve_flakeref(
         ".#hello",
@@ -121,11 +127,6 @@ def test_try_resolve_flakeref_logs_flake_progress_at_info():
     )
 
     assert resolved == "/nix/store/resolved"
-    assert (
-        "info",
-        "Evaluating flakeref '%s'",
-        (".#hello",),
-    ) in logger.records
     assert (
         "info",
         "Realising flakeref '%s'",
@@ -156,12 +157,22 @@ def test_try_resolve_flakeref_keeps_plain_path_probe_verbose():
 
 
 def test_try_resolve_flakeref_raises_on_failed_force_realise():
-    def fake_exec_cmd(cmd, **_kwargs):
-        if cmd[1] == "eval":
-            return SimpleNamespace(stdout="/nix/store/resolved\n", returncode=0)
+    def fake_exec_cmd(_cmd, **_kwargs):
         return SimpleNamespace(stdout="", stderr="build failed", returncode=1)
 
     with pytest.raises(FlakeRefRealisationError, match="build failed"):
+        try_resolve_flakeref(
+            "/tmp/my flake#pkg",
+            force_realise=True,
+            exec_cmd_fn=fake_exec_cmd,
+        )
+
+
+def test_try_resolve_flakeref_raises_when_force_realise_prints_no_path():
+    def fake_exec_cmd(_cmd, **_kwargs):
+        return SimpleNamespace(stdout="\n", stderr="", returncode=0)
+
+    with pytest.raises(FlakeRefRealisationError, match="returned no output path"):
         try_resolve_flakeref(
             "/tmp/my flake#pkg",
             force_realise=True,

--- a/tests/test_nix_target_resolution.py
+++ b/tests/test_nix_target_resolution.py
@@ -24,6 +24,97 @@ def test_resolve_nix_target_preserves_flakeref_on_success(monkeypatch):
     assert resolved == sbomnix_cli_utils.ResolvedNixTarget(
         path="/nix/store/resolved",
         flakeref=".#hello",
+        original_ref=".#hello",
+    )
+
+
+def test_resolve_nix_target_normalizes_plain_nixos_configuration(monkeypatch):
+    calls = []
+
+    def fake_resolve(flakeref, **_kwargs):
+        calls.append(flakeref)
+        return "/nix/store/resolved"
+
+    monkeypatch.setattr(
+        sbomnix_cli_utils,
+        "try_resolve_flakeref",
+        fake_resolve,
+    )
+
+    resolved = sbomnix_cli_utils.resolve_nix_target(
+        "/flake#nixosConfigurations.host",
+        buildtime=False,
+    )
+
+    assert calls == ['/flake#nixosConfigurations."host".config.system.build.toplevel']
+    assert resolved == sbomnix_cli_utils.ResolvedNixTarget(
+        path="/nix/store/resolved",
+        flakeref='/flake#nixosConfigurations."host".config.system.build.toplevel',
+        original_ref="/flake#nixosConfigurations.host",
+    )
+
+
+def test_resolve_nix_target_normalizes_quoted_nixos_configuration(monkeypatch):
+    calls = []
+
+    def fake_resolve(flakeref, **_kwargs):
+        calls.append(flakeref)
+        return "/nix/store/resolved"
+
+    monkeypatch.setattr(
+        sbomnix_cli_utils,
+        "try_resolve_flakeref",
+        fake_resolve,
+    )
+
+    resolved = sbomnix_cli_utils.resolve_nix_target(
+        '/flake#nixosConfigurations."host.example.com"',
+        buildtime=False,
+    )
+
+    assert calls == [
+        '/flake#nixosConfigurations."host.example.com".config.system.build.toplevel'
+    ]
+    assert resolved == sbomnix_cli_utils.ResolvedNixTarget(
+        path="/nix/store/resolved",
+        flakeref=(
+            '/flake#nixosConfigurations."host.example.com".config.system.build.toplevel'
+        ),
+        original_ref='/flake#nixosConfigurations."host.example.com"',
+    )
+
+
+@pytest.mark.parametrize(
+    "nixref",
+    [
+        "/flake#nixosConfigurations.",
+        '/flake#nixosConfigurations."unterminated',
+        '/flake#nixosConfigurations."trailing\\',
+    ],
+)
+def test_resolve_nix_target_leaves_malformed_nixos_configuration_refs(
+    nixref,
+    monkeypatch,
+):
+    calls = []
+
+    def fake_resolve(flakeref, **_kwargs):
+        calls.append(flakeref)
+        return "/nix/store/resolved"
+
+    monkeypatch.setattr(
+        sbomnix_cli_utils,
+        "try_resolve_flakeref",
+        fake_resolve,
+    )
+
+    resolved = sbomnix_cli_utils.resolve_nix_target(nixref, buildtime=False)
+
+    assert calls == [nixref]
+    assert resolved == sbomnix_cli_utils.ResolvedNixTarget(
+        path="/nix/store/resolved",
+        flakeref=nixref,
+        original_ref=nixref,
     )
 
 
@@ -102,5 +193,6 @@ def test_resolve_nix_target_falls_back_to_store_path_validation(monkeypatch):
     assert resolved == sbomnix_cli_utils.ResolvedNixTarget(
         path="/nix/store/not-a-flake",
         flakeref=None,
+        original_ref="/nix/store/not-a-flake",
     )
     assert artifact_checks == [("/nix/store/not-a-flake", True)]

--- a/tests/test_nixmeta_progress.py
+++ b/tests/test_nixmeta_progress.py
@@ -7,6 +7,7 @@
 """Focused tests for nixmeta progress logging."""
 
 import json
+import subprocess
 from types import SimpleNamespace
 
 from nixmeta import flake_metadata
@@ -93,12 +94,46 @@ def test_get_flake_metadata_logs_metadata_read():
     ) in logger.records
 
 
+def test_get_nixpkgs_flakeref_uses_root_nixpkgs_input_with_renamed_node():
+    meta_json = {
+        "locks": {
+            "root": "root",
+            "nodes": {
+                "root": {"inputs": {"nixpkgs": "nixpkgs_3"}},
+                "nixpkgs": {
+                    "locked": {
+                        "type": "github",
+                        "owner": "NixOS",
+                        "repo": "nixpkgs",
+                        "rev": "wrong",
+                    }
+                },
+                "nixpkgs_3": {
+                    "locked": {
+                        "type": "github",
+                        "owner": "NixOS",
+                        "repo": "nixpkgs",
+                        "rev": "right",
+                    }
+                },
+            },
+        }
+    }
+
+    assert (
+        flake_metadata.get_nixpkgs_flakeref(meta_json)
+        == "github:NixOS/nixpkgs?rev=right"
+    )
+
+
 def test_nixmeta_scanner_logs_nix_env_progress(tmp_path, monkeypatch):
     nixpkgs_path = tmp_path / "nixpkgs"
     nixpkgs_path.mkdir()
     logger = CapturingLogger()
+    commands = []
 
-    def fake_exec_cmd(_cmd, stdout):
+    def fake_run_nix_env_metadata(_cmd, stdout):
+        commands.append(_cmd)
         stdout.write(
             json.dumps(
                 {
@@ -131,7 +166,11 @@ def test_nixmeta_scanner_logs_nix_env_progress(tmp_path, monkeypatch):
         "nixref_to_nixpkgs_path",
         lambda *_args, **_kwargs: nixpkgs_path,
     )
-    monkeypatch.setattr(nixmeta_scanner, "exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(
+        nixmeta_scanner,
+        "_run_nix_env_metadata",
+        fake_run_nix_env_metadata,
+    )
 
     scanner = nixmeta_scanner.NixMetaScanner()
     scanner.scan("github:NixOS/nixpkgs?ref=nixos-unstable")
@@ -142,4 +181,100 @@ def test_nixmeta_scanner_logs_nix_env_progress(tmp_path, monkeypatch):
         (nixpkgs_path.as_posix(),),
     ) in logger.records
     assert ("info", "Parsing nixpkgs metadata", ()) in logger.records
+    assert commands
     assert scanner.to_df() is not None
+
+
+def test_run_nix_env_metadata_captures_successful_stderr(monkeypatch, tmp_path):
+    calls = []
+    logger = CapturingLogger()
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return SimpleNamespace(stderr="warning: noisy eval\n")
+
+    monkeypatch.setattr(nixmeta_scanner.subprocess, "run", fake_run)
+    monkeypatch.setattr(nixmeta_scanner, "LOG", logger)
+    out_path = tmp_path / "meta.json"
+
+    with out_path.open("w", encoding="utf-8") as out:
+        nixmeta_scanner._run_nix_env_metadata(["nix-env"], stdout=out)
+
+    assert calls
+    assert calls[0][1]["stderr"] is subprocess.PIPE
+    assert calls[0][1]["stdout"].name == out_path.as_posix()
+    assert (
+        "debug",
+        "nix-env metadata stderr:\n%s",
+        ("warning: noisy eval",),
+    ) in logger.records
+
+
+def test_nixmeta_scanner_tolerates_empty_metadata_json(tmp_path, monkeypatch):
+    nixpkgs_path = tmp_path / "nixpkgs"
+    nixpkgs_path.mkdir()
+
+    def fake_run_nix_env_metadata(_cmd, stdout):
+        stdout.write(b"{}")
+        stdout.flush()
+
+    monkeypatch.setattr(
+        nixmeta_scanner,
+        "_run_nix_env_metadata",
+        fake_run_nix_env_metadata,
+    )
+
+    scanner = nixmeta_scanner.NixMetaScanner()
+    scanner.scan_path(nixpkgs_path)
+
+    assert scanner.to_df() is not None
+    assert scanner.to_df().empty
+
+
+def test_nixmeta_expression_scan_enables_flakes(monkeypatch):
+    commands = []
+
+    def fake_run_nix_env_metadata(cmd, stdout):
+        commands.append(cmd)
+        stdout.write(b"{}")
+        stdout.flush()
+
+    monkeypatch.setattr(
+        nixmeta_scanner,
+        "_run_nix_env_metadata",
+        fake_run_nix_env_metadata,
+    )
+
+    scanner = nixmeta_scanner.NixMetaScanner()
+    scanner.scan_expression('builtins.getFlake "github:NixOS/nixpkgs"')
+
+    assert commands
+    assert [
+        "--option",
+        "experimental-features",
+        "nix-command flakes",
+    ] in [commands[0][idx : idx + 3] for idx in range(len(commands[0]) - 2)]
+
+
+def test_nixmeta_expression_scan_honors_impure(monkeypatch):
+    commands = []
+
+    def fake_run_nix_env_metadata(cmd, stdout):
+        commands.append(cmd)
+        stdout.write(b"{}")
+        stdout.flush()
+
+    monkeypatch.setattr(
+        nixmeta_scanner,
+        "_run_nix_env_metadata",
+        fake_run_nix_env_metadata,
+    )
+
+    scanner = nixmeta_scanner.NixMetaScanner()
+    scanner.scan_expression(
+        'builtins.getFlake "path:/tmp/local-flake"',
+        impure=True,
+    )
+
+    assert commands
+    assert "--impure" in commands[0]

--- a/tests/test_nixmeta_source.py
+++ b/tests/test_nixmeta_source.py
@@ -1,0 +1,833 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+# pylint: disable=missing-function-docstring
+
+"""Focused tests for nixpkgs metadata source selection."""
+
+import json
+import pathlib
+from types import SimpleNamespace
+
+import pytest
+
+from common.errors import SbomnixError
+from sbomnix import meta as sbomnix_meta
+from sbomnix import meta_source as sbomnix_meta_source
+
+
+def test_classify_meta_nixpkgs_reserved_modes_before_explicit_source():
+    assert (
+        sbomnix_meta.classify_meta_nixpkgs(sbomnix_meta.META_NIXPKGS_NIX_PATH)
+        == sbomnix_meta.META_NIXPKGS_NIX_PATH
+    )
+    assert sbomnix_meta.classify_meta_nixpkgs("/nix/store/source") == "explicit"
+
+
+def test_get_nixpkgs_meta_with_source_records_flakeref_lock(monkeypatch, tmp_path):
+    nixpkgs_path = tmp_path / "nixpkgs"
+    (nixpkgs_path / "lib").mkdir(parents=True)
+    (nixpkgs_path / "lib" / ".version").write_text("25.11\n", encoding="utf-8")
+    scanned = []
+
+    monkeypatch.setattr(
+        sbomnix_meta_source,
+        "nixref_to_nixpkgs_path",
+        lambda _nixref: nixpkgs_path,
+    )
+    monkeypatch.setattr(
+        sbomnix_meta.Meta,
+        "_scan",
+        lambda self, path: scanned.append(path) or "df",
+    )
+
+    df_meta, source = sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+        target_path="/nix/store/target",
+        flakeref=".#target",
+        original_ref=".#target",
+    )
+
+    assert df_meta == "df"
+    assert scanned == [nixpkgs_path.as_posix()]
+    assert source == sbomnix_meta.NixpkgsMetaSource(
+        method="flakeref-lock",
+        path=nixpkgs_path.as_posix(),
+        flakeref=".#target",
+        version="25.11",
+    )
+
+
+def test_get_nixpkgs_meta_with_source_records_opt_in_nix_path(monkeypatch):
+    scanned = []
+
+    monkeypatch.setenv("NIX_PATH", "foo=/tmp/other:nixpkgs=/tmp/my flake")
+    monkeypatch.setattr(
+        sbomnix_meta.Meta,
+        "_scan",
+        lambda self, path: scanned.append(path) or "df",
+    )
+
+    df_meta, source = sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+        target_path="/nix/store/target",
+        flakeref=None,
+        original_ref="/nix/store/target",
+        explicit_nixpkgs=sbomnix_meta.META_NIXPKGS_NIX_PATH,
+    )
+
+    assert df_meta == "df"
+    assert scanned == ["/tmp/my flake"]
+    assert source == sbomnix_meta.NixpkgsMetaSource(
+        method="nix-path",
+        path="/tmp/my flake",
+        message="NIX_PATH metadata source may not match the target",
+    )
+
+
+def test_explicit_nix_path_source_requires_nixpkgs_entry(monkeypatch):
+    def fail_if_scanned(self, path):
+        raise AssertionError(f"nix-path scan should not run: {path}")
+
+    monkeypatch.setenv("NIX_PATH", "foo=/tmp/other")
+    monkeypatch.setattr(sbomnix_meta.Meta, "_scan", fail_if_scanned)
+
+    with pytest.raises(SbomnixError, match="NIX_PATH.*nixpkgs="):
+        sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+            target_path="/nix/store/target",
+            flakeref=None,
+            original_ref="/nix/store/target",
+            explicit_nixpkgs=sbomnix_meta.META_NIXPKGS_NIX_PATH,
+        )
+
+
+def test_path_target_without_source_skips_nix_path_metadata(monkeypatch):
+    def fail_if_scanned(self, path):
+        raise AssertionError(f"path-target scan should be skipped: {path}")
+
+    monkeypatch.setenv("NIX_PATH", "nixpkgs=/tmp/nixpkgs")
+    monkeypatch.setattr(sbomnix_meta.Meta, "_scan", fail_if_scanned)
+
+    df_meta, source = sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+        target_path="/nix/store/resolved-target",
+        flakeref=None,
+        original_ref="./result",
+    )
+
+    assert df_meta is None
+    assert source.method == "none"
+    assert source.path is None
+    assert "store-path target" in source.message
+    assert "./result" not in source.message
+    assert "--meta-nixpkgs" in source.message
+
+
+def test_explicit_store_path_source_records_explicit_method(monkeypatch, tmp_path):
+    nixpkgs_path = tmp_path / "nixpkgs"
+    (nixpkgs_path / "lib").mkdir(parents=True)
+    (nixpkgs_path / "lib" / ".version").write_text("25.11\n", encoding="utf-8")
+    scanned = []
+
+    monkeypatch.setattr(
+        sbomnix_meta.Meta,
+        "_scan",
+        lambda self, path: scanned.append(path) or "df",
+    )
+    monkeypatch.setattr(
+        sbomnix_meta_source,
+        "is_nix_store_path",
+        lambda path: path.as_posix() == nixpkgs_path.as_posix(),
+    )
+
+    df_meta, source = sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+        target_path="/nix/store/target",
+        explicit_nixpkgs=nixpkgs_path.as_posix(),
+    )
+
+    assert df_meta == "df"
+    assert scanned == [nixpkgs_path.as_posix()]
+    assert source == sbomnix_meta.NixpkgsMetaSource(
+        method="explicit",
+        path=nixpkgs_path.as_posix(),
+        version="25.11",
+    )
+
+
+def test_explicit_flakeref_source_resolves_nixpkgs_path(monkeypatch):
+    nixpkgs_path = "/nix/store/abc-source"
+    scanned = []
+
+    monkeypatch.setattr(
+        sbomnix_meta_source,
+        "nixref_to_nixpkgs_path",
+        lambda _nixref: pathlib.Path(nixpkgs_path),
+    )
+    monkeypatch.setattr(
+        sbomnix_meta.Meta,
+        "_scan",
+        lambda self, path: scanned.append(path) or "df",
+    )
+
+    df_meta, source = sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+        target_path="/nix/store/target",
+        explicit_nixpkgs="github:NixOS/nixpkgs?rev=abc",
+    )
+
+    assert df_meta == "df"
+    assert scanned == [nixpkgs_path]
+    assert source == sbomnix_meta.NixpkgsMetaSource(
+        method="explicit",
+        path=nixpkgs_path,
+        flakeref="github:NixOS/nixpkgs?rev=abc",
+    )
+
+
+def test_mutable_explicit_path_is_normalized_before_scanning(monkeypatch, tmp_path):
+    mutable_path = tmp_path / "nixpkgs-checkout"
+    mutable_path.mkdir()
+    store_path = pathlib.Path("/nix/store/normalized-source")
+    scanned = []
+
+    monkeypatch.setattr(
+        sbomnix_meta_source,
+        "nixref_to_nixpkgs_path",
+        lambda nixref: store_path if nixref == mutable_path.as_posix() else None,
+    )
+    monkeypatch.setattr(
+        sbomnix_meta.Meta,
+        "_scan",
+        lambda self, path: scanned.append(path) or "df",
+    )
+
+    df_meta, source = sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+        target_path="/nix/store/target",
+        explicit_nixpkgs=mutable_path.as_posix(),
+    )
+
+    assert df_meta == "df"
+    assert scanned == [store_path.as_posix()]
+    assert source == sbomnix_meta.NixpkgsMetaSource(
+        method="explicit",
+        path=store_path.as_posix(),
+        flakeref=mutable_path.as_posix(),
+    )
+
+
+def test_mutable_explicit_path_is_rejected_if_not_cache_safe(monkeypatch, tmp_path):
+    mutable_path = tmp_path / "nixpkgs-checkout"
+    mutable_path.mkdir()
+
+    monkeypatch.setattr(
+        sbomnix_meta_source, "nixref_to_nixpkgs_path", lambda _nixref: None
+    )
+
+    with pytest.raises(SbomnixError, match="immutable /nix/store source"):
+        sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+            target_path="/nix/store/target",
+            explicit_nixpkgs=mutable_path.as_posix(),
+        )
+
+
+def test_nixos_toplevel_flakeref_prefers_configuration_pkgs_path(
+    monkeypatch,
+    tmp_path,
+):
+    nixpkgs_path = tmp_path / "nixpkgs"
+    nixpkgs_path.mkdir()
+    calls = []
+    expressions = []
+    fake_df = SimpleNamespace(empty=False)
+
+    def fake_exec_cmd(cmd, **_kwargs):
+        calls.append(cmd)
+        if cmd == [
+            "nix",
+            "eval",
+            "--raw",
+            '/flake#nixosConfigurations."host".pkgs.path',
+        ]:
+            return SimpleNamespace(stdout=f"{nixpkgs_path}\n", returncode=0)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(
+        sbomnix_meta_source,
+        "nix_cmd",
+        lambda *args, impure=False: ["nix", *args] + (["--impure"] if impure else []),
+    )
+    monkeypatch.setattr(sbomnix_meta_source, "exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(
+        sbomnix_meta_source,
+        "nixref_to_nixpkgs_path",
+        lambda _nixref: (_ for _ in ()).throw(
+            AssertionError("lock-node fallback should not run")
+        ),
+    )
+    monkeypatch.setattr(
+        sbomnix_meta.Meta,
+        "_scan_expression",
+        lambda self, expression, *, cache_key=None, impure=False: (
+            expressions.append((expression, cache_key, impure)) or fake_df
+        ),
+    )
+
+    df_meta, source = sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+        target_path="/nix/store/target",
+        flakeref="/flake#nixosConfigurations.host.config.system.build.toplevel",
+        original_ref="/flake#nixosConfigurations.host.config.system.build.toplevel",
+    )
+
+    assert df_meta is fake_df
+    assert calls == [
+        ["nix", "eval", "--raw", '/flake#nixosConfigurations."host".pkgs.path']
+    ]
+    assert source.method == "flakeref-target"
+    assert source.path == nixpkgs_path.as_posix()
+    assert source.flakeref == '/flake#nixosConfigurations."host".pkgs.path'
+    assert source.message == "Scanning evaluated NixOS package set from flakeref"
+    assert expressions == [
+        (
+            'let\n  flake = builtins.getFlake "/flake";\nin\n'
+            '  flake.nixosConfigurations."host".pkgs\n',
+            None,
+            False,
+        )
+    ]
+
+
+def test_nixos_toplevel_expression_locks_relative_flake_refs(
+    monkeypatch,
+    tmp_path,
+):
+    nixpkgs_path = tmp_path / "nixpkgs"
+    nixpkgs_path.mkdir()
+    source_path = "/nix/store/root-source"
+    calls = []
+    expressions = []
+    fake_df = SimpleNamespace(empty=False)
+
+    def fake_exec_cmd(cmd, **_kwargs):
+        calls.append(cmd)
+        if cmd == [
+            "nix",
+            "eval",
+            "--raw",
+            '.#nixosConfigurations."host".pkgs.path',
+        ]:
+            return SimpleNamespace(stdout=f"{nixpkgs_path}\n", returncode=0)
+        if cmd == ["nix", "flake", "metadata", ".", "--json"]:
+            return SimpleNamespace(
+                stdout=json.dumps(
+                    {
+                        "path": source_path,
+                        "locked": {"narHash": "sha256-abc"},
+                    }
+                ),
+                returncode=0,
+            )
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(
+        sbomnix_meta_source,
+        "nix_cmd",
+        lambda *args, impure=False: ["nix", *args] + (["--impure"] if impure else []),
+    )
+    monkeypatch.setattr(sbomnix_meta_source, "exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(
+        sbomnix_meta.Meta,
+        "_scan_expression",
+        lambda self, expression, *, cache_key=None, impure=False: (
+            expressions.append((expression, cache_key, impure)) or fake_df
+        ),
+    )
+
+    df_meta, source = sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+        target_path="/nix/store/target",
+        flakeref=".#nixosConfigurations.host.config.system.build.toplevel",
+        original_ref=".#nixosConfigurations.host.config.system.build.toplevel",
+    )
+
+    locked_ref = f"path:{source_path}?narHash=sha256-abc"
+    assert df_meta is fake_df
+    assert source.method == "flakeref-target"
+    assert source.flakeref == '.#nixosConfigurations."host".pkgs.path'
+    assert calls == [
+        ["nix", "eval", "--raw", '.#nixosConfigurations."host".pkgs.path'],
+        ["nix", "flake", "metadata", ".", "--json"],
+    ]
+    cache_key = "nixos-pkgs:" + json.dumps(
+        [locked_ref, "host"],
+        separators=(",", ":"),
+    )
+    assert expressions == [
+        (
+            f'let\n  flake = builtins.getFlake "{locked_ref}";\nin\n'
+            '  flake.nixosConfigurations."host".pkgs\n',
+            cache_key,
+            False,
+        )
+    ]
+
+
+def test_nixos_toplevel_expression_preserves_locked_subflake_dir(
+    monkeypatch,
+    tmp_path,
+):
+    nixpkgs_path = tmp_path / "nixpkgs"
+    nixpkgs_path.mkdir()
+    source_path = "/nix/store/root-source"
+    calls = []
+    expressions = []
+    fake_df = SimpleNamespace(empty=False)
+
+    def fake_exec_cmd(cmd, **_kwargs):
+        calls.append(cmd)
+        if cmd == [
+            "nix",
+            "eval",
+            "--raw",
+            'path:.?dir=sub/flake#nixosConfigurations."host".pkgs.path',
+        ]:
+            return SimpleNamespace(stdout=f"{nixpkgs_path}\n", returncode=0)
+        if cmd == ["nix", "flake", "metadata", "path:.?dir=sub/flake", "--json"]:
+            return SimpleNamespace(
+                stdout=json.dumps(
+                    {
+                        "path": source_path,
+                        "locked": {
+                            "narHash": "sha256-abc",
+                            "dir": "sub/flake",
+                        },
+                    }
+                ),
+                returncode=0,
+            )
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(
+        sbomnix_meta_source,
+        "nix_cmd",
+        lambda *args, impure=False: ["nix", *args] + (["--impure"] if impure else []),
+    )
+    monkeypatch.setattr(sbomnix_meta_source, "exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(
+        sbomnix_meta.Meta,
+        "_scan_expression",
+        lambda self, expression, *, cache_key=None, impure=False: (
+            expressions.append((expression, cache_key, impure)) or fake_df
+        ),
+    )
+
+    df_meta, source = sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+        target_path="/nix/store/target",
+        flakeref=(
+            "path:.?dir=sub/flake#nixosConfigurations.host.config.system.build.toplevel"
+        ),
+        original_ref=(
+            "path:.?dir=sub/flake#nixosConfigurations.host.config.system.build.toplevel"
+        ),
+    )
+
+    locked_ref = f"path:{source_path}?narHash=sha256-abc&dir=sub/flake"
+    assert df_meta is fake_df
+    assert source.method == "flakeref-target"
+    assert calls == [
+        [
+            "nix",
+            "eval",
+            "--raw",
+            'path:.?dir=sub/flake#nixosConfigurations."host".pkgs.path',
+        ],
+        ["nix", "flake", "metadata", "path:.?dir=sub/flake", "--json"],
+    ]
+    cache_key = "nixos-pkgs:" + json.dumps(
+        [locked_ref, "host"],
+        separators=(",", ":"),
+    )
+    assert expressions == [
+        (
+            f'let\n  flake = builtins.getFlake "{locked_ref}";\nin\n'
+            '  flake.nixosConfigurations."host".pkgs\n',
+            cache_key,
+            False,
+        )
+    ]
+
+
+def test_nixos_toplevel_flakeref_handles_quoted_configuration_names(
+    monkeypatch,
+    tmp_path,
+):
+    nixpkgs_path = tmp_path / "nixpkgs"
+    nixpkgs_path.mkdir()
+    expressions = []
+    fake_df = SimpleNamespace(empty=False)
+
+    def fake_exec_cmd(cmd, **_kwargs):
+        if cmd == [
+            "nix",
+            "eval",
+            "--raw",
+            '/flake#nixosConfigurations."host.example.com".pkgs.path',
+        ]:
+            return SimpleNamespace(stdout=f"{nixpkgs_path}\n", returncode=0)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(
+        sbomnix_meta_source,
+        "nix_cmd",
+        lambda *args, impure=False: ["nix", *args] + (["--impure"] if impure else []),
+    )
+    monkeypatch.setattr(sbomnix_meta_source, "exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(
+        sbomnix_meta.Meta,
+        "_scan_expression",
+        lambda self, expression, *, cache_key=None, impure=False: (
+            expressions.append((expression, cache_key, impure)) or fake_df
+        ),
+    )
+
+    df_meta, source = sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+        target_path="/nix/store/target",
+        flakeref=(
+            '/flake#nixosConfigurations."host.example.com".config.system.build.toplevel'
+        ),
+        original_ref=(
+            '/flake#nixosConfigurations."host.example.com".config.system.build.toplevel'
+        ),
+    )
+
+    assert df_meta is fake_df
+    assert source.method == "flakeref-target"
+    assert source.flakeref == (
+        '/flake#nixosConfigurations."host.example.com".pkgs.path'
+    )
+    assert expressions == [
+        (
+            'let\n  flake = builtins.getFlake "/flake";\nin\n'
+            '  flake.nixosConfigurations."host.example.com".pkgs\n',
+            None,
+            False,
+        )
+    ]
+
+
+def test_nixos_toplevel_flakeref_metadata_eval_honors_impure(monkeypatch, tmp_path):
+    nixpkgs_path = tmp_path / "nixpkgs"
+    nixpkgs_path.mkdir()
+    calls = []
+    expressions = []
+    fake_df = SimpleNamespace(empty=False)
+
+    def fake_exec_cmd(cmd, **_kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(stdout=f"{nixpkgs_path}\n", returncode=0)
+
+    monkeypatch.setattr(
+        sbomnix_meta_source,
+        "nix_cmd",
+        lambda *args, impure=False: ["nix", *args] + (["--impure"] if impure else []),
+    )
+    monkeypatch.setattr(sbomnix_meta_source, "exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(
+        sbomnix_meta.Meta,
+        "_scan_expression",
+        lambda self, expression, *, cache_key=None, impure=False: (
+            expressions.append((expression, cache_key, impure)) or fake_df
+        ),
+    )
+
+    df_meta, source = sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+        target_path="/nix/store/target",
+        flakeref="/flake#nixosConfigurations.host.config.system.build.toplevel",
+        original_ref="/flake#nixosConfigurations.host.config.system.build.toplevel",
+        impure=True,
+    )
+
+    assert df_meta is fake_df
+    assert source.method == "flakeref-target"
+    assert calls == [
+        [
+            "nix",
+            "eval",
+            "--raw",
+            '/flake#nixosConfigurations."host".pkgs.path',
+            "--impure",
+        ]
+    ]
+    assert expressions == [
+        (
+            'let\n  flake = builtins.getFlake "/flake";\nin\n'
+            '  flake.nixosConfigurations."host".pkgs\n',
+            None,
+            True,
+        )
+    ]
+    assert source.expression_cache_key is None
+    assert source.expression_impure is True
+
+
+def test_nixos_toplevel_expression_cache_uses_only_stable_refs(monkeypatch, tmp_path):
+    nixpkgs_path = tmp_path / "nixpkgs"
+    nixpkgs_path.mkdir()
+    expressions = []
+    fake_df = SimpleNamespace(empty=False)
+
+    def fake_exec_cmd(_cmd, **_kwargs):
+        return SimpleNamespace(stdout=f"{nixpkgs_path}\n", returncode=0)
+
+    monkeypatch.setattr(
+        sbomnix_meta_source,
+        "nix_cmd",
+        lambda *args, impure=False: ["nix", *args] + (["--impure"] if impure else []),
+    )
+    monkeypatch.setattr(sbomnix_meta_source, "exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(
+        sbomnix_meta.Meta,
+        "_scan_expression",
+        lambda self, expression, *, cache_key=None, impure=False: (
+            expressions.append((expression, cache_key, impure)) or fake_df
+        ),
+    )
+
+    df_meta, source = sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+        target_path="/nix/store/target",
+        flakeref=(
+            "github:example/flake?rev=abc"
+            '#nixosConfigurations."host:8080".config.system.build.toplevel'
+        ),
+        original_ref=(
+            "github:example/flake?rev=abc"
+            '#nixosConfigurations."host:8080".config.system.build.toplevel'
+        ),
+    )
+
+    cache_key = "nixos-pkgs:" + json.dumps(
+        ["github:example/flake?rev=abc", "host:8080"],
+        separators=(",", ":"),
+    )
+    assert df_meta is fake_df
+    assert source.method == "flakeref-target"
+    assert expressions == [
+        (
+            'let\n  flake = builtins.getFlake "github:example/flake?rev=abc";\n'
+            "in\n"
+            '  flake.nixosConfigurations."host:8080".pkgs\n',
+            cache_key,
+            False,
+        )
+    ]
+
+
+def test_nixos_toplevel_expression_scan_fallback_updates_source(
+    monkeypatch,
+    tmp_path,
+):
+    nixpkgs_path = tmp_path / "nixpkgs"
+    nixpkgs_path.mkdir()
+    fake_df = SimpleNamespace(empty=False)
+    scanned = []
+
+    def fake_exec_cmd(_cmd, **_kwargs):
+        return SimpleNamespace(stdout=f"{nixpkgs_path}\n", returncode=0)
+
+    monkeypatch.setattr(
+        sbomnix_meta_source,
+        "nix_cmd",
+        lambda *args, impure=False: ["nix", *args] + (["--impure"] if impure else []),
+    )
+    monkeypatch.setattr(sbomnix_meta_source, "exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(
+        sbomnix_meta.Meta,
+        "_scan_expression",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        sbomnix_meta.Meta,
+        "_scan",
+        lambda self, path: scanned.append(path) or fake_df,
+    )
+
+    df_meta, source = sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+        target_path="/nix/store/target",
+        flakeref="/flake#nixosConfigurations.host.config.system.build.toplevel",
+        original_ref="/flake#nixosConfigurations.host.config.system.build.toplevel",
+    )
+
+    assert df_meta is fake_df
+    assert scanned == [nixpkgs_path.as_posix()]
+    assert source.method == "flakeref-target"
+    assert source.expression is None
+    assert source.expression_cache_key is None
+    assert source.expression_impure is False
+    assert "fell back to base nixpkgs source metadata" in source.message
+    assert "evaluated NixOS package set" not in source.message
+
+
+def test_nixos_toplevel_flakeref_falls_back_to_revision(monkeypatch, tmp_path):
+    nixpkgs_path = tmp_path / "nixpkgs"
+    nixpkgs_path.mkdir()
+    calls = []
+    scanned = []
+
+    def fake_exec_cmd(cmd, **_kwargs):
+        calls.append(cmd)
+        if cmd == [
+            "nix",
+            "eval",
+            "--raw",
+            '/flake#nixosConfigurations."host".pkgs.path',
+        ]:
+            return SimpleNamespace(stdout="", stderr="missing", returncode=1)
+        if cmd == [
+            "nix",
+            "eval",
+            "--raw",
+            '/flake#nixosConfigurations."host".config.system.nixos.revision',
+        ]:
+            return SimpleNamespace(stdout="abc123\n", returncode=0)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(
+        sbomnix_meta_source,
+        "nix_cmd",
+        lambda *args, impure=False: ["nix", *args] + (["--impure"] if impure else []),
+    )
+    monkeypatch.setattr(sbomnix_meta_source, "exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(
+        sbomnix_meta_source,
+        "nixref_to_nixpkgs_path",
+        lambda nixref: (
+            nixpkgs_path if nixref == "github:NixOS/nixpkgs?rev=abc123" else None
+        ),
+    )
+    monkeypatch.setattr(
+        sbomnix_meta.Meta,
+        "_scan",
+        lambda self, path: scanned.append(path) or "df",
+    )
+
+    df_meta, source = sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+        target_path="/nix/store/target",
+        flakeref="/flake#nixosConfigurations.host.config.system.build.toplevel",
+        original_ref="/flake#nixosConfigurations.host.config.system.build.toplevel",
+    )
+
+    assert df_meta == "df"
+    assert calls == [
+        ["nix", "eval", "--raw", '/flake#nixosConfigurations."host".pkgs.path'],
+        [
+            "nix",
+            "eval",
+            "--raw",
+            '/flake#nixosConfigurations."host".config.system.nixos.revision',
+        ],
+    ]
+    assert scanned == [nixpkgs_path.as_posix()]
+    assert source == sbomnix_meta.NixpkgsMetaSource(
+        method="flakeref-target",
+        path=nixpkgs_path.as_posix(),
+        flakeref="github:NixOS/nixpkgs?rev=abc123",
+        rev="abc123",
+        message=(
+            "Resolved nixpkgs from NixOS configuration revision as a "
+            "best-effort fallback; this may not represent forked, patched, "
+            "dirty, local, or offline nixpkgs inputs"
+        ),
+    )
+
+
+def test_nixos_toplevel_flakeref_without_pkgs_or_revision_returns_message(
+    monkeypatch,
+):
+    calls = []
+
+    def fake_exec_cmd(cmd, **_kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(stdout="", stderr="missing", returncode=1)
+
+    monkeypatch.setattr(
+        sbomnix_meta_source,
+        "nix_cmd",
+        lambda *args, impure=False: ["nix", *args] + (["--impure"] if impure else []),
+    )
+    monkeypatch.setattr(sbomnix_meta_source, "exec_cmd", fake_exec_cmd)
+    monkeypatch.setattr(
+        sbomnix_meta_source,
+        "nixref_to_nixpkgs_path",
+        lambda _nixref: None,
+    )
+
+    df_meta, source = sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+        target_path="/nix/store/target",
+        flakeref="/flake#nixosConfigurations.host.config.system.build.toplevel",
+        original_ref="/flake#nixosConfigurations.host.config.system.build.toplevel",
+    )
+
+    assert df_meta is None
+    assert calls == [
+        ["nix", "eval", "--raw", '/flake#nixosConfigurations."host".pkgs.path'],
+        [
+            "nix",
+            "eval",
+            "--raw",
+            '/flake#nixosConfigurations."host".config.system.nixos.revision',
+        ],
+    ]
+    assert source.method == "none"
+    assert source.path is None
+    assert "NixOS configuration flakeref" in source.message
+    assert "--meta-nixpkgs" in source.message
+
+
+def test_plain_nixos_configuration_attrset_is_not_target_inferred(
+    monkeypatch,
+    tmp_path,
+):
+    nixpkgs_path = tmp_path / "lock-source"
+    nixpkgs_path.mkdir()
+    scanned = []
+
+    monkeypatch.setattr(
+        sbomnix_meta.Meta,
+        "_scan",
+        lambda self, path: scanned.append(path) or "df",
+    )
+    monkeypatch.setattr(
+        sbomnix_meta_source,
+        "nixref_to_nixpkgs_path",
+        lambda _nixref: nixpkgs_path,
+    )
+
+    df_meta, source = sbomnix_meta.Meta().get_nixpkgs_meta_with_source(
+        target_path="/nix/store/target",
+        flakeref="/flake#nixosConfigurations.host",
+        original_ref="/flake#nixosConfigurations.host",
+    )
+
+    assert df_meta == "df"
+    assert scanned == [nixpkgs_path.as_posix()]
+    assert source.method == "flakeref-lock"
+
+
+def test_meta_scan_uses_already_resolved_scanner_path(monkeypatch):
+    calls = []
+    fake_df = SimpleNamespace(empty=False)
+
+    class FakeScanner:
+        """Scanner stand-in that records normalized scan paths."""
+
+        def scan(self, path):
+            raise AssertionError(f"scan should not resolve path again: {path}")
+
+        def scan_path(self, path):
+            calls.append(path)
+
+        def to_df(self):
+            return fake_df
+
+    meta = sbomnix_meta.Meta()
+    monkeypatch.setattr(meta.cache, "get", lambda _key: None)
+    monkeypatch.setattr(meta.cache, "set", lambda **_kwargs: None)
+    monkeypatch.setattr(sbomnix_meta, "NixMetaScanner", FakeScanner)
+
+    assert meta._scan("/nix/store/source") is fake_df  # pylint: disable=protected-access
+    assert calls == ["/nix/store/source"]

--- a/tests/test_nixmeta_source_export.py
+++ b/tests/test_nixmeta_source_export.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+# pylint: disable=missing-function-docstring
+
+"""Tests for SBOM-level nixpkgs metadata source export."""
+
+import uuid
+
+import pandas as pd
+
+from sbomnix.meta import NixpkgsMetaSource
+from sbomnix.sbomdb import SbomDb
+
+
+def _make_minimal_sbomdb():
+    sbomdb = object.__new__(SbomDb)
+    sbomdb.uid = "store_path"
+    sbomdb.nix_path = "/nix/store/target"
+    sbomdb.buildtime = False
+    sbomdb.target_deriver = "/nix/store/target.drv"
+    sbomdb.depth = None
+    sbomdb.uuid = uuid.uuid4()
+    sbomdb.sbom_type = "runtime_only"
+    sbomdb.nixpkgs_meta_source = NixpkgsMetaSource(
+        method="flakeref-target",
+        path="/nix/store/source",
+        rev="1234",
+        flakeref=".#target",
+        version="25.11",
+        message="base nixpkgs source metadata",
+    )
+    sbomdb.df_sbomdb = pd.DataFrame(
+        [
+            {
+                "store_path": "/nix/store/target.drv",
+                "pname": "target",
+                "name": "target",
+                "version": "1.0",
+                "outputs": ["/nix/store/target"],
+                "out": "/nix/store/target",
+                "purl": "",
+                "cpe": "",
+                "urls": "",
+                "patches": "",
+            }
+        ]
+    )
+    return sbomdb
+
+
+def test_cdx_document_records_nixpkgs_metadata_source(monkeypatch):
+    sbomdb = _make_minimal_sbomdb()
+    monkeypatch.setattr(SbomDb, "lookup_dependencies", lambda *_args, **_kwargs: None)
+
+    cdx = sbomdb.to_cdx_data()
+
+    properties = {prop["name"]: prop["value"] for prop in cdx["metadata"]["properties"]}
+    assert properties["nixpkgs:metadata_source_method"] == "flakeref-target"
+    assert properties["nixpkgs:path"] == "/nix/store/source"
+    assert properties["nixpkgs:rev"] == "1234"
+    assert properties["nixpkgs:flakeref"] == ".#target"
+    assert properties["nixpkgs:version"] == "25.11"
+    assert properties["nixpkgs:message"] == "base nixpkgs source metadata"
+
+
+def test_spdx_document_records_nixpkgs_metadata_source(monkeypatch):
+    sbomdb = _make_minimal_sbomdb()
+    monkeypatch.setattr(SbomDb, "lookup_dependencies", lambda *_args, **_kwargs: None)
+
+    spdx = sbomdb.to_spdx_data()
+
+    assert "included dependencies: 'runtime_only'" in spdx["comment"]
+    assert (
+        "nixpkgs metadata source: metadata_source_method=flakeref-target"
+        in spdx["comment"]
+    )
+    assert "path=/nix/store/source" in spdx["comment"]
+    assert "rev=1234" in spdx["comment"]
+    assert "message=base nixpkgs source metadata" in spdx["comment"]
+    assert "warning=" not in spdx["comment"]

--- a/tests/test_sbom_vuln_enrichment.py
+++ b/tests/test_sbom_vuln_enrichment.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 import pandas as pd
 import pytest
 
+from common.errors import SbomnixError
 from sbomnix import cli_utils as sbomnix_cli_utils
 from sbomnix import main as sbomnix_main
 from sbomnix import vuln_enrichment as sbomnix_vuln_enrichment
@@ -31,6 +32,38 @@ class CapturingLogger:
         self.records.append(("fatal", msg, args))
 
 
+def test_sbomnix_getargs_accepts_meta_nixpkgs():
+    args = sbomnix_main.getargs(
+        [
+            "/nix/store/target",
+            "--meta-nixpkgs",
+            "nix-path",
+        ]
+    )
+
+    assert args.meta_nixpkgs == "nix-path"
+
+
+def test_sbomnix_run_rejects_exclude_meta_with_meta_nixpkgs():
+    args = SimpleNamespace(
+        NIXREF="/nix/store/target",
+        buildtime=False,
+        depth=None,
+        verbose=0,
+        include_vulns=False,
+        exclude_meta=True,
+        meta_nixpkgs="nix-path",
+        exclude_cpe_matching=False,
+        csv=None,
+        cdx=None,
+        spdx=None,
+        impure=True,
+    )
+
+    with pytest.raises(SbomnixError, match="--exclude-meta"):
+        sbomnix_main._run(args)
+
+
 def test_sbomnix_main_enriches_cdx_explicitly_when_include_vulns_is_set(monkeypatch):
     args = SimpleNamespace(
         NIXREF=".#target",
@@ -39,11 +72,12 @@ def test_sbomnix_main_enriches_cdx_explicitly_when_include_vulns_is_set(monkeypa
         verbose=0,
         include_vulns=True,
         exclude_meta=False,
+        meta_nixpkgs=None,
         exclude_cpe_matching=False,
         csv=None,
         cdx="sbom.cdx.json",
         spdx=None,
-        impure=False,
+        impure=True,
     )
     events = []
 
@@ -90,6 +124,9 @@ def test_sbomnix_main_enriches_cdx_explicitly_when_include_vulns_is_set(monkeypa
                 "buildtime": False,
                 "depth": None,
                 "flakeref": ".#target",
+                "original_ref": None,
+                "meta_nixpkgs": None,
+                "impure": True,
                 "include_meta": True,
                 "include_vulns": True,
                 "include_cpe": True,
@@ -114,6 +151,7 @@ def test_sbomnix_main_logs_generation_before_initializing_sbomdb(monkeypatch):
         verbose=0,
         include_vulns=False,
         exclude_meta=False,
+        meta_nixpkgs=None,
         exclude_cpe_matching=False,
         csv=None,
         cdx=None,
@@ -151,6 +189,9 @@ def test_sbomnix_main_logs_generation_before_initializing_sbomdb(monkeypatch):
                 "buildtime": False,
                 "depth": None,
                 "flakeref": ".#target",
+                "original_ref": None,
+                "meta_nixpkgs": None,
+                "impure": False,
                 "include_meta": True,
                 "include_vulns": False,
                 "include_cpe": True,


### PR DESCRIPTION
#### Motivation

Previously, for nix store path targets,  nixpkgs metadata enrichment could silently fall back to whatever `nixpkgs=` happened to be in `NIX_PATH`, making SBOM metadata non-reproducible and fragile for store-path targets. Flakeref targets also had limited visibility into which nixpkgs source was scanned. This change makes source selection explicit, target-aware, auditable, and recorded in the SBOM document itself.

#### Changes

- Add `--meta-nixpkgs` to `sbomnix` for explicit, reproducible nixpkgs metadata source selection. It accepts a nixpkgs flakeref, a nixpkgs source path normalized to an immutable store source, or the `nix-path` legacy mode that opts into `NIX_PATH=nixpkgs=...`.
- Resolve nixpkgs metadata automatically from flakeref targets. NixOS toplevel flakerefs are handled through the evaluated package set so overlays, overrides, nixpkgs config, and target system-specific changes can be represented.
- Skip nixpkgs metadata by default for store-path targets; `--meta-nixpkgs` is required to opt in.
- Record the selected metadata source in SBOM outputs: CycloneDX metadata properties and SPDX document comments include fields such as `nixpkgs:metadata_source_method`, `nixpkgs:path`, `nixpkgs:rev`, `nixpkgs:flakeref`, `nixpkgs:version`, and `nixpkgs:message`.
- Update the release asset script to generate SBOMs from the `.#sbomnix` flakeref target so release SBOMs can carry target-derived nixpkgs metadata.
- Add focused tests for metadata source resolution, NixOS flakeref handling, explicit source selection, output metadata export, and scanner behavior.
