### PR TITLE
sbomnix: recover buildtime attrs and export homepage refs

### DIFF
--- a/src/sbomnix/cdx.py
+++ b/src/sbomnix/cdx.py
@@ -14,6 +14,19 @@ from common.spdx import canonicalize_spdx_license_id
 from vulnxscan.utils import _vuln_source, _vuln_url
 
 
+def _split_meta_homepage(homepage_value):
+    """Split flattened homepage metadata into URLs.
+
+    Nix metadata may flatten homepage lists into a single semicolon-separated
+    string, but literal homepage URLs can also contain semicolons. Only split
+    when the next entry looks like a new URI.
+    """
+    if not homepage_value:
+        return []
+    entries = re.split(r";(?=[A-Za-z][A-Za-z0-9+.-]*:)", homepage_value)
+    return [entry.strip() for entry in entries if entry.strip()]
+
+
 def _drv_to_cdx_licenses_entry(drv, column_name, cdx_license_type):
     """Parse license entries of type cdx_license_type from column_name"""
     licenses = []
@@ -85,6 +98,16 @@ def _cdx_component_add_patches(component, drv):
             component["pedigree"] = pedigree
 
 
+def _cdx_component_add_external_references(component, drv):
+    """Add CycloneDX external references to a component (if any)."""
+    external_references = []
+    if "meta_homepage" in drv._asdict() and drv.meta_homepage:
+        for homepage_url in _split_meta_homepage(drv.meta_homepage):
+            external_references.append({"type": "website", "url": homepage_url})
+    if external_references:
+        component["externalReferences"] = external_references
+
+
 def _drv_to_cdx_component(drv, uid=cols.STORE_PATH):
     """Convert one SBOM component row to a CycloneDX component."""
     component = {}
@@ -107,6 +130,7 @@ def _drv_to_cdx_component(drv, uid=cols.STORE_PATH):
         component["description"] = drv.meta_description
     _cdx_component_add_licenses(component, drv)
     _cdx_component_add_patches(component, drv)
+    _cdx_component_add_external_references(component, drv)
     properties = []
     for output_path in drv.outputs:
         prop = {}
@@ -123,11 +147,6 @@ def _drv_to_cdx_component(drv, uid=cols.STORE_PATH):
         prop = {}
         prop["name"] = "nix:fetch_url"
         prop["value"] = drv.urls
-        properties.append(prop)
-    if "meta_homepage" in drv._asdict() and drv.meta_homepage:
-        prop = {}
-        prop["name"] = "homepage"
-        prop["value"] = drv.meta_homepage
         properties.append(prop)
     if "meta_position" in drv._asdict() and drv.meta_position:
         prop = {}

--- a/src/sbomnix/derivation.py
+++ b/src/sbomnix/derivation.py
@@ -211,6 +211,21 @@ def destructure(env):
     return {}
 
 
+def _structured_attr_map(value):
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _reconstruct_pname(name, pname):
+    if not pname:
+        return name
+    prefix, sep, _suffix = name.partition(pname)
+    if sep:
+        return prefix + pname
+    return pname
+
+
 class Derive:
     """Nix derivation as found as .drv files in the Nix store."""
 
@@ -233,26 +248,46 @@ class Derive:
         if envVars is None:
             envVars = {}
         envVars = dict(envVars)
+        structured_env = _structured_attr_map(destructure(envVars))
         LOG.log(LOG_SPAM, envVars)
-        self.name = name or envVars.get("name")
+        self.name = (
+            name
+            or envVars.get("name")
+            or _coerce_derivation_string(structured_env.get("name"))
+        )
         if not self.name:
             self.name = destructure(envVars)["name"]
 
-        pname = envVars.get("pname", self.name)
+        pname = (
+            envVars.get("pname")
+            or _coerce_derivation_string(structured_env.get("pname"))
+            or self.name
+        )
         # pname read from envVars might not match the pname in nixpkgs.
         # As an example 'Authen-SASL' full pname is 'perl5.36.0-Authen-SASL'
         # Below, we reconstruct the full pname based on self.name which
         # contains the full pname:
-        self.pname = self.name.partition(pname)[0] + pname
-        self.version = envVars.get("version", "")
-        self.patches = patches or envVars.get("patches", "")
+        self.pname = _reconstruct_pname(self.name, pname)
+        self.version = envVars.get("version", "") or _coerce_derivation_string(
+            structured_env.get("version")
+        )
+        self.patches = (
+            _coerce_derivation_patch_list(patches)
+            or _coerce_derivation_patch_list(envVars.get("patches", ""))
+            or _coerce_derivation_patch_list(structured_env.get("patches"))
+        )
         self.system = envVars.get("system", "")
-        self.out = envVars.get("out", "")
+        self.out = envVars.get("out", "") or _coerce_derivation_string(
+            structured_env.get("out")
+        )
         self.outputs = []
         self.store_path = None
-        outputs = envVars.get("outputs", "").split()
+        outputs = str(
+            envVars.get("outputs", "")
+            or _coerce_derivation_string(structured_env.get("outputs"))
+        ).split()
         for output in outputs:
-            path = envVars.get(output, None)
+            path = envVars.get(output, None) or structured_env.get(output)
             self.add_output_path(path)
         LOG.log(LOG_SPAM, "%s outputs: %s", self, self.outputs)
         # pname 'source' in Nix has special meaning - it is the default name
@@ -268,7 +303,12 @@ class Derive:
     def from_nix_derivation_info(cls, path, drv_info, outpath=None):
         """Create a derivation from normalized `nix derivation show` JSON."""
         env_vars = dict(drv_info.get("env", {}))
-        name = _coerce_derivation_string(drv_info.get("name")) or env_vars.get("name")
+        structured_attrs = _structured_attr_map(drv_info.get("structuredAttrs"))
+        name = (
+            _coerce_derivation_string(drv_info.get("name"))
+            or env_vars.get("name")
+            or _coerce_derivation_string(structured_attrs.get("name"))
+        )
         if not name:
             name = destructure(env_vars).get("name")
         outputs = drv_info.get("outputs", {})
@@ -277,13 +317,25 @@ class Derive:
         drv = cls(
             envVars=env_vars,
             name=name,
-            patches=env_vars.get("patches", ""),
+            patches=_coerce_derivation_patch_list(env_vars.get("patches", ""))
+            or _coerce_derivation_patch_list(structured_attrs.get("patches")),
         )
         drv.system = _coerce_derivation_string(drv_info.get("system")) or drv.system
-        drv.version = env_vars.get("version", "")
-        if not drv.version:
-            drv.version = _coerce_derivation_string(drv_info.get("version"))
-        drv.out = drv.out or _derivation_output_path(outputs, "out")
+        pname = env_vars.get("pname") or _coerce_derivation_string(
+            structured_attrs.get("pname")
+        )
+        if pname:
+            drv.pname = _reconstruct_pname(drv.name, pname)
+        drv.version = (
+            env_vars.get("version", "")
+            or _coerce_derivation_string(structured_attrs.get("version"))
+            or drv.version
+        )
+        drv.out = (
+            drv.out
+            or _derivation_output_path(outputs, "out")
+            or _coerce_derivation_string(structured_attrs.get("out"))
+        )
         drv._refresh_purl()
         drv.outputs = []
         _set_derivation_output_paths(drv, outputs, env_vars)
@@ -340,6 +392,14 @@ def _derivation_output_path(outputs, output_name):
 def _coerce_derivation_string(value):
     if isinstance(value, str):
         return value
+    return ""
+
+
+def _coerce_derivation_patch_list(value):
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return " ".join(item for item in value if isinstance(item, str))
     return ""
 
 

--- a/tests/test_derivation_hardening.py
+++ b/tests/test_derivation_hardening.py
@@ -70,6 +70,128 @@ def test_load_derivation_uses_nix_derivation_show(monkeypatch):
     assert drv.purl == "pkg:nix/hello@2.12.3"
 
 
+def test_from_nix_derivation_info_uses_structured_attrs_for_pname_and_version():
+    drv_path = "/nix/store/0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-audit-4.1.2.drv"
+    out_path = "/nix/store/1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-audit-4.1.2"
+
+    drv = sbomnix_derivation.Derive.from_nix_derivation_info(
+        drv_path,
+        {
+            "name": "audit-4.1.2",
+            "version": 4,
+            "outputs": {
+                "out": {"path": out_path},
+            },
+            "env": {
+                "name": "audit-4.1.2",
+                "out": out_path,
+                "outputs": "out",
+            },
+            "structuredAttrs": {
+                "name": "audit-4.1.2",
+                "pname": "audit",
+                "version": "4.1.2",
+                "out": out_path,
+            },
+        },
+    )
+
+    assert drv.store_path == drv_path
+    assert drv.name == "audit-4.1.2"
+    assert drv.pname == "audit"
+    assert drv.version == "4.1.2"
+    assert drv.out == out_path
+    assert drv.outputs == [out_path]
+    assert drv.purl == "pkg:nix/audit@4.1.2"
+
+
+def test_from_nix_derivation_info_preserves_structured_attrs_patch_lists_for_cdx():
+    drv_path = "/nix/store/0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-demo-1.0.drv"
+    out_path = "/nix/store/1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-demo-1.0"
+    security_patch = (
+        "/nix/store/2ccccccccccccccccccccccccccccccc-fix-CVE-2026-1234.patch"
+    )
+    local_patch = "/nix/store/3ddddddddddddddddddddddddddddddd-local-adjustment.patch"
+
+    drv = sbomnix_derivation.Derive.from_nix_derivation_info(
+        drv_path,
+        {
+            "name": "demo-1.0",
+            "outputs": {
+                "out": {"path": out_path},
+            },
+            "env": {
+                "name": "demo-1.0",
+                "out": out_path,
+                "outputs": "out",
+            },
+            "structuredAttrs": {
+                "name": "demo-1.0",
+                "pname": "demo",
+                "version": "1.0",
+                "patches": [security_patch, local_patch],
+            },
+        },
+    )
+
+    assert drv.patches == f"{security_patch} {local_patch}"
+
+    drv_type = namedtuple(
+        "Drv",
+        [
+            "name",
+            "pname",
+            "version",
+            "purl",
+            "cpe",
+            "meta_description",
+            "meta_license_spdxid",
+            "meta_license_short",
+            "patches",
+            "outputs",
+            "store_path",
+            "out",
+            "urls",
+            "meta_homepage",
+            "meta_position",
+        ],
+    )
+    component = sbomnix_cdx._drv_to_cdx_component(
+        drv_type(
+            name=drv.name,
+            pname=drv.pname,
+            version=drv.version,
+            purl=drv.purl,
+            cpe=drv.cpe,
+            meta_description="",
+            meta_license_spdxid="",
+            meta_license_short="",
+            patches=drv.patches,
+            outputs=drv.outputs,
+            store_path=drv.store_path,
+            out=drv.out,
+            urls=drv.urls,
+            meta_homepage="",
+            meta_position="",
+        )
+    )
+
+    assert component["pedigree"] == {
+        "patches": [
+            {
+                "type": "unofficial",
+                "resolves": [
+                    {
+                        "type": "security",
+                        "id": "CVE-2026-1234",
+                        "references": [f"file://{security_patch}"],
+                    }
+                ],
+            }
+        ]
+    }
+
+
 def test_canonicalize_spdx_license_id_canonicalizes_aliases():
     expected_canonical_ids = {
         "GPL-2.0+": "GPL-2.0-or-later",
@@ -193,3 +315,100 @@ def test_cdx_falls_back_to_license_short_name_when_spdx_id_is_invalid():
     assert component["licenses"] == [{"license": {"name": "Custom Short Name"}}]
     assert "licenseInfoFromFiles" not in package
     assert package["licenseConcluded"] == "NOASSERTION"
+
+
+def test_cdx_exports_homepage_as_external_reference():
+    drv_type = namedtuple(
+        "Drv",
+        [
+            "name",
+            "pname",
+            "version",
+            "purl",
+            "cpe",
+            "meta_description",
+            "meta_license_spdxid",
+            "meta_license_short",
+            "patches",
+            "outputs",
+            "store_path",
+            "out",
+            "urls",
+            "meta_homepage",
+            "meta_position",
+        ],
+    )
+    drv = drv_type(
+        name="hello-2.12.3",
+        pname="hello",
+        version="2.12.3",
+        purl="pkg:nix/hello@2.12.3",
+        cpe="",
+        meta_description="Hello",
+        meta_license_spdxid="MIT",
+        meta_license_short="MIT",
+        patches="",
+        outputs=["/nix/store/out"],
+        store_path="/nix/store/0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-2.12.3.drv",
+        out="/nix/store/out",
+        urls="",
+        meta_homepage="https://example.invalid/hello;https://example.invalid/docs",
+        meta_position="/nix/store/src/pkgs/by-name/he/hello/package.nix:1",
+    )
+
+    component = sbomnix_cdx._drv_to_cdx_component(drv)
+
+    assert component["externalReferences"] == [
+        {"type": "website", "url": "https://example.invalid/hello"},
+        {"type": "website", "url": "https://example.invalid/docs"},
+    ]
+    assert "homepage" not in {prop["name"] for prop in component["properties"]}
+
+
+def test_cdx_keeps_semicolon_inside_single_homepage_url():
+    drv_type = namedtuple(
+        "Drv",
+        [
+            "name",
+            "pname",
+            "version",
+            "purl",
+            "cpe",
+            "meta_description",
+            "meta_license_spdxid",
+            "meta_license_short",
+            "patches",
+            "outputs",
+            "store_path",
+            "out",
+            "urls",
+            "meta_homepage",
+            "meta_position",
+        ],
+    )
+    drv = drv_type(
+        name="uid_wrapper-1.3.2",
+        pname="uid_wrapper",
+        version="1.3.2",
+        purl="pkg:nix/uid_wrapper@1.3.2",
+        cpe="",
+        meta_description="UID wrapper",
+        meta_license_spdxid="GPL-3.0-or-later",
+        meta_license_short="GPL-3.0-or-later",
+        patches="",
+        outputs=["/nix/store/out"],
+        store_path="/nix/store/0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-uid_wrapper-1.3.2.drv",
+        out="/nix/store/out",
+        urls="",
+        meta_homepage="https://git.samba.org/?p=uid_wrapper.git;a=summary;",
+        meta_position="/nix/store/src/pkgs/by-name/ui/uid_wrapper/package.nix:1",
+    )
+
+    component = sbomnix_cdx._drv_to_cdx_component(drv)
+
+    assert component["externalReferences"] == [
+        {
+            "type": "website",
+            "url": "https://git.samba.org/?p=uid_wrapper.git;a=summary;",
+        }
+    ]


### PR DESCRIPTION
Buildtime derivations do not always carry pname and version in env. Some of them only expose those fields through structuredAttrs, which left components such as audit with an empty version and a degraded purl in the CycloneDX output.

Use structuredAttrs as a fallback when reading buildtime derivation metadata so pname, version, and derived identifiers stay aligned with the actual nixpkgs package metadata.

Also export meta.homepage through CycloneDX externalReferences instead of a custom homepage property so the SBOM uses the standard field for website links, while preserving semicolons inside literal homepage URLs when expanding flattened metadata.

Add focused tests for the structuredAttrs fallback and homepage external reference export.
