### PR TITLE
sbomnix: prefer nixpkgs CPE metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ Store-path targets skip nixpkgs metadata because the store path does not
 identify the nixpkgs source that produced it. `--exclude-meta` disables metadata
 enrichment.
 
+When nixpkgs metadata is available, `sbomnix` prefers exact CPE identifiers
+from nixpkgs metadata and falls back to heuristic CPE matching only when no
+exact nixpkgs CPE is present. `--exclude-cpe-matching` disables only the
+heuristic fallback, while `--exclude-meta` disables nixpkgs metadata entirely,
+including metadata-derived CPEs. Using both flags results in no CPE output.
+Store-path targets have no nixpkgs metadata source, so `--exclude-cpe-matching`
+usually removes all CPEs for store-path targets.
+
 CycloneDX and SPDX outputs record the selected metadata source in document
 metadata, including fields such as `nixpkgs:metadata_source_method`,
 `nixpkgs:path`, `nixpkgs:rev`, `nixpkgs:flakeref`, `nixpkgs:version`, and

--- a/doc/sbomnix_metadata.md
+++ b/doc/sbomnix_metadata.md
@@ -40,6 +40,18 @@ primary nixpkgs package set. After scanning the selected package set, `sbomnix`
 may scan package roots exported by the target flake inputs for components that
 remain unmatched.
 
+## CPE sources
+
+When nixpkgs metadata is available, `sbomnix` prefers exact CPE identifiers
+from nixpkgs metadata and falls back to heuristic CPE matching only when
+nixpkgs metadata does not provide a canonical CPE. The heuristic fallback can
+be disabled with `--exclude-cpe-matching`, while `--exclude-meta` disables
+nixpkgs metadata entirely, including metadata-derived CPEs.
+
+Nixpkgs may also expose `possibleCPEs` guesses alongside its canonical CPE
+metadata. `sbomnix` keeps those guesses diagnostic-only and does not export them
+as the final component CPE.
+
 ## Caching and diagnostics
 
 Package metadata lookups are cached by metadata source identity, lookup set,

--- a/src/sbomnix/builder.py
+++ b/src/sbomnix/builder.py
@@ -423,11 +423,25 @@ class SbomBuilder:
             on=[cols.STORE_PATH],
             suffixes=("", "_meta"),
         )
+        self._apply_meta_cpe_overrides()
         LOG.verbose("Joined nixpkgs metadata for %d component(s)", len(df_meta))
         LOG.verbose(
             "Joined nixpkgs metadata in %.3fs",
             time.perf_counter() - started,
         )
+
+    def _apply_meta_cpe_overrides(self):
+        """Prefer exact nixpkgs metadata CPEs over heuristic CPEs."""
+        if self.df_sbomdb is None or "meta_cpe" not in self.df_sbomdb.columns:
+            return
+        if cols.CPE not in self.df_sbomdb.columns:
+            self.df_sbomdb[cols.CPE] = ""
+        meta_cpe = self.df_sbomdb["meta_cpe"].fillna("").astype(str).to_numpy()
+        override_mask = meta_cpe != ""
+        if not bool(np.any(override_mask)):
+            return
+        current_cpe = self.df_sbomdb[cols.CPE].fillna("").astype(str).to_numpy()
+        self.df_sbomdb[cols.CPE] = np.where(override_mask, meta_cpe, current_cpe)
 
     def lookup_dependencies(self, drv, uid=cols.STORE_PATH):
         """Return indexed dependency values for one SBOM component."""

--- a/src/sbomnix/cpe.py
+++ b/src/sbomnix/cpe.py
@@ -28,6 +28,7 @@ class CPE:
         self,
         include_cpe=True,
     ):
+        self.include_cpe = include_cpe
         self._product_vendor = {}
         self._ambiguous_products = set()
         # Let's initialize the fields anyway.
@@ -120,6 +121,9 @@ class CPE:
 
     def generate(self, name, version):
         """Generate CPE identifier, given the product name and version"""
+        if not self.include_cpe:
+            LOG.log(LOG_SPAM, "CPE generation disabled")
+            return ""
         cpe_vendor = self._candidate_vendor(name.strip())
         cpe_product = name.strip()
         cpe_version = version.strip()

--- a/src/sbomnix/main.py
+++ b/src/sbomnix/main.py
@@ -47,11 +47,11 @@ def getargs(args=None):
     add_verbose_argument(parser)
     helps = "Include vulnerabilities in the output of CyloneDX SBOM"
     parser.add_argument("--include-vulns", help=helps, action="store_true")
-    helps = "Exclude Nixpkgs metadata information in the output"
+    helps = "Exclude nixpkgs metadata enrichment, including metadata-derived CPEs"
     parser.add_argument(
         "--exclude-meta", help=helps, action="store_true", default=False
     )
-    helps = "Exclude using heuristics-based CPE matches in the output"
+    helps = "Exclude heuristic CPE matching; keep exact nixpkgs metadata CPEs"
     parser.add_argument(
         "--exclude-cpe-matching", help=helps, action="store_true", default=False
     )

--- a/src/sbomnix/package_meta.nix
+++ b/src/sbomnix/package_meta.nix
@@ -283,16 +283,69 @@ let
     # attr name cannot be inferred exactly.
     if hasMatches canonicalCandidates then canonicalCandidates else plausibleCandidates;
 
-  filteredMeta = meta: {
-    description = meta.description or null;
-    homepage = meta.homepage or null;
-    unfree = meta.unfree or false;
-    position = meta.position or null;
-    license = meta.license or { };
-    maintainers = builtins.map (maintainer: { email = maintainer.email or ""; }) (
-      builtins.filter isAttrs (meta.maintainers or [ ])
-    );
-  };
+  normalizedIdentifiers =
+    meta:
+    let
+      hasNonEmptyString = value: builtins.isString value && value != "";
+      hasNonEmptyList = value: builtins.isList value && value != [ ];
+      metaIdentifiers = safeAttr meta "identifiers";
+      identifiers = if isAttrs metaIdentifiers then metaIdentifiers else { };
+      identifiersV1Value = safeAttr identifiers "v1";
+      identifiersV1 = if isAttrs identifiersV1Value then identifiersV1Value else { };
+      topLevelPossibleCPEs = safeAttr meta "possibleCPEs";
+      nestedPossibleCPEs = safeAttr identifiers "possibleCPEs";
+      nestedV1PossibleCPEs = safeAttr identifiersV1 "possibleCPEs";
+      possibleCPEs =
+        if hasNonEmptyList topLevelPossibleCPEs then
+          topLevelPossibleCPEs
+        else if hasNonEmptyList nestedPossibleCPEs then
+          nestedPossibleCPEs
+        else if hasNonEmptyList nestedV1PossibleCPEs then
+          nestedV1PossibleCPEs
+        else if builtins.isList topLevelPossibleCPEs then
+          topLevelPossibleCPEs
+        else if builtins.isList nestedPossibleCPEs then
+          nestedPossibleCPEs
+        else if builtins.isList nestedV1PossibleCPEs then
+          nestedV1PossibleCPEs
+        else
+          [ ];
+      metaCPE = safeAttr meta "cpe";
+      identifiersCPE = safeAttr identifiers "cpe";
+      identifiersV1CPE = safeAttr identifiersV1 "cpe";
+    in
+    {
+      cpe =
+        if hasNonEmptyString metaCPE then
+          metaCPE
+        else if hasNonEmptyString identifiersCPE then
+          identifiersCPE
+        else if hasNonEmptyString identifiersV1CPE then
+          identifiersV1CPE
+        else
+          null;
+      possibleCPEs = builtins.filter (
+        candidate: isAttrs candidate && safeAttr candidate "cpe" != null
+      ) possibleCPEs;
+    };
+
+  filteredMeta =
+    meta:
+    let
+      identifiers = normalizedIdentifiers meta;
+    in
+    {
+      description = meta.description or null;
+      homepage = meta.homepage or null;
+      unfree = meta.unfree or false;
+      position = meta.position or null;
+      cpe = identifiers.cpe;
+      possibleCPEs = identifiers.possibleCPEs;
+      license = meta.license or { };
+      maintainers = builtins.map (maintainer: { email = maintainer.email or ""; }) (
+        builtins.filter isAttrs (meta.maintainers or [ ])
+      );
+    };
 
   drvOutputs =
     drv: if drv ? outputs then builtins.map (output: drv.${output}) drv.outputs else [ drv ];

--- a/src/sbomnix/package_meta.py
+++ b/src/sbomnix/package_meta.py
@@ -36,6 +36,8 @@ _META_DERIVATION_PATH = "_meta_derivation_path"
 _RICH_META_COLUMNS = (
     "meta_homepage",
     "meta_description",
+    "meta_cpe",
+    "meta_possible_cpes",
     "meta_license_short",
     "meta_license_spdxid",
 )
@@ -236,6 +238,11 @@ def _metadata_row(drv):
         "meta_unfree": meta.get("unfree", ""),
         "meta_description": meta.get("description", "") or "",
         "meta_position": meta.get("position", "") or "",
+        "meta_cpe": _parse_optional_meta_entry(meta, key="cpe"),
+        "meta_possible_cpes": _parse_optional_meta_entry(
+            meta.get("possibleCPEs", []),
+            key="cpe",
+        ),
         "meta_license_short": _parse_optional_meta_entry(meta_license, key="shortName"),
         "meta_license_spdxid": _parse_optional_meta_entry(meta_license, key="spdxId"),
         "meta_maintainers_email": _parse_optional_meta_entry(

--- a/tests/test_builder_runtime.py
+++ b/tests/test_builder_runtime.py
@@ -310,3 +310,44 @@ def test_join_meta_uses_package_component_identity(monkeypatch):
     assert builder.df_sbomdb["pname_meta"].iloc[0] == "target-pname-from-meta"
     assert builder.df_sbomdb["version_meta"].iloc[0] == "1.0-from-meta"
     assert "name_meta" not in builder.df_sbomdb.columns
+
+
+def test_join_meta_cpe_resolution_prefers_exact_nixpkgs_value(monkeypatch):
+    class FakeMeta:
+        def get_package_meta_with_source(self, **kwargs):
+            assert kwargs["components"].equals(builder.df_sbomdb)
+            return (
+                pd.DataFrame(
+                    [
+                        {
+                            cols.STORE_PATH: TARGET_DERIVER,
+                            "meta_cpe": ("cpe:2.3:a:nixpkgs:target:1.0:*:*:*:*:*:*:*"),
+                        }
+                    ]
+                ),
+                NixpkgsMetaSource(method="package-meta-nix"),
+            )
+
+    monkeypatch.setattr(sbomnix_builder, "Meta", FakeMeta)
+    builder = _builder_double()
+    builder.flakeref = "nixpkgs#target"
+    builder.original_ref = "nixpkgs#target"
+    builder.impure = False
+    builder.df_sbomdb = pd.DataFrame(
+        [
+            {
+                cols.STORE_PATH: TARGET_DERIVER,
+                cols.NAME: "target",
+                cols.PNAME: "target",
+                cols.VERSION: "1.0",
+                cols.CPE: "cpe:2.3:a:heuristic:target:1.0:*:*:*:*:*:*:*",
+                cols.OUTPUTS: [TARGET_PATH],
+            }
+        ]
+    )
+
+    builder._join_meta()
+
+    assert builder.df_sbomdb[cols.CPE].iloc[0] == (
+        "cpe:2.3:a:nixpkgs:target:1.0:*:*:*:*:*:*:*"
+    )

--- a/tests/test_cpe.py
+++ b/tests/test_cpe.py
@@ -57,3 +57,9 @@ def test_cpe_ambiguous_product_falls_back_to_product_name(monkeypatch):
     generated = cpe.CPE().generate("openssl", "3.0.0")
 
     assert generated == "cpe:2.3:a:openssl:openssl:3.0.0:*:*:*:*:*:*:*"
+
+
+def test_cpe_disabled_returns_empty_string():
+    generated = cpe.CPE(include_cpe=False).generate("openssl", "3.0.0")
+
+    assert generated == ""

--- a/tests/test_package_meta.py
+++ b/tests/test_package_meta.py
@@ -491,9 +491,14 @@ def test_parse_package_metadata_records_identity_fields():
                         "pname": "pkg",
                         "version": "1.0",
                         "meta": {
+                            "cpe": "cpe:2.3:a:pkg_vendor:pkg:1.0:*:*:*:*:*:*:*",
                             "description": "Package",
                             "license": [{"spdxId": "MIT", "shortName": "MIT"}],
                             "maintainers": [{"email": "maintainer@example.invalid"}],
+                            "possibleCPEs": [
+                                {"cpe": "cpe:2.3:a:pkg_vendor:pkg:1.0:*:*:*:*:*:*:*"},
+                                {"cpe": "cpe:2.3:a:pkg_vendor:pkg:1:*:*:*:*:*:*:*"},
+                            ],
                         },
                     }
                 ]
@@ -505,6 +510,11 @@ def test_parse_package_metadata_records_identity_fields():
     assert record[cols.STORE_PATH] == "/nix/store/pkg.drv"
     assert record[package_meta.META_OUTPUT_PATH] == "/nix/store/pkg-out"
     assert record["meta_description"] == "Package"
+    assert record["meta_cpe"] == "cpe:2.3:a:pkg_vendor:pkg:1.0:*:*:*:*:*:*:*"
+    assert record["meta_possible_cpes"] == (
+        "cpe:2.3:a:pkg_vendor:pkg:1.0:*:*:*:*:*:*:*;"
+        "cpe:2.3:a:pkg_vendor:pkg:1:*:*:*:*:*:*:*"
+    )
     assert record["meta_license_spdxid"] == "MIT"
 
 
@@ -526,6 +536,12 @@ def test_package_meta_scans_flake_package_roots_and_preserves_output_metadata(tm
   pname = "shadow";
   version = "1.0";
   meta.description = description;
+  meta.identifiers = {
+    cpe = "cpe:2.3:a:shadow_project:shadow:1.0:*:*:*:*:*:*:*";
+    possibleCPEs = [
+      { cpe = "cpe:2.3:a:shadow_project:shadow:1.0:*:*:*:*:*:*:*"; }
+    ];
+  };
 }
 """
     package_set = """{ system, config ? { } }: {
@@ -568,6 +584,12 @@ def test_package_meta_scans_flake_package_roots_and_preserves_output_metadata(tm
       pname = "input-shadow";
       version = "1.0";
       meta.description = "flake-input";
+      meta.identifiers = {
+        cpe = "cpe:2.3:a:shadow_project:input-shadow:1.0:*:*:*:*:*:*:*";
+        possibleCPEs = [
+          { cpe = "cpe:2.3:a:shadow_project:input-shadow:1.0:*:*:*:*:*:*:*"; }
+        ];
+      };
     };
   };
 }
@@ -593,6 +615,10 @@ def test_package_meta_scans_flake_package_roots_and_preserves_output_metadata(tm
 
     assert df is not None
     assert df["meta_description"].to_list() == ["flake-root", "flake-root"]
+    assert df["meta_cpe"].to_list() == [
+        "cpe:2.3:a:shadow_project:shadow:1.0:*:*:*:*:*:*:*",
+        "cpe:2.3:a:shadow_project:shadow:1.0:*:*:*:*:*:*:*",
+    ]
     assert df[cols.PNAME].to_list() == ["shadow", "shadow"]
     assert df[cols.VERSION].to_list() == ["1.0", "1.0"]
 
@@ -605,6 +631,10 @@ def test_package_meta_scans_flake_package_roots_and_preserves_output_metadata(tm
 
     assert df_fallback is not None
     assert df_fallback["meta_description"].to_list() == ["flake-root", "flake-root"]
+    assert df_fallback["meta_cpe"].to_list() == [
+        "cpe:2.3:a:shadow_project:shadow:1.0:*:*:*:*:*:*:*",
+        "cpe:2.3:a:shadow_project:shadow:1.0:*:*:*:*:*:*:*",
+    ]
     assert df_fallback[cols.PNAME].to_list() == ["shadow", "shadow"]
     assert df_fallback[cols.VERSION].to_list() == ["1.0", "1.0"]
 
@@ -624,8 +654,148 @@ def test_package_meta_scans_flake_package_roots_and_preserves_output_metadata(tm
 
     assert df_input is not None
     assert df_input["meta_description"].to_list() == ["flake-input", "flake-input"]
+    assert df_input["meta_cpe"].to_list() == [
+        "cpe:2.3:a:shadow_project:input-shadow:1.0:*:*:*:*:*:*:*",
+        "cpe:2.3:a:shadow_project:input-shadow:1.0:*:*:*:*:*:*:*",
+    ]
     assert df_input[cols.PNAME].to_list() == ["input-shadow", "input-shadow"]
     assert df_input[cols.VERSION].to_list() == ["1.0", "1.0"]
+
+
+def test_package_meta_preserves_top_level_possible_cpes(tmp_path):
+    if shutil.which("nix") is None:
+        pytest.skip("nix is not available")
+
+    system = package_meta.nix_system()
+    flake = """
+{
+  outputs = { self }:
+  let
+    system = "__SYSTEM__";
+  in
+    {
+    packages.${system}.shadow = (derivation {
+      name = "shadow-1.0";
+      inherit system;
+      builder = "/bin/sh";
+      args = [ "-c" "echo out > $out" ];
+    }) // {
+      pname = "shadow";
+      version = "1.0";
+      meta.possibleCPEs = [
+        { cpe = "cpe:2.3:a:shadow_project:shadow:1.0:*:*:*:*:*:*:*"; }
+      ];
+    };
+  };
+}
+""".replace("__SYSTEM__", system)
+    flake_dir = tmp_path / "flake"
+    flake_dir.mkdir()
+    (flake_dir / "flake.nix").write_text(flake, encoding="utf-8")
+
+    df = package_meta.try_scan_package_meta(
+        [{"name": "shadow-1.0", "pname": "shadow", "version": "1.0"}],
+        flakeref=flake_dir.as_posix(),
+        impure=True,
+    )
+
+    assert df is not None
+    assert df["meta_possible_cpes"].to_list() == [
+        "cpe:2.3:a:shadow_project:shadow:1.0:*:*:*:*:*:*:*"
+    ]
+
+
+def test_package_meta_ignores_unreadable_identifier_attrs(tmp_path):
+    if shutil.which("nix") is None:
+        pytest.skip("nix is not available")
+
+    system = package_meta.nix_system()
+    flake = """
+{
+  outputs = { self }:
+  let
+    system = "__SYSTEM__";
+  in
+    {
+    packages.${system}.shadow = (derivation {
+      name = "shadow-1.0";
+      inherit system;
+      builder = "/bin/sh";
+      args = [ "-c" "echo out > $out" ];
+    }) // {
+      pname = "shadow";
+      version = "1.0";
+      meta.description = "shadow description";
+      meta.identifiers = throw "bad";
+    };
+  };
+}
+""".replace("__SYSTEM__", system)
+    flake_dir = tmp_path / "flake"
+    flake_dir.mkdir()
+    (flake_dir / "flake.nix").write_text(flake, encoding="utf-8")
+
+    df = package_meta.try_scan_package_meta(
+        [{"name": "shadow-1.0", "pname": "shadow", "version": "1.0"}],
+        flakeref=flake_dir.as_posix(),
+        impure=True,
+    )
+
+    assert df is not None
+    assert df["meta_description"].to_list() == ["shadow description"]
+    assert df["meta_cpe"].to_list() == [""]
+    assert df["meta_possible_cpes"].to_list() == [""]
+
+
+def test_package_meta_falls_back_from_empty_legacy_cpe_fields(tmp_path):
+    if shutil.which("nix") is None:
+        pytest.skip("nix is not available")
+
+    system = package_meta.nix_system()
+    flake = """
+{
+  outputs = { self }:
+  let
+    system = "__SYSTEM__";
+  in
+    {
+    packages.${system}.shadow = (derivation {
+      name = "shadow-1.0";
+      inherit system;
+      builder = "/bin/sh";
+      args = [ "-c" "echo out > $out" ];
+    }) // {
+      pname = "shadow";
+      version = "1.0";
+      meta.cpe = "";
+      meta.possibleCPEs = [ ];
+      meta.identifiers = {
+        cpe = "cpe:2.3:a:shadow_project:shadow:1.0:*:*:*:*:*:*:*";
+        possibleCPEs = [
+          { cpe = "cpe:2.3:a:shadow_project:shadow:1.0:*:*:*:*:*:*:*"; }
+        ];
+      };
+    };
+  };
+}
+""".replace("__SYSTEM__", system)
+    flake_dir = tmp_path / "flake"
+    flake_dir.mkdir()
+    (flake_dir / "flake.nix").write_text(flake, encoding="utf-8")
+
+    df = package_meta.try_scan_package_meta(
+        [{"name": "shadow-1.0", "pname": "shadow", "version": "1.0"}],
+        flakeref=flake_dir.as_posix(),
+        impure=True,
+    )
+
+    assert df is not None
+    assert df["meta_cpe"].to_list() == [
+        "cpe:2.3:a:shadow_project:shadow:1.0:*:*:*:*:*:*:*"
+    ]
+    assert df["meta_possible_cpes"].to_list() == [
+        "cpe:2.3:a:shadow_project:shadow:1.0:*:*:*:*:*:*:*"
+    ]
 
 
 def test_package_meta_scans_target_flake_attr_when_name_differs(tmp_path):


### PR DESCRIPTION
Read exact CPE identifiers from nixpkgs metadata, prefer them over heuristic CPEs, and keep the heuristic path only as a fallback when nixpkgs metadata does not provide a canonical CPE.

Make --exclude-cpe-matching disable only heuristic CPE generation, while --exclude-meta disables nixpkgs metadata enrichment, including metadata-derived CPEs. Keep possibleCPEs informational-only and document the resulting CLI semantics.

Also fix the heuristic generator so include_cpe=False truly suppresses generated CPE values.