### PR TITLE
Pin vulnix to nix-community upstream

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,7 +131,60 @@
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
         "git-hooks-nix": "git-hooks-nix",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "vulnix": "vulnix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "vulnix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "vulnix": {
+      "inputs": {
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "flake-root": [
+          "flake-root"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1778651554,
+        "narHash": "sha256-QxkkaBVdIIot/YVxPuzUhjP7cDAp7U9iJXWozVTcuww=",
+        "owner": "nix-community",
+        "repo": "vulnix",
+        "rev": "038b06e335c41d7d2dcbccbf4f821f95d7c17b16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "master",
+        "repo": "vulnix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,15 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-root.url = "github:srid/flake-root";
+    vulnix = {
+      url = "github:nix-community/vulnix/master";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-compat.follows = "flake-compat";
+        flake-parts.follows = "flake-parts";
+        flake-root.follows = "flake-root";
+      };
+    };
     # For preserving compatibility with non-Flake users
     flake-compat = {
       url = "github:nix-community/flake-compat";

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -6,6 +6,7 @@
   perSystem =
     {
       pkgs,
+      inputs',
       lib,
       config,
       self',
@@ -38,7 +39,7 @@
         grype
         nix
         nix-visualize
-        vulnix
+        inputs'.vulnix.packages.vulnix
       ];
       check_inputs = with pp; [
         hypothesis


### PR DESCRIPTION
This lets sbomnix pick up the nix-community vulnix upstream fix nix-community/vulnix@1e9462612c2d before that fix is available through nixpkgs.