### PR TITLE
tests: default vulnix test harness to dummy mode

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -10,3 +10,4 @@ markers =
     network: indicates a test that relies on external network access.
     slow: indicates a slow test.
     grype: indicates a test that invokes grype (triggers grype DB pre-warm).
+    real_vulnix: opt-in tests that execute the real vulnix binary.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,14 @@
 
 import os
 import re
+import shutil
 import subprocess
 import time
 from pathlib import Path
 
 import pytest
+
+from tests import vulnix_test_support
 
 REPOROOT = Path(__file__).resolve().parent.parent
 INTEGRATION_DIR = REPOROOT / "tests" / "integration"
@@ -72,6 +75,42 @@ def _warm_grype_db(request, tmp_path_factory):
     return cache_dir
 
 
+@pytest.fixture(scope="session")
+def _configure_test_vulnix(request, tmp_path_factory):
+    """Prepare the vulnix test wrapper with a deterministic default mode."""
+    requested_mode = os.environ.get("SBOMNIX_TEST_VULNIX_MODE", "dummy")
+    if requested_mode not in {"dummy", "real"}:
+        raise ValueError(
+            "invalid SBOMNIX_TEST_VULNIX_MODE "
+            f"{requested_mode!r}; expected one of: dummy, real"
+        )
+    tmp_root = tmp_path_factory.getbasetemp().parent
+    real_vulnix = shutil.which("vulnix")
+    if requested_mode == "real" and real_vulnix is None:
+        raise RuntimeError(
+            "real vulnix selected for tests, but 'vulnix' is not available in PATH"
+        )
+    cache_dir = vulnix_test_support.default_vulnix_cache_dir()
+    reporter = request.config.pluginmanager.get_plugin("terminalreporter")
+    if reporter is not None:
+        reporter.write_sep(
+            "=",
+            f"vulnix test mode: {requested_mode}",
+            bold=True,
+        )
+        if requested_mode == "real":
+            reporter.write_line(f"real vulnix binary: {real_vulnix}")
+            reporter.write_line(f"real vulnix cache dir: {cache_dir}")
+        else:
+            reporter.write_line("using dummy vulnix wrapper for deterministic tests")
+    return vulnix_test_support.configure_vulnix_for_tests(
+        tmp_root=tmp_root,
+        effective_mode=requested_mode,
+        cache_dir=cache_dir,
+        real_vulnix=real_vulnix,
+    )
+
+
 @pytest.fixture(name="test_work_dir")
 def fixture_test_work_dir(tmp_path):
     """Return a per-test working directory."""
@@ -113,7 +152,7 @@ def fixture_test_cdx_sbom():
 
 
 @pytest.fixture(name="_run_python_script")
-def fixture_run_python_script(test_work_dir, _warm_grype_db):
+def fixture_run_python_script(test_work_dir, _warm_grype_db, _configure_test_vulnix):
     """Invoke a Python entrypoint from an isolated test workdir."""
 
     def _run(args, **kwargs):
@@ -122,6 +161,10 @@ def fixture_run_python_script(test_work_dir, _warm_grype_db):
         env.setdefault("GRYPE_DB_VALIDATE_AGE", "false")
         if _warm_grype_db is not None:
             env["GRYPE_DB_CACHE_DIR"] = str(_warm_grype_db)
+        env = vulnix_test_support.build_vulnix_test_env(
+            env,
+            config=_configure_test_vulnix,
+        )
         kwargs.setdefault("cwd", test_work_dir)
         check = kwargs.pop("check", True)
         return subprocess.run(args, check=check, env=env, **kwargs)
@@ -172,7 +215,13 @@ def fixture_run_python_script_retry_on_repology_network_error(_run_python_script
 
 def pytest_collection_modifyitems(items):
     """Mark integration tests based on their path."""
+    run_real_vulnix = os.environ.get("SBOMNIX_RUN_REAL_VULNIX_TESTS") == "1"
+    skip_real_vulnix = pytest.mark.skip(
+        reason="real vulnix tests are opt-in; set SBOMNIX_RUN_REAL_VULNIX_TESTS=1"
+    )
     for item in items:
         path = Path(str(item.fspath)).resolve()
         if INTEGRATION_DIR in path.parents:
             item.add_marker(pytest.mark.integration)
+        if item.get_closest_marker("real_vulnix") and not run_real_vulnix:
+            item.add_marker(skip_real_vulnix)

--- a/tests/test_vulnix_test_support.py
+++ b/tests/test_vulnix_test_support.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the vulnix test wrapper helpers."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from tests import vulnix_test_support
+
+
+def test_build_vulnix_test_env_prepends_wrapper_dir(tmp_path):
+    """Wrapper dir should take precedence on PATH for test subprocesses."""
+    wrapper_dir = tmp_path / "bin"
+    config = vulnix_test_support.VulnixTestConfig(
+        wrapper_dir=wrapper_dir,
+        effective_mode="dummy",
+        effective_cache_dir=None,
+        real_vulnix=None,
+    )
+    env = vulnix_test_support.build_vulnix_test_env(
+        {"PATH": "/usr/bin"},
+        config=config,
+    )
+    assert env["PATH"] == os.pathsep.join([str(wrapper_dir), "/usr/bin"])
+    assert env["SBOMNIX_TEST_VULNIX_EFFECTIVE_MODE"] == "dummy"
+    assert env["SBOMNIX_TEST_REAL_VULNIX"] == ""
+    assert "SBOMNIX_TEST_VULNIX_EFFECTIVE_CACHE_DIR" not in env
+
+
+def test_dummy_vulnix_wrapper_returns_empty_json(tmp_path):
+    """Dummy mode should behave like a no-op vulnix process."""
+    config = vulnix_test_support.configure_vulnix_for_tests(
+        tmp_root=tmp_path,
+        effective_mode="dummy",
+        cache_dir=tmp_path / "cache",
+        real_vulnix=None,
+    )
+    env = vulnix_test_support.build_vulnix_test_env({}, config=config)
+    ret = subprocess.run(
+        [str(config.wrapper_dir / "vulnix"), "--json"],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+        env=env,
+    )
+    assert ret.stdout == "[]"
+    assert ret.stderr == ""
+
+
+def test_real_vulnix_wrapper_forwards_cache_dir_and_args(tmp_path):
+    """Real mode wrapper should exec the underlying binary with the cache dir."""
+    real_vulnix = tmp_path / "real-vulnix"
+    real_vulnix.write_text(
+        """#!/bin/sh
+set -eu
+printf '%s\\n' "$@"
+""",
+        encoding="utf-8",
+    )
+    real_vulnix.chmod(0o755)
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    (cache_dir / "Data.fs").write_text("ready", encoding="utf-8")
+    config = vulnix_test_support.configure_vulnix_for_tests(
+        tmp_root=tmp_path,
+        effective_mode="real",
+        cache_dir=cache_dir,
+        real_vulnix=real_vulnix.as_posix(),
+    )
+    env = vulnix_test_support.build_vulnix_test_env({}, config=config)
+    env = {"PATH": os.environ.get("PATH", os.defpath), **env}
+    ret = subprocess.run(
+        [str(config.wrapper_dir / "vulnix"), "target", "-C", "--json"],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+        env=env,
+    )
+    assert ret.stdout.splitlines() == [
+        "--cache-dir",
+        cache_dir.as_posix(),
+        "target",
+        "-C",
+        "--json",
+    ]
+
+
+def test_configure_vulnix_for_tests_rejects_unknown_mode(tmp_path):
+    """configure_vulnix_for_tests should only accept dummy or real modes."""
+    with pytest.raises(ValueError, match="invalid effective vulnix mode"):
+        vulnix_test_support.configure_vulnix_for_tests(
+            tmp_root=tmp_path,
+            effective_mode="surprise",
+            cache_dir=tmp_path / "cache",
+            real_vulnix=None,
+        )
+
+
+def test_real_vulnix_wrapper_shows_clear_error_when_binary_missing(tmp_path):
+    """Real mode wrapper should fail with a readable message if env is stale."""
+    config = vulnix_test_support.configure_vulnix_for_tests(
+        tmp_root=tmp_path,
+        effective_mode="dummy",
+        cache_dir=tmp_path / "cache",
+        real_vulnix=None,
+    )
+    env = {
+        "PATH": os.environ.get("PATH", os.defpath),
+        "SBOMNIX_TEST_VULNIX_EFFECTIVE_MODE": "real",
+    }
+    ret = subprocess.run(
+        [str(config.wrapper_dir / "vulnix"), "--json"],
+        check=False,
+        capture_output=True,
+        encoding="utf-8",
+        env=env,
+    )
+    assert ret.returncode != 0
+    assert "SBOMNIX_TEST_REAL_VULNIX is empty" in ret.stderr
+
+
+def test_ensure_real_vulnix_cache_surfaces_warmup_errors(tmp_path):
+    """Warm-up failures should include stderr details in the raised error."""
+    real_vulnix = tmp_path / "fake-vulnix"
+    real_vulnix.write_text(
+        """#!/bin/sh
+set -eu
+echo 'vulnix boom' >&2
+exit 7
+""",
+        encoding="utf-8",
+    )
+    real_vulnix.chmod(0o755)
+    result = tmp_path / "build" / "result"
+    result.parent.mkdir(parents=True, exist_ok=True)
+    result.write_text("placeholder", encoding="utf-8")
+
+    with pytest.raises(
+        RuntimeError, match="vulnix cache warm-up scan failed: vulnix boom"
+    ):
+        vulnix_test_support.ensure_real_vulnix_cache(
+            tmp_path / "cache",
+            build_root=tmp_path / "build",
+            real_vulnix=real_vulnix.as_posix(),
+            test_derivation=tmp_path / "derivation.nix",
+        )
+
+
+@pytest.mark.real_vulnix
+def test_real_vulnix_wrapper_executes_real_binary(tmp_path):
+    """Opt-in smoke test that executes the real vulnix binary via the wrapper."""
+    real_vulnix = shutil.which("vulnix")
+    if real_vulnix is None:
+        pytest.skip("'vulnix' is not available in PATH")
+    cache_dir = tmp_path / "real-cache"
+    config = vulnix_test_support.configure_vulnix_for_tests(
+        tmp_root=tmp_path,
+        effective_mode="real",
+        cache_dir=cache_dir,
+        real_vulnix=real_vulnix,
+    )
+    env = vulnix_test_support.build_vulnix_test_env({}, config=config)
+    env = {"PATH": os.environ.get("PATH", os.defpath), **env}
+    ret = subprocess.run(
+        [str(config.wrapper_dir / "vulnix"), "--version"],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+        env=env,
+    )
+    assert "vulnix" in ret.stdout.lower() or "vulnix" in ret.stderr.lower()

--- a/tests/vulnix_test_support.py
+++ b/tests/vulnix_test_support.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for choosing the real or dummy vulnix binary in tests."""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import shutil
+import stat
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+_WRAPPER_BASENAME = "vulnix"
+
+
+@dataclass(frozen=True)
+class VulnixTestConfig:
+    """Resolved vulnix test execution configuration."""
+
+    wrapper_dir: Path
+    effective_mode: str
+    effective_cache_dir: Path | None
+    real_vulnix: str | None
+
+
+def default_vulnix_cache_dir(env: dict[str, str] | None = None) -> Path:
+    """Return the real vulnix cache dir for this environment."""
+    env = os.environ if env is None else env
+    cache_dir = env.get("SBOMNIX_TEST_VULNIX_CACHE_DIR")
+    if cache_dir:
+        return Path(cache_dir).expanduser()
+    return Path("~/.cache/vulnix").expanduser()
+
+
+def vulnix_cache_ready(cache_dir: Path) -> bool:
+    """Return True when `cache_dir` already contains a usable vulnix DB."""
+    data_file = cache_dir / "Data.fs"
+    return data_file.is_file() and data_file.stat().st_size > 0
+
+
+def write_vulnix_wrapper(wrapper_dir: Path) -> Path:
+    """Create the test-only vulnix wrapper and return its path."""
+    wrapper_dir.mkdir(parents=True, exist_ok=True)
+    wrapper_path = wrapper_dir / _WRAPPER_BASENAME
+    wrapper_path.write_text(
+        """#!/bin/sh
+set -eu
+
+mode="${SBOMNIX_TEST_VULNIX_EFFECTIVE_MODE:?}"
+if [ "$mode" = "dummy" ]; then
+  printf '[]'
+  exit 0
+fi
+
+real_vulnix="${SBOMNIX_TEST_REAL_VULNIX:-}"
+if [ -z "$real_vulnix" ]; then
+  echo "SBOMNIX_TEST_REAL_VULNIX is empty while vulnix test mode is real" >&2
+  exit 2
+fi
+cache_dir="${SBOMNIX_TEST_VULNIX_EFFECTIVE_CACHE_DIR:-}"
+if [ -n "$cache_dir" ]; then
+  exec "$real_vulnix" --cache-dir "$cache_dir" "$@"
+fi
+exec "$real_vulnix" "$@"
+""",
+        encoding="utf-8",
+    )
+    wrapper_path.chmod(
+        wrapper_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    )
+    return wrapper_path
+
+
+def build_vulnix_test_env(
+    env: dict[str, str],
+    *,
+    config: VulnixTestConfig,
+) -> dict[str, str]:
+    """Return environment variables needed by the vulnix test wrapper."""
+    env = env.copy()
+    path_entries = [str(config.wrapper_dir)]
+    path_entries.append(env.get("PATH", os.defpath))
+    env["PATH"] = os.pathsep.join(path_entries)
+    env["SBOMNIX_TEST_VULNIX_EFFECTIVE_MODE"] = config.effective_mode
+    env["SBOMNIX_TEST_REAL_VULNIX"] = config.real_vulnix or ""
+    if config.effective_cache_dir is not None:
+        env["SBOMNIX_TEST_VULNIX_EFFECTIVE_CACHE_DIR"] = str(config.effective_cache_dir)
+    else:
+        env.pop("SBOMNIX_TEST_VULNIX_EFFECTIVE_CACHE_DIR", None)
+    return env
+
+
+def configure_vulnix_for_tests(
+    *,
+    tmp_root: Path,
+    effective_mode: str,
+    cache_dir: Path,
+    real_vulnix: str | None = None,
+) -> VulnixTestConfig:
+    """Resolve vulnix wrapper mode and materialize the wrapper script."""
+    if effective_mode not in {"dummy", "real"}:
+        raise ValueError(
+            f"invalid effective vulnix mode {effective_mode!r}; expected 'dummy' or 'real'"
+        )
+    if effective_mode == "real" and real_vulnix is None:
+        real_vulnix = shutil.which("vulnix")
+    if effective_mode == "real" and real_vulnix is None:
+        raise RuntimeError(
+            "real vulnix requested, but 'vulnix' is not available in PATH"
+        )
+    wrapper_dir = tmp_root / "tool-wrappers"
+    write_vulnix_wrapper(wrapper_dir)
+    return VulnixTestConfig(
+        wrapper_dir=wrapper_dir,
+        effective_mode=effective_mode,
+        effective_cache_dir=cache_dir if effective_mode == "real" else None,
+        real_vulnix=real_vulnix,
+    )
+
+
+def ensure_real_vulnix_cache(
+    cache_dir: Path,
+    *,
+    build_root: Path,
+    real_vulnix: str,
+    test_derivation: Path,
+) -> Path:
+    """Warm a shared vulnix cache once for opt-in/manual real-vulnix test runs.
+
+    The default test harness uses dummy vulnix and does not call this helper.
+    """
+
+    def _run_warmup_command(cmd: list[str], *, step: str) -> None:
+        try:
+            subprocess.run(
+                cmd,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or "").strip()
+            stdout = (exc.stdout or "").strip()
+            details = stderr or stdout or "no output captured"
+            raise RuntimeError(f"{step} failed: {details}") from exc
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    build_root.mkdir(parents=True, exist_ok=True)
+    lock_path = build_root / "vulnix-cache.lock"
+    with lock_path.open("w", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        if vulnix_cache_ready(cache_dir):
+            return cache_dir
+        result_link = build_root / "result"
+        if not result_link.exists():
+            _run_warmup_command(
+                ["nix-build", test_derivation.as_posix(), "-o", result_link.as_posix()],
+                step="nix-build for vulnix cache warm-up",
+            )
+        _run_warmup_command(
+            [
+                real_vulnix,
+                "--cache-dir",
+                cache_dir.as_posix(),
+                result_link.as_posix(),
+                "-C",
+                "--json",
+            ],
+            step="vulnix cache warm-up scan",
+        )
+    return cache_dir


### PR DESCRIPTION
Use a deterministic dummy vulnix wrapper for the default test harness and keep real-vulnix execution explicitly opt-in. This keeps normal test runs stable and independent from host vulnix state.

- Set SBOMNIX_TEST_VULNIX_MODE default to dummy in conftest and accept only dummy|real.
- Inject a test-only vulnix wrapper through PATH in _run_python_script so subprocesses use controlled test behavior.
- Add real_vulnix pytest marker and skip marked tests unless SBOMNIX_RUN_REAL_VULNIX_TESTS=1.
- Add vulnix test support helpers and focused unit tests for wrapper behavior, env wiring, and warm-up error diagnostics.
- Add an opt-in real-vulnix smoke test behind the real_vulnix marker.