### PR TITLE
sbomnix: unify persistent cache paths

### DIFF
--- a/src/common/http.py
+++ b/src/common/http.py
@@ -13,6 +13,8 @@ from requests_cache import CacheMixin
 from requests_ratelimiter import LimiterMixin
 from urllib3.util.retry import Retry
 
+from sbomnix.cache_paths import http_cache_name
+
 DEFAULT_RETRY_STATUS_CODES = (429, 500, 502, 503, 504)
 
 
@@ -46,13 +48,14 @@ def mount_retries(
     return session
 
 
-def create_cached_limited_session(
+def create_cached_limited_session(  # noqa: PLR0913
     *,
     per_second: int | None = None,
     per_minute: int | None = None,
     expire_after: int | None = None,
     user_agent: str | None = None,
     allowed_methods: Collection[str] = frozenset(("GET", "HEAD")),
+    cache_name: str | None = None,
 ) -> Session:
     """Create a cached, rate-limited session with retry policy attached."""
     kwargs: dict[str, Any] = {}
@@ -62,6 +65,9 @@ def create_cached_limited_session(
         kwargs["per_minute"] = per_minute
     if expire_after is not None:
         kwargs["expire_after"] = expire_after
+    if cache_name is None:
+        cache_name = str(http_cache_name())
+    kwargs["cache_name"] = cache_name
     session = CachedLimiterSession(**kwargs)
     mount_retries(session, allowed_methods=allowed_methods)
     if user_agent:

--- a/src/sbomnix/cache_paths.py
+++ b/src/sbomnix/cache_paths.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2026 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared cache path helpers for sbomnix."""
+
+import os
+import pathlib
+import tempfile
+from getpass import getuser
+
+
+def cache_root():
+    """Return the common cache root for sbomnix."""
+    candidates = []
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+    if xdg_cache_home:
+        candidates.append(lambda: pathlib.Path(xdg_cache_home).expanduser() / "sbomnix")
+    candidates.append(lambda: pathlib.Path.home() / ".cache" / "sbomnix")
+    candidates.append(
+        lambda: pathlib.Path(tempfile.gettempdir()) / f"{getuser()}_sbomnix_cache"
+    )
+    last_error = None
+    for get_path in candidates:
+        try:
+            path = get_path()
+            path.mkdir(parents=True, exist_ok=True)
+            if not os.access(path, os.W_OK | os.X_OK):
+                raise PermissionError(f"Cache root is not writable: {path}")
+            return path
+        except (OSError, RuntimeError) as error:
+            last_error = error
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("Failed determining sbomnix cache root")
+
+
+def dfcache_dir():
+    """Return the persistent dataframe cache directory."""
+    path = cache_root() / "dataframes"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def dfcache_lock_path():
+    """Return the dataframe cache lock path."""
+    return cache_root() / "dataframes.lock"
+
+
+def meta_lock_path():
+    """Return the metadata scan lock path."""
+    return cache_root() / "meta.lock"
+
+
+def http_cache_name():
+    """Return the requests-cache base path for persistent HTTP caching."""
+    return cache_root() / "http_cache"

--- a/src/sbomnix/dfcache.py
+++ b/src/sbomnix/dfcache.py
@@ -4,27 +4,29 @@
 
 """Thread-safe DataFrameDiskCache"""
 
-import pathlib
+import hashlib
+import os
 import tempfile
-from getpass import getuser
 
 from dfdiskcache import DataFrameDiskCache
+from dfdiskcache._core import DiskCacheInfo, get_utcnow_timestamp
 from filelock import FileLock
+from simplesqlite.query import Set, Where
 
-###############################################################################
-
-# DataFrameDiskCache cache local path and lock file
-DFCACHE_PATH = pathlib.Path(tempfile.gettempdir()) / f"{getuser()}_sbomnix_df_cache"
-DFCACHE_LOCK = DFCACHE_PATH / "dfcache.lock"
-
-################################################################################
+from sbomnix.cache_paths import dfcache_dir, dfcache_lock_path
 
 
 class LockedDfCache:
     """Thread-safe (and process-safe) wrapper for DataFrameDiskCache"""
 
     def __init__(self):
-        self.dflock = FileLock(DFCACHE_LOCK)
+        self.dflock = FileLock(dfcache_lock_path())
+
+    def set(self, key, value, ttl=None):
+        """Store dataframe cache entries without cross-device renames."""
+        with self.dflock:
+            dfcache = DataFrameDiskCache(cache_dir_path=dfcache_dir())
+            return _cache_local_set(dfcache, key, value, ttl=ttl)
 
     def __getattr__(self, name):
         def wrap(*a, **k):
@@ -38,10 +40,62 @@ class LockedDfCache:
                 # for the first thread making other threads throw with
                 # 'database locked' etc. even if we otherwise protect
                 # concurrent writes.
-                dfcache = DataFrameDiskCache(cache_dir_path=DFCACHE_PATH)
+                dfcache = DataFrameDiskCache(cache_dir_path=dfcache_dir())
                 return getattr(dfcache, name)(*a, **k)
 
         return wrap
+
+
+def _cache_local_set(dfcache, key, value, ttl=None):
+    """Set dataframe cache entries using a temp file in the cache directory."""
+    key_hash = hashlib.sha256(key.strip().encode()).hexdigest()
+    cache_fpath = dfcache.cache_dir_path / f"{key_hash}.{dfcache.PICKLE_EXT}"
+    tmp_fpath = None
+    try:
+        fd, tmp_name = tempfile.mkstemp(
+            dir=dfcache.cache_dir_path,
+            prefix=f"dfdiskcache_{key_hash}_",
+            suffix=f".{dfcache.PICKLE_EXT}",
+        )
+        os.close(fd)
+        tmp_fpath = tmp_name
+        value.to_pickle(tmp_fpath)
+        # df-diskcache writes the temporary file under /tmp and renames it into
+        # the cache directory. That fails with EXDEV when those paths are on
+        # different filesystems.
+        os.replace(tmp_fpath, cache_fpath)
+        tmp_fpath = None
+    finally:
+        if tmp_fpath and os.path.exists(tmp_fpath):
+            os.unlink(tmp_fpath)
+
+    utcnow_timestamp = get_utcnow_timestamp()
+    where_key = Where(DiskCacheInfo.key, key_hash)
+    record_exists = any(DiskCacheInfo.select(where=where_key))
+
+    if not record_exists:
+        if ttl is None:
+            ttl = dfcache.DEFAULT_TTL
+
+        DiskCacheInfo.insert(
+            DiskCacheInfo(
+                key=key_hash,
+                path=str(cache_fpath),
+                ttl=ttl,
+                created_at=utcnow_timestamp,
+                updated_at=utcnow_timestamp,
+            )
+        )
+    else:
+        DiskCacheInfo.update(
+            set_query=[
+                Set(DiskCacheInfo.path, str(cache_fpath)),
+                Set(DiskCacheInfo.updated_at, utcnow_timestamp),
+            ],
+            where=where_key,
+        )
+
+    return key_hash
 
 
 ###############################################################################

--- a/src/sbomnix/meta.py
+++ b/src/sbomnix/meta.py
@@ -4,15 +4,13 @@
 
 """Cache and scan nixpkgs meta information."""
 
-import pathlib
-import tempfile
 from dataclasses import replace
-from getpass import getuser
 
 from filelock import FileLock
 
 from common.log import LOG
 from nixmeta.scanner import NixMetaScanner
+from sbomnix.cache_paths import meta_lock_path
 from sbomnix.dfcache import LockedDfCache
 from sbomnix.meta_source import (
     META_NIXPKGS_NIX_PATH,
@@ -28,11 +26,6 @@ from sbomnix.meta_source import (
 # is cleaned.
 _NIXMETA_NIXPKGS_TTL = 60 * 60 * 24 * 30
 
-# FileLock lock path
-_FLOCK = pathlib.Path(tempfile.gettempdir()) / f"{getuser()}_sbomnix_meta.lock"
-
-###############################################################################
-
 __all__ = [
     "META_NIXPKGS_NIX_PATH",
     "Meta",
@@ -45,7 +38,7 @@ class Meta:
     """Cache nixpkgs meta information."""
 
     def __init__(self):
-        self.lock = FileLock(_FLOCK)
+        self.lock = FileLock(str(meta_lock_path()))
         self.cache = LockedDfCache()
         self.source_resolver = NixpkgsMetaSourceResolver()
 

--- a/tests/test_dfcache.py
+++ b/tests/test_dfcache.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for dataframe cache handling."""
+
+import errno
+import os
+
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from sbomnix.dfcache import LockedDfCache
+
+
+def test_locked_dfcache_set_avoids_cross_device_rename(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", (tmp_path / "xdg").as_posix())
+
+    def fail_rename(*_args):
+        raise OSError(errno.EXDEV, "Invalid cross-device link")
+
+    monkeypatch.setattr(os, "rename", fail_rename)
+
+    cache = LockedDfCache()
+    df = pd.DataFrame(
+        {
+            "product": ["openssl"],
+            "vendor": ["openssl_project"],
+        }
+    )
+
+    cache.set("https://example.invalid/cpes.csv", df, ttl=60)
+
+    assert_frame_equal(cache.get("https://example.invalid/cpes.csv"), df)
+
+
+def test_locked_dfcache_set_metadata_works_with_standard_cache_operations(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("XDG_CACHE_HOME", (tmp_path / "xdg").as_posix())
+
+    cache = LockedDfCache()
+    key = "https://example.invalid/metadata.csv"
+    df = pd.DataFrame({"package": ["openssl"], "version": ["3.0.0"]})
+    updated_df = pd.DataFrame({"package": ["openssl"], "version": ["3.0.1"]})
+
+    cache_key = cache.set(key, df, ttl=60)
+    assert cache.set(key, updated_df, ttl=60) == cache_key
+    assert cache.touch(key) == cache_key
+    assert_frame_equal(cache.get(key), updated_df)
+
+    assert cache.delete(key) == cache_key
+    assert cache.get(key) is None

--- a/tests/test_http_cache.py
+++ b/tests/test_http_cache.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for shared cache-path configuration."""
+
+from pathlib import Path
+
+from common.http import create_cached_limited_session
+from sbomnix import cache_paths as sbomnix_cache_paths
+from sbomnix.cache_paths import cache_root, http_cache_name, meta_lock_path
+from sbomnix.meta import Meta
+
+
+def test_cache_root_prefers_xdg_cache_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", tmp_path.as_posix())
+
+    assert cache_root() == tmp_path / "sbomnix"
+
+
+def test_cache_root_falls_back_to_home_cache(monkeypatch, tmp_path):
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    assert cache_root() == tmp_path / ".cache" / "sbomnix"
+
+
+def test_cache_root_uses_xdg_when_tmp_fallback_cannot_resolve_user(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("XDG_CACHE_HOME", tmp_path.as_posix())
+    monkeypatch.setattr(
+        sbomnix_cache_paths,
+        "getuser",
+        lambda: (_ for _ in ()).throw(OSError("no user")),
+    )
+
+    assert cache_root() == tmp_path / "sbomnix"
+
+
+def test_cache_root_falls_back_to_tmp_when_home_cannot_be_resolved(
+    monkeypatch, tmp_path
+):
+    tmp_root = tmp_path / "tmp"
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.setattr(
+        Path,
+        "home",
+        lambda: (_ for _ in ()).throw(RuntimeError("no home")),
+    )
+    monkeypatch.setattr(
+        sbomnix_cache_paths.tempfile,
+        "gettempdir",
+        tmp_root.as_posix,
+    )
+    monkeypatch.setattr(sbomnix_cache_paths, "getuser", lambda: "tester")
+
+    assert cache_root() == tmp_root / "tester_sbomnix_cache"
+
+
+def test_cached_http_session_uses_shared_sbomnix_cache_path():
+    session = create_cached_limited_session()
+    try:
+        assert Path(session.cache.db_path) == http_cache_name().with_suffix(".sqlite")
+    finally:
+        session.close()
+
+
+def test_meta_lock_uses_shared_sbomnix_cache_root(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", tmp_path.as_posix())
+
+    assert meta_lock_path() == tmp_path / "sbomnix" / "meta.lock"
+    assert Meta().lock.lock_file == str(tmp_path / "sbomnix" / "meta.lock")
+
+
+def test_cache_root_falls_back_to_tmp_when_xdg_and_home_are_unwritable(
+    monkeypatch, tmp_path
+):
+    xdg_root = tmp_path / "xdg"
+    home_root = tmp_path / "home"
+    tmp_root = tmp_path / "tmp"
+    orig_mkdir = Path.mkdir
+
+    monkeypatch.setenv("XDG_CACHE_HOME", xdg_root.as_posix())
+    monkeypatch.setattr(Path, "home", lambda: home_root)
+    monkeypatch.setattr(
+        sbomnix_cache_paths.tempfile,
+        "gettempdir",
+        tmp_root.as_posix,
+    )
+    monkeypatch.setattr(sbomnix_cache_paths, "getuser", lambda: "tester")
+
+    def fake_mkdir(self, *args, **kwargs):
+        if self in {
+            xdg_root / "sbomnix",
+            home_root / ".cache" / "sbomnix",
+        }:
+            raise PermissionError("unwritable")
+        return orig_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", fake_mkdir)
+
+    assert cache_root() == tmp_root / "tester_sbomnix_cache"
+
+
+def test_cache_root_falls_back_to_tmp_when_existing_dirs_are_not_writable(
+    monkeypatch, tmp_path
+):
+    xdg_root = tmp_path / "xdg"
+    home_root = tmp_path / "home"
+    tmp_root = tmp_path / "tmp"
+    xdg_cache = xdg_root / "sbomnix"
+    home_cache = home_root / ".cache" / "sbomnix"
+    xdg_cache.mkdir(parents=True)
+    home_cache.mkdir(parents=True)
+    real_access = sbomnix_cache_paths.os.access
+
+    monkeypatch.setenv("XDG_CACHE_HOME", xdg_root.as_posix())
+    monkeypatch.setattr(Path, "home", lambda: home_root)
+    monkeypatch.setattr(
+        sbomnix_cache_paths.tempfile,
+        "gettempdir",
+        tmp_root.as_posix,
+    )
+    monkeypatch.setattr(sbomnix_cache_paths, "getuser", lambda: "tester")
+
+    def fake_access(path, mode):
+        path = Path(path)
+        if path in {xdg_cache, home_cache}:
+            return False
+        return real_access(path, mode)
+
+    monkeypatch.setattr(sbomnix_cache_paths.os, "access", fake_access)
+
+    assert cache_root() == tmp_root / "tester_sbomnix_cache"


### PR DESCRIPTION
Centralize sbomnix cache path selection in a shared cache_paths module and route the dataframe cache helpers through it instead of rebuilding temporary paths in each cache implementation.

Prefer XDG_CACHE_HOME for the shared cache root, fall back to ~/.cache/sbomnix, and keep /tmp as the final fallback when the configured cache roots cannot be resolved or are not writable. Also move the metadata scan lock under the shared cache root and make the HTTP cache path explicit instead of relying on the current working directory default from requests-cache.

Add focused tests for the HTTP cache path, shared cache-root behavior, and unwritable cache-directory fallback.
