### PR TITLE
sbomnix: speed up flakeref resolution

### DIFF
--- a/src/common/flakeref.py
+++ b/src/common/flakeref.py
@@ -45,41 +45,20 @@ def try_resolve_flakeref(  # noqa: PLR0913
 
     looks_like_flakeref = _looks_like_flakeref(flakeref)
     if derivation and not force_realise and looks_like_flakeref:
-        log.info("Evaluating flakeref '%s'", flakeref)
-        cmd = nix_cmd("derivation", "show", flakeref, impure=impure)
-        ret = exec_cmd_fn(cmd, raise_on_error=False, return_error=True, log_error=False)
-        if ret is None or ret.returncode != 0:
-            raise FlakeRefResolutionError(flakeref, ret.stderr if ret else "")
-        drv_paths = parse_nix_derivation_show(ret.stdout)
-        drv_path = next(iter(drv_paths), "")
-        if not drv_path:
-            raise FlakeRefResolutionError(
-                flakeref,
-                "nix derivation show returned no derivation path",
-            )
-        log.debug("flakeref='%s' maps to derivation='%s'", flakeref, drv_path)
-        return drv_path
-
-    if force_realise and looks_like_flakeref:
-        log.info("Realising flakeref '%s'", flakeref)
-        cmd = nix_cmd(
-            "build",
-            "--no-link",
-            "--print-out-paths",
+        return _resolve_flakeref_derivation(
             flakeref,
             impure=impure,
+            exec_cmd_fn=exec_cmd_fn,
+            log=log,
         )
-        ret = exec_cmd_fn(cmd, raise_on_error=False, return_error=True, log_error=False)
-        if ret is None or ret.returncode != 0:
-            raise FlakeRefRealisationError(flakeref, ret.stderr if ret else "")
-        nixpath = _first_output_path(ret.stdout)
-        if not nixpath:
-            raise FlakeRefRealisationError(
-                flakeref,
-                "nix build returned no output path",
-            )
-        log.debug("flakeref='%s' maps to path='%s'", flakeref, nixpath)
-        return nixpath
+
+    if force_realise and looks_like_flakeref:
+        return _force_realise_flakeref(
+            flakeref,
+            impure=impure,
+            exec_cmd_fn=exec_cmd_fn,
+            log=log,
+        )
 
     if looks_like_flakeref:
         log.info("Evaluating flakeref '%s'", flakeref)
@@ -107,6 +86,76 @@ def try_resolve_flakeref(  # noqa: PLR0913
 def _first_output_path(stdout: str) -> str:
     """Return the first output path printed by ``nix build --print-out-paths``."""
     return next((line.strip() for line in stdout.splitlines() if line.strip()), "")
+
+
+def _resolve_flakeref_derivation(flakeref, *, impure, exec_cmd_fn, log):
+    """Return the derivation path for a flakeref target."""
+    log.info("Evaluating flakeref '%s'", flakeref)
+    cmd = nix_cmd("derivation", "show", flakeref, impure=impure)
+    ret = exec_cmd_fn(cmd, raise_on_error=False, return_error=True, log_error=False)
+    if ret is None or ret.returncode != 0:
+        raise FlakeRefResolutionError(flakeref, ret.stderr if ret else "")
+    drv_paths = parse_nix_derivation_show(ret.stdout)
+    drv_path = next(iter(drv_paths), "")
+    if not drv_path:
+        raise FlakeRefResolutionError(
+            flakeref,
+            "nix derivation show returned no derivation path",
+        )
+    log.debug("flakeref='%s' maps to derivation='%s'", flakeref, drv_path)
+    return drv_path
+
+
+def _force_realise_flakeref(flakeref, *, impure, exec_cmd_fn, log):
+    """Return the realized output path for a runtime flakeref target."""
+    log.info("Evaluating flakeref '%s'", flakeref)
+    nixpath = _realised_flakeref_path(
+        flakeref,
+        impure=impure,
+        exec_cmd_fn=exec_cmd_fn,
+    )
+    if nixpath:
+        log.debug("flakeref='%s' maps to realised path='%s'", flakeref, nixpath)
+        return nixpath
+
+    return _build_flakeref_path(
+        flakeref,
+        impure=impure,
+        exec_cmd_fn=exec_cmd_fn,
+        log=log,
+    )
+
+
+def _build_flakeref_path(flakeref, *, impure, exec_cmd_fn, log):
+    """Build a flakeref target and return the first printed output path."""
+    log.info("Realising flakeref '%s'", flakeref)
+    cmd = nix_cmd(
+        "build",
+        "--no-link",
+        "--print-out-paths",
+        flakeref,
+        impure=impure,
+    )
+    ret = exec_cmd_fn(cmd, raise_on_error=False, return_error=True, log_error=False)
+    if ret is None or ret.returncode != 0:
+        raise FlakeRefRealisationError(flakeref, ret.stderr if ret else "")
+    nixpath = _first_output_path(ret.stdout)
+    if not nixpath:
+        raise FlakeRefRealisationError(
+            flakeref,
+            "nix build returned no output path",
+        )
+    log.debug("flakeref='%s' maps to path='%s'", flakeref, nixpath)
+    return nixpath
+
+
+def _realised_flakeref_path(flakeref, *, impure, exec_cmd_fn):
+    """Return the already-realised output path for ``flakeref`` when available."""
+    cmd = nix_cmd("path-info", flakeref, impure=impure)
+    ret = exec_cmd_fn(cmd, raise_on_error=False, return_error=True, log_error=False)
+    if ret is None or ret.returncode != 0:
+        return None
+    return _first_output_path(ret.stdout)
 
 
 def parse_nixos_configuration_ref(

--- a/tests/test_flakeref_resolution.py
+++ b/tests/test_flakeref_resolution.py
@@ -79,6 +79,8 @@ def test_try_resolve_flakeref_uses_argv_lists():
 
     def fake_exec_cmd(cmd, **kwargs):
         calls.append((cmd, kwargs))
+        if cmd[1] == "path-info":
+            return SimpleNamespace(stdout="", stderr="not realised", returncode=1)
         return SimpleNamespace(stdout="/nix/store/resolved\n", stderr="", returncode=0)
 
     resolved = try_resolve_flakeref(
@@ -90,6 +92,19 @@ def test_try_resolve_flakeref_uses_argv_lists():
 
     assert resolved == "/nix/store/resolved"
     assert calls == [
+        (
+            [
+                "nix",
+                "path-info",
+                "/tmp/my flake#pkg",
+                "--extra-experimental-features",
+                "flakes",
+                "--extra-experimental-features",
+                "nix-command",
+                "--impure",
+            ],
+            {"raise_on_error": False, "return_error": True, "log_error": False},
+        ),
         (
             [
                 "nix",
@@ -106,6 +121,73 @@ def test_try_resolve_flakeref_uses_argv_lists():
             {"raise_on_error": False, "return_error": True, "log_error": False},
         ),
     ]
+
+
+def test_try_resolve_flakeref_reuses_realised_path_info():
+    calls = []
+
+    def fake_exec_cmd(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        assert cmd[1] == "path-info"
+        return SimpleNamespace(
+            stdout="/nix/store/00000000000000000000000000000000-resolved\n",
+            stderr="",
+            returncode=0,
+        )
+
+    resolved = try_resolve_flakeref(
+        ".#hello",
+        force_realise=True,
+        exec_cmd_fn=fake_exec_cmd,
+    )
+
+    assert resolved == "/nix/store/00000000000000000000000000000000-resolved"
+    assert calls == [
+        (
+            [
+                "nix",
+                "path-info",
+                ".#hello",
+                "--extra-experimental-features",
+                "flakes",
+                "--extra-experimental-features",
+                "nix-command",
+            ],
+            {"raise_on_error": False, "return_error": True, "log_error": False},
+        )
+    ]
+
+
+def test_try_resolve_flakeref_rejects_invalid_explicit_output_selector():
+    calls = []
+
+    def fake_exec_cmd(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[1] == "path-info":
+            return SimpleNamespace(
+                stdout="",
+                stderr="does not have output",
+                returncode=1,
+            )
+        if cmd[1] == "eval":
+            raise AssertionError("invalid output selectors must not use eval fallback")
+        return SimpleNamespace(
+            stdout="",
+            stderr="derivation does not have output 'missing'",
+            returncode=1,
+        )
+
+    with pytest.raises(
+        FlakeRefRealisationError,
+        match="derivation does not have output 'missing'",
+    ):
+        try_resolve_flakeref(
+            "nixpkgs#package^missing",
+            force_realise=True,
+            exec_cmd_fn=fake_exec_cmd,
+        )
+
+    assert [cmd[1] for cmd, _kwargs in calls] == ["path-info", "build"]
 
 
 def test_try_resolve_flakeref_can_return_derivation_path():
@@ -169,7 +251,7 @@ def test_try_resolve_flakeref_logs_flake_progress_at_info():
     assert resolved == "/nix/store/resolved"
     assert (
         "info",
-        "Realising flakeref '%s'",
+        "Evaluating flakeref '%s'",
         (".#hello",),
     ) in logger.records
 
@@ -197,7 +279,9 @@ def test_try_resolve_flakeref_keeps_plain_path_probe_verbose():
 
 
 def test_try_resolve_flakeref_raises_on_failed_force_realise():
-    def fake_exec_cmd(_cmd, **_kwargs):
+    def fake_exec_cmd(cmd, **_kwargs):
+        if cmd[1] == "path-info":
+            return SimpleNamespace(stdout="", stderr="not realised", returncode=1)
         return SimpleNamespace(stdout="", stderr="build failed", returncode=1)
 
     with pytest.raises(FlakeRefRealisationError, match="build failed"):
@@ -209,7 +293,9 @@ def test_try_resolve_flakeref_raises_on_failed_force_realise():
 
 
 def test_try_resolve_flakeref_raises_when_force_realise_prints_no_path():
-    def fake_exec_cmd(_cmd, **_kwargs):
+    def fake_exec_cmd(cmd, **_kwargs):
+        if cmd[1] == "path-info":
+            return SimpleNamespace(stdout="", stderr="not realised", returncode=1)
         return SimpleNamespace(stdout="\n", stderr="", returncode=0)
 
     with pytest.raises(FlakeRefRealisationError, match="returned no output path"):


### PR DESCRIPTION
When a runtime flakeref target is requested, first try to reuse an already realised path or an eval result that already exists in the local store before falling back to a full nix build.

This keeps the old behavior as the fallback path, but avoids needless realisation work for common repeated flakeref lookups and adds focused coverage for the new resolution order.

Signed-off-by: Henri Rosten <henri.rosten@unikie.com>