### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -54,53 +54,31 @@
         "flake-compat": [
           "flake-compat"
         ],
-        "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776796298,
-        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {
@@ -112,11 +90,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -173,11 +151,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1778651554,
-        "narHash": "sha256-QxkkaBVdIIot/YVxPuzUhjP7cDAp7U9iJXWozVTcuww=",
+        "lastModified": 1784627745,
+        "narHash": "sha256-EFbgwK/CPrP4EmSUH3LqYmtbra9lAxwpsf16ByfZeCc=",
         "owner": "nix-community",
         "repo": "vulnix",
-        "rev": "038b06e335c41d7d2dcbccbf4f821f95d7c17b16",
+        "rev": "c0a930a55f4ef7026a41bcc1d39261d92f488b8b",
         "type": "github"
       },
       "original": {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
 #
 # SPDX-License-Identifier: Apache-2.0
+{ inputs, ... }:
 {
   imports = [
     ./apps.nix
@@ -8,4 +9,27 @@
     ./packages.nix
     ./git-hooks.nix
   ];
+  perSystem =
+    { system, ... }:
+    {
+      # df-diskcache upstream pins pandas<3, but its test suite passes with
+      # pandas 3: relax the pin for all python envs in this flake.
+      # The same fix is in review for nixpkgs in
+      # https://github.com/NixOS/nixpkgs/pull/540439; this overlay can be
+      # removed once the nixpkgs pin includes that change.
+      _module.args.pkgs = import inputs.nixpkgs {
+        inherit system;
+        overlays = [
+          (_final: prev: {
+            pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
+              (_pyfinal: pyprev: {
+                dfdiskcache = pyprev.dfdiskcache.overridePythonAttrs (old: {
+                  pythonRelaxDeps = (old.pythonRelaxDeps or [ ]) ++ [ "pandas" ];
+                });
+              })
+            ];
+          })
+        ];
+      };
+    };
 }

--- a/src/common/proc.py
+++ b/src/common/proc.py
@@ -87,17 +87,6 @@ def exec_cmd(
                 encoding="utf-8",
                 check=True,
             )
-        LOG.debug(
-            "Finished in %.3fs (rc=%s, stdout=%s, stderr=%s): %s",
-            time.perf_counter() - started,
-            ret.returncode,
-            _stream_summary(ret.stdout),
-            _stream_summary(ret.stderr),
-            command_str,
-        )
-        if ret.stderr:
-            LOG.debug("Command stderr:\n%s", _stream_preview(ret.stderr))
-        return ret
     except subprocess.CalledProcessError as error:
         LOG.debug(
             "Failed in %.3fs (rc=%s, stdout=%s, stderr=%s): %s",
@@ -119,6 +108,17 @@ def exec_cmd(
         if return_error:
             return error
         return None
+    LOG.debug(
+        "Finished in %.3fs (rc=%s, stdout=%s, stderr=%s): %s",
+        time.perf_counter() - started,
+        ret.returncode,
+        _stream_summary(ret.stdout),
+        _stream_summary(ret.stderr),
+        command_str,
+    )
+    if ret.stderr:
+        LOG.debug("Command stderr:\n%s", _stream_preview(ret.stderr))
+    return ret
 
 
 def exit_unless_command_exists(

--- a/src/sbomnix/cli_utils.py
+++ b/src/sbomnix/cli_utils.py
@@ -102,6 +102,11 @@ def _normalize_nixos_configuration_ref(nixref):
     return f"{flake}#nixosConfigurations.{attr}{NIXOS_CONFIGURATION_TOPLEVEL_SUFFIX}"
 
 
+def _temp_sbom_path(prefix, suffix):
+    with NamedTemporaryFile(delete=False, prefix=prefix, suffix=suffix) as fobj:
+        return pathlib.Path(fobj.name)
+
+
 def generate_temp_sbom(
     target_path,
     buildtime=False,
@@ -115,19 +120,14 @@ def generate_temp_sbom(
     cdx_path = None
     csv_path = None
     try:
-        with NamedTemporaryFile(delete=False, prefix=prefix, suffix=cdx_suffix) as fcdx:
-            cdx_path = pathlib.Path(fcdx.name)
-            if not include_csv:
-                sbom.to_cdx(cdx_path, printinfo=False)
-                return GeneratedSbom(cdx_path=cdx_path)
-            with NamedTemporaryFile(delete=False, prefix=prefix, suffix=".csv") as fcsv:
-                csv_path = pathlib.Path(fcsv.name)
-                sbom.to_cdx(cdx_path, printinfo=False)
-                sbom.to_csv(csv_path, loglevel=logging.DEBUG)
-        return GeneratedSbom(cdx_path=cdx_path, csv_path=csv_path)
-    except Exception:
-        if cdx_path is not None:
-            cdx_path.unlink(missing_ok=True)
+        cdx_path = _temp_sbom_path(prefix, cdx_suffix)
+        csv_path = _temp_sbom_path(prefix, ".csv") if include_csv else None
+        sbom.to_cdx(cdx_path, printinfo=False)
         if csv_path is not None:
-            csv_path.unlink(missing_ok=True)
+            sbom.to_csv(csv_path, loglevel=logging.DEBUG)
+    except Exception:
+        for path in (cdx_path, csv_path):
+            if path is not None:
+                path.unlink(missing_ok=True)
         raise
+    return GeneratedSbom(cdx_path=cdx_path, csv_path=csv_path)

--- a/src/sbomnix/package_meta.py
+++ b/src/sbomnix/package_meta.py
@@ -897,6 +897,53 @@ def _concat_metadata_frames(frames):
     return pd.concat(frames, ignore_index=True)
 
 
+def _scan_package_meta(  # noqa: PLR0913
+    lookup_keys,
+    *,
+    flakeref=None,
+    nixpkgs_path=None,
+    pkgs_expression=None,
+    input_roots_only=False,
+    impure=False,
+):
+    started = time.perf_counter()
+    lookup_keys = _normalized_lookup_keys(lookup_keys)
+    if not lookup_keys:
+        return pd.DataFrame()
+    flakeref = normalize_flakeref_for_nix_eval(flakeref)
+    LOG.debug("Reading package metadata for flakeref: %s", flakeref)
+    frames = []
+    for request_system, system_lookup_keys in _request_system_groups(
+        flakeref, lookup_keys
+    ):
+        LOG.verbose(
+            "Evaluating package metadata for %d lookup(s) on system '%s'",
+            len(system_lookup_keys),
+            request_system,
+        )
+        request = {
+            "flakeref": flakeref or None,
+            "system": request_system,
+            "nixpkgsPath": str(nixpkgs_path) if nixpkgs_path else None,
+            "lookupKeys": _request_lookup_keys(system_lookup_keys),
+            "inputRootsOnly": bool(input_roots_only),
+        }
+        frames.append(
+            _eval_package_meta_request(
+                request,
+                pkgs_expression=pkgs_expression,
+                impure=impure,
+            )
+        )
+    df = _concat_metadata_frames(frames)
+    LOG.verbose(
+        "Read package metadata with %d candidate row(s) in %.3fs",
+        len(df),
+        time.perf_counter() - started,
+    )
+    return df
+
+
 def try_scan_package_meta(  # noqa: PLR0913
     lookup_keys,
     *,
@@ -908,42 +955,14 @@ def try_scan_package_meta(  # noqa: PLR0913
 ):
     """Return package metadata dataframe, or None on failure."""
     try:
-        started = time.perf_counter()
-        lookup_keys = _normalized_lookup_keys(lookup_keys)
-        if not lookup_keys:
-            return pd.DataFrame()
-        flakeref = normalize_flakeref_for_nix_eval(flakeref)
-        LOG.debug("Reading package metadata for flakeref: %s", flakeref)
-        frames = []
-        for request_system, system_lookup_keys in _request_system_groups(
-            flakeref, lookup_keys
-        ):
-            LOG.verbose(
-                "Evaluating package metadata for %d lookup(s) on system '%s'",
-                len(system_lookup_keys),
-                request_system,
-            )
-            request = {
-                "flakeref": flakeref or None,
-                "system": request_system,
-                "nixpkgsPath": str(nixpkgs_path) if nixpkgs_path else None,
-                "lookupKeys": _request_lookup_keys(system_lookup_keys),
-                "inputRootsOnly": bool(input_roots_only),
-            }
-            frames.append(
-                _eval_package_meta_request(
-                    request,
-                    pkgs_expression=pkgs_expression,
-                    impure=impure,
-                )
-            )
-        df = _concat_metadata_frames(frames)
-        LOG.verbose(
-            "Read package metadata with %d candidate row(s) in %.3fs",
-            len(df),
-            time.perf_counter() - started,
+        return _scan_package_meta(
+            lookup_keys,
+            flakeref=flakeref,
+            nixpkgs_path=nixpkgs_path,
+            pkgs_expression=pkgs_expression,
+            input_roots_only=input_roots_only,
+            impure=impure,
         )
-        return df
     except (
         FileNotFoundError,
         KeyError,


### PR DESCRIPTION
Update flake inputs. The nixpkgs bump moves python to 3.14 and pandas to 3.0.4: relax the df-diskcache pandas pin with an overlay since its test suite passes with pandas 3, and shorten the try clauses flagged by the ruff preview rule
too-many-statements-in-try-clause added in the updated ruff.

Overlay can be removed once https://github.com/NixOS/nixpkgs/pull/540439 lands.