### PR TITLE
provenance: handle unrealized path-info records

### DIFF
--- a/src/common/nix_utils.py
+++ b/src/common/nix_utils.py
@@ -317,6 +317,10 @@ def normalize_nix_path_info(path_info, *, command=NIX_PATH_INFO_JSON):
                     command,
                     "expected path-info object keys to be non-empty strings",
                 )
+            if info is None:
+                # Nix can emit null for substitutable paths that are not local.
+                normalized[path] = info
+                continue
             if not isinstance(info, dict):
                 raise InvalidNixJsonError(
                     command,

--- a/src/provenance/dependencies.py
+++ b/src/provenance/dependencies.py
@@ -72,11 +72,16 @@ def dependency_paths(drv_path, recursive=False, outputs_by_path=None, hooks=None
                 paths.append(path)
         return paths
 
-    drv_info = path_infos.get(drv_path)
-    if drv_info is None:
+    if drv_path not in path_infos:
         raise InvalidNixJsonError(
             NIX_PATH_INFO_JSON,
             f"missing path-info record for `{drv_path}`",
+        )
+    drv_info = path_infos[drv_path]
+    if drv_info is None:
+        raise InvalidNixJsonError(
+            NIX_PATH_INFO_JSON,
+            f"path-info record for `{drv_path}` is unrealized",
         )
     return list(nix_path_info_references(drv_info, drv_path))
 
@@ -92,7 +97,7 @@ def dependency_package(drv, output_hash, infos, outputs_by_path, hooks=None):
     if digest is None:
         digest = hooks.normalize_digest_fn(output_hash)
     if digest is None:
-        hooks.log.warning("Cannot determine digest for dependency '%s'", drv)
+        hooks.log.log(LOG_VERBOSE, "Cannot determine digest for dependency '%s'", drv)
         return None
 
     package = {

--- a/src/provenance/path_info.py
+++ b/src/provenance/path_info.py
@@ -68,16 +68,34 @@ def query_path_hashes(paths, *, exec_cmd_fn=exec_cmd):
             exec_cmd_fn=exec_cmd_fn,
         )
     if path_infos is None:
-        return []
-    return [nar_hash_for_path(path_infos, path) for path in paths]
+        return [None for _path in paths]
+    return [optional_nar_hash_for_path(path_infos, path) for path in paths]
 
 
 def nar_hash_for_path(path_infos, path):
     """Return the NAR hash for one path-info record."""
-    info = path_infos.get(path)
-    if info is None:
+    if path not in path_infos:
         raise InvalidNixJsonError(
             NIX_PATH_INFO_JSON,
             f"missing path-info record for `{path}`",
         )
+    info = path_infos[path]
+    if info is None:
+        raise InvalidNixJsonError(
+            NIX_PATH_INFO_JSON,
+            f"path-info record for `{path}` is unrealized",
+        )
+    return nix_path_info_nar_hash(info, path)
+
+
+def optional_nar_hash_for_path(path_infos, path):
+    """Return the NAR hash for a realized path, or None for unrealized paths."""
+    if path not in path_infos:
+        raise InvalidNixJsonError(
+            NIX_PATH_INFO_JSON,
+            f"missing path-info record for `{path}`",
+        )
+    info = path_infos[path]
+    if info is None:
+        return None
     return nix_path_info_nar_hash(info, path)

--- a/src/provenance/subjects.py
+++ b/src/provenance/subjects.py
@@ -75,7 +75,11 @@ def get_subjects(
                 exec_cmd_fn=hooks.exec_cmd_fn,
                 raise_on_error=False,
             )
-            if path_infos is None or resolved_output_path not in path_infos:
+            if (
+                path_infos is None
+                or resolved_output_path not in path_infos
+                or path_infos[resolved_output_path] is None
+            ):
                 hooks.log.warning(
                     "Derivation output '%s' was not found in the nix store, "
                     "assuming it was not built.",

--- a/src/sbomnix/runtime.py
+++ b/src/sbomnix/runtime.py
@@ -61,6 +61,8 @@ def runtime_closure_from_path_info(path_info):
     rows = []
     output_paths_by_drv = {}
     for target_path, info in normalize_nix_path_info(path_info).items():
+        if info is None:
+            continue
         deriver = nix_path_info_deriver(info, target_path)
         if deriver:
             output_paths_by_drv.setdefault(deriver, set()).add(target_path)

--- a/tests/test_provenance_path_info.py
+++ b/tests/test_provenance_path_info.py
@@ -14,7 +14,7 @@ import pytest
 from common.errors import InvalidNixJsonError, NixCommandError
 from common.nix_utils import normalize_nix_path_info
 from provenance.dependencies import DependencyHooks, dependency_paths
-from provenance.path_info import nar_hash_for_path, query_path_info
+from provenance.path_info import nar_hash_for_path, query_path_hashes, query_path_info
 
 
 def test_normalize_path_info_rejects_malformed_list_records():
@@ -24,7 +24,13 @@ def test_normalize_path_info_rejects_malformed_list_records():
 
 def test_normalize_path_info_rejects_malformed_object_records():
     with pytest.raises(InvalidNixJsonError, match="expected path-info record"):
-        normalize_nix_path_info({"/nix/store/target": None})
+        normalize_nix_path_info({"/nix/store/target": "not-a-record"})
+
+
+def test_normalize_path_info_preserves_unrealized_object_records():
+    target = "/nix/store/11111111111111111111111111111111-target"
+
+    assert normalize_nix_path_info({target: None}) == {target: None}
 
 
 def test_normalize_path_info_supports_list_records():
@@ -50,6 +56,45 @@ def test_nar_hash_for_path_rejects_missing_hash():
 def test_nar_hash_for_path_rejects_missing_record():
     with pytest.raises(InvalidNixJsonError, match="missing path-info record"):
         nar_hash_for_path({}, "/nix/store/target")
+
+
+def test_nar_hash_for_path_rejects_unrealized_record():
+    with pytest.raises(InvalidNixJsonError, match="is unrealized"):
+        nar_hash_for_path({"/nix/store/target": None}, "/nix/store/target")
+
+
+def test_query_path_hashes_preserves_unrealized_records():
+    realized = "/nix/store/11111111111111111111111111111111-realized"
+    unrealized = "/nix/store/22222222222222222222222222222222-source"
+    nar_hash = "sha256:1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s"
+
+    def fake_exec_cmd(cmd, **_kwargs):
+        assert realized in cmd
+        assert unrealized in cmd
+        return SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    realized: {"narHash": nar_hash},
+                    unrealized: None,
+                }
+            )
+        )
+
+    assert query_path_hashes(
+        [realized, unrealized],
+        exec_cmd_fn=fake_exec_cmd,
+    ) == [nar_hash, None]
+
+
+def test_query_path_hashes_rejects_omitted_records():
+    requested = "/nix/store/11111111111111111111111111111111-requested"
+
+    def fake_exec_cmd(cmd, **_kwargs):
+        assert requested in cmd
+        return SimpleNamespace(stdout=json.dumps({}))
+
+    with pytest.raises(InvalidNixJsonError, match="missing path-info record"):
+        query_path_hashes([requested], exec_cmd_fn=fake_exec_cmd)
 
 
 def test_dependency_paths_rejects_mismatched_path_info_record():
@@ -95,6 +140,31 @@ def test_dependency_paths_recursive_includes_derivation_outputs():
         root_drv,
         dep_drv,
         root_out,
+        dep_out,
+    ]
+
+
+def test_dependency_paths_recursive_keeps_unrealized_path_records():
+    root_drv = "/nix/store/11111111111111111111111111111111-root.drv"
+    dep_out = "/nix/store/22222222222222222222222222222222-source"
+
+    def fake_exec_cmd(cmd, **_kwargs):
+        assert "--recursive" in cmd
+        return SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    root_drv: {"references": [dep_out]},
+                    dep_out: None,
+                }
+            )
+        )
+
+    assert dependency_paths(
+        root_drv,
+        recursive=True,
+        hooks=DependencyHooks(exec_cmd_fn=fake_exec_cmd),
+    ) == [
+        root_drv,
         dep_out,
     ]
 

--- a/tests/test_provenance_subjects.py
+++ b/tests/test_provenance_subjects.py
@@ -17,7 +17,7 @@ from common.errors import (
     MissingNixDerivationMetadataError,
     NixCommandError,
 )
-from common.log import LOG
+from common.log import LOG, LOG_VERBOSE
 from common.nix_utils import parse_nix_derivation_show
 from provenance import main as provenance_main
 from provenance.dependencies import (
@@ -148,7 +148,25 @@ def test_dependency_package_skips_non_normalized_digest(caplog):
         )
 
     assert package is None
+    assert "Cannot determine digest" not in caplog.text
+
+    caplog.clear()
+    with caplog.at_level(LOG_VERBOSE, logger=LOG.name):
+        package = dependency_package(
+            drv_path,
+            "sha999:abc",
+            {},
+            {},
+            hooks=DependencyHooks(
+                normalize_digest_fn=normalize_digest,
+                output_digest_fn=output_digest,
+                log=LOG,
+            ),
+        )
+
+    assert package is None
     assert "Cannot determine digest" in caplog.text
+    assert caplog.records[0].levelno == LOG_VERBOSE
 
 
 def test_get_dependencies_prefers_fixed_output_digest_for_output_paths():
@@ -202,6 +220,85 @@ def test_get_dependencies_prefers_fixed_output_digest_for_output_paths():
             "annotations": {"version": "1.2.3"},
         }
     ]
+
+
+def test_get_dependencies_uses_fixed_output_digest_for_unrealized_path_info():
+    drv_path = "/nix/store/0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-root.drv"
+    drv_basename = "0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-root.drv"
+    dep_drv_basename = "1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-source.drv"
+    root_out_path = "/nix/store/3ddddddddddddddddddddddddddddddd-root"
+    dep_out_basename = "2ccccccccccccccccccccccccccccccc-source"
+    dep_out_path = f"/nix/store/{dep_out_basename}"
+    metadata_digest = "77a94a83ccab42a68278ac5d3e340dcefecd736dd4feff1de71dec137b6b44ce"
+    root_nar_hash = "sha256:1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s"
+
+    def fake_exec_cmd(cmd, **kwargs):
+        if cmd[:4] == ["nix", "derivation", "show", "-r"]:
+            return SimpleNamespace(
+                stdout=json.dumps(
+                    {
+                        "derivations": {
+                            drv_basename: {
+                                "name": "root",
+                                "outputs": {"out": {"path": root_out_path}},
+                                "env": {"out": root_out_path},
+                            },
+                            dep_drv_basename: {
+                                "name": "source",
+                                "outputs": {
+                                    "out": {
+                                        "path": dep_out_basename,
+                                        "hash": metadata_digest,
+                                        "hashAlgo": "r:sha256",
+                                    }
+                                },
+                                "env": {
+                                    "out": dep_out_basename,
+                                    "version": "1.2.3",
+                                },
+                            },
+                        },
+                        "version": 4,
+                    }
+                )
+            )
+        if cmd[:5] == ["nix", "path-info", "--json", "--json-format", "1"]:
+            args = cmd[5:]
+            if "--extra-experimental-features" in args:
+                args = args[: args.index("--extra-experimental-features")]
+            recursive = "--recursive" in args
+            paths = [arg for arg in args if arg != "--recursive"]
+            if recursive and paths == [drv_path]:
+                return SimpleNamespace(
+                    stdout=json.dumps(
+                        {
+                            drv_path: {"references": [dep_out_path]},
+                            dep_out_path: None,
+                        }
+                    )
+                )
+            if not recursive and paths == [drv_path, dep_out_path, root_out_path]:
+                return SimpleNamespace(
+                    stdout=json.dumps(
+                        {
+                            drv_path: {"narHash": root_nar_hash},
+                            dep_out_path: None,
+                            root_out_path: {"narHash": root_nar_hash},
+                        }
+                    )
+                )
+        raise AssertionError(f"unexpected command: {cmd} kwargs={kwargs}")
+
+    assert {
+        "name": "source",
+        "uri": dep_out_path,
+        "digest": {"sha256": metadata_digest},
+        "annotations": {"version": "1.2.3"},
+    } in get_dependencies(
+        drv_path,
+        recursive=True,
+        hooks=_dependency_hooks(exec_cmd_fn=fake_exec_cmd),
+    )
 
 
 def test_get_dependencies_maps_env_only_output_paths_back_to_derivations():
@@ -369,6 +466,20 @@ def test_get_subjects_skips_unrealized_outputs_without_digest():
 
     def fake_exec_cmd(cmd, **_kwargs):
         assert _path_info_paths(cmd) == [output_path_value]
+
+    assert not get_subjects(
+        {"out": {"method": "nar"}},
+        env={"out": output_path_value},
+        hooks=_subject_hooks(fake_exec_cmd),
+    )
+
+
+def test_get_subjects_skips_null_path_info_outputs_without_digest():
+    output_path_value = "/custom/store/2ccccccccccccccccccccccccccccccc-nghttp2-doc"
+
+    def fake_exec_cmd(cmd, **_kwargs):
+        assert _path_info_paths(cmd) == [output_path_value]
+        return SimpleNamespace(stdout=json.dumps({output_path_value: None}))
 
     assert not get_subjects(
         {"out": {"method": "nar"}},

--- a/tests/test_runtime_closure.py
+++ b/tests/test_runtime_closure.py
@@ -68,6 +68,28 @@ def test_runtime_closure_from_path_info_supports_list_payloads():
     }
 
 
+def test_runtime_closure_from_path_info_skips_unrealized_records():
+    closure = runtime_closure_from_path_info(
+        {
+            "/nix/store/11111111111111111111111111111111-target-1.0": {
+                "deriver": None,
+                "references": ["/nix/store/22222222222222222222222222222222-source"],
+            },
+            "/nix/store/22222222222222222222222222222222-source": None,
+        }
+    )
+
+    assert closure.df_deps.to_dict("records") == [
+        {
+            "src_path": "/nix/store/22222222222222222222222222222222-source",
+            "src_pname": "source",
+            "target_path": "/nix/store/11111111111111111111111111111111-target-1.0",
+            "target_pname": "target-1.0",
+        }
+    ]
+    assert closure.output_paths_by_drv == {}
+
+
 def test_runtime_closure_from_path_info_rejects_missing_references():
     with pytest.raises(InvalidNixJsonError, match="missing `references`"):
         runtime_closure_from_path_info(


### PR DESCRIPTION
Nix can emit null path-info records for substitutable store paths that are not realized locally. Preserve those entries during path-info normalization instead of treating them as malformed JSON.

Return missing NAR hashes as None for explicit unrealized records so provenance dependency generation can fall back to fixed-output derivation metadata. Keep omitted path-info records strict, and skip unrealized records where there is no digest to use.

Add regression coverage for null path-info records, recursive provenance dependency handling, subject skipping, and runtime closure parsing.

Signed-off-by: Henri Rosten <henri.rosten@unikie.com>