### PR TITLE
sbomnix: retry CPE dictionary downloads

### DIFF
--- a/src/sbomnix/cpe.py
+++ b/src/sbomnix/cpe.py
@@ -4,10 +4,14 @@
 
 """Generate CPE (Common Platform Enumeration) identifiers"""
 
+import io
 import string
+
+from requests import RequestException, Session
 
 from common.df import df_from_csv_file, df_log
 from common.errors import InvalidCpeDictionaryError
+from common.http import mount_retries
 from common.log import LOG, LOG_SPAM
 from sbomnix.dfcache import LockedDfCache
 
@@ -75,7 +79,16 @@ class CPE:
             LOG.debug("read CPE dictionary from cache")
         else:
             LOG.debug("CPE cache miss, downloading: %s", _CPE_CSV_URL)
-            self.df_cpedict = df_from_csv_file(_CPE_CSV_URL, exit_on_error=False)
+            try:
+                with mount_retries(Session()) as session:
+                    response = session.get(_CPE_CSV_URL, timeout=30)
+                    response.raise_for_status()
+                    self.df_cpedict = df_from_csv_file(
+                        io.StringIO(response.text), exit_on_error=False
+                    )
+            except RequestException as error:
+                LOG.debug("Error downloading cpedict: %s", error)
+                self.df_cpedict = None
             if self.df_cpedict is None or self.df_cpedict.empty:
                 LOG.warning(
                     "Failed downloading cpedict: CPE information might not be accurate"

--- a/tests/test_cpe.py
+++ b/tests/test_cpe.py
@@ -6,6 +6,7 @@
 """Focused tests for CPE generation."""
 
 import pandas as pd
+from requests import HTTPError
 
 from sbomnix import cpe
 
@@ -19,6 +20,38 @@ class FakeCache:
 
     def set(self, *_args, **_kwargs):
         raise AssertionError("cache set should not be called for populated data")
+
+
+def test_cpe_download_uses_retries_before_fallback(monkeypatch):
+    class FailingResponse:
+        def raise_for_status(self):
+            raise HTTPError("503 Server Error")
+
+    class FailingSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def get(self, url, timeout):
+            assert (url, timeout) == (cpe._CPE_CSV_URL, 30)
+            return FailingResponse()
+
+    session = FailingSession()
+    mounted = []
+    monkeypatch.setattr(cpe, "LockedDfCache", lambda: FakeCache(None))
+    monkeypatch.setattr(cpe, "Session", lambda: session)
+    monkeypatch.setattr(
+        cpe,
+        "mount_retries",
+        lambda candidate: mounted.append(candidate) or candidate,
+    )
+
+    generated = cpe.CPE().generate("openssl", "3.0.0")
+
+    assert mounted == [session]
+    assert generated == "cpe:2.3:a:openssl:openssl:3.0.0:*:*:*:*:*:*:*"
 
 
 def test_cpe_uses_indexed_unique_product_vendor(monkeypatch):


### PR DESCRIPTION
CPE dictionary downloads currently bypass the shared HTTP retry policy. A transient failure therefore falls back immediately to less accurate heuristic vendor names.

Use the shared retry adapter before preserving the existing warning and fallback when retries are exhausted. This improves reliability during transient failures without changing offline behavior.

I found this when a transient failure fetching the GitHub-hosted CPE dictionary reduced vulnxscan findings from 150 to 117 because Grype lost accurate vendor mappings.