### PR TITLE
sbomnix: optionally require CPE dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ including metadata-derived CPEs. Using both flags results in no CPE output.
 Store-path targets have no nixpkgs metadata source, so `--exclude-cpe-matching`
 usually removes all CPEs for store-path targets.
 
+If the CPE dictionary cannot be loaded, `sbomnix` warns and falls back to less
+accurate CPE identifiers. `--require-cpe-dictionary` makes this condition fatal
+and cannot be combined with `--exclude-cpe-matching`.
+
 CycloneDX and SPDX outputs record the selected metadata source in document
 metadata, including fields such as `nixpkgs:metadata_source_method`,
 `nixpkgs:path`, `nixpkgs:rev`, `nixpkgs:flakeref`, `nixpkgs:version`, and

--- a/doc/vulnxscan.md
+++ b/doc/vulnxscan.md
@@ -52,6 +52,8 @@ Also, it is worth mentioning that OSV queries without ecosystem are undocumented
 ### Nix and Grype
 [Grype](https://github.com/anchore/grype) is a vulnerability scanner targeted for container images. It uses the vulnerability data from [a variety of publicly available data sources](https://github.com/anchore/grype#grypes-database). Grype also [supports input from CycloneDX SBOM](https://github.com/anchore/grype#supported-sources) which makes it possible to use Grype with SBOM input from `sbomnix`, thus, allowing Grype scans against Nix targets.
 
+When the CPE dictionary cannot be loaded, `sbomnix` and `vulnxscan` warn and fall back to less accurate CPE identifiers. Pass `--require-cpe-dictionary` to either command to fail instead when generating an SBOM for vulnerability scanning. This option has no effect when `vulnxscan --sbom` uses an existing SBOM.
+
 ### Vulnix
 [Vulnix](https://github.com/nix-community/vulnix) is a vulnerability scanner intended for Nix targets. It uses [NIST NVD](https://nvd.nist.gov/vuln) vulnerability database.
 

--- a/src/sbomnix/builder.py
+++ b/src/sbomnix/builder.py
@@ -106,6 +106,7 @@ class SbomBuilder:
         include_meta=True,
         include_vulns=False,
         include_cpe=True,
+        require_cpe_dictionary=False,
     ):
         # self.uid specifies the attribute that identifies SBOM components.
         # See the column names in
@@ -140,6 +141,7 @@ class SbomBuilder:
         # found no source.
         self.nixpkgs_meta_source = NixpkgsMetaSource(method="disabled")
         self.include_cpe = include_cpe
+        self.require_cpe_dictionary = require_cpe_dictionary
         self._init_components(include_meta)
         target_component_ref = self._resolve_target_component_ref()
         self.target_component_ref = target_component_ref
@@ -292,6 +294,7 @@ class SbomBuilder:
             paths,
             self._runtime_output_paths_by_load_path,
             include_cpe=self.include_cpe,
+            require_cpe_dictionary=self.require_cpe_dictionary,
         )
         if df_components.empty:
             raise MissingNixDerivationMetadataError(self.nix_path)
@@ -319,6 +322,7 @@ class SbomBuilder:
                 paths,
                 self._recursive_buildtime_derivations,
                 include_cpe=self.include_cpe,
+                require_cpe_dictionary=self.require_cpe_dictionary,
             )
         elif self._runtime_output_paths_by_load_path is not None:
             self.df_sbomdb = self._init_runtime_components(paths)

--- a/src/sbomnix/cli_utils.py
+++ b/src/sbomnix/cli_utils.py
@@ -107,16 +107,22 @@ def _temp_sbom_path(prefix, suffix):
         return pathlib.Path(fobj.name)
 
 
-def generate_temp_sbom(
+def generate_temp_sbom(  # noqa: PLR0913, PLR0917
     target_path,
     buildtime=False,
     prefix="sbomnix_",
     cdx_suffix=".cdx.json",
     include_csv=False,
+    require_cpe_dictionary=False,
 ):
     """Generate temporary SBOM artifact files for downstream CLI workflows."""
     LOG.info("Generating SBOM for target '%s'", target_path)
-    sbom = SbomBuilder(target_path, buildtime, include_meta=False)
+    sbom = SbomBuilder(
+        target_path,
+        buildtime,
+        include_meta=False,
+        require_cpe_dictionary=require_cpe_dictionary,
+    )
     cdx_path = None
     csv_path = None
     try:

--- a/src/sbomnix/components.py
+++ b/src/sbomnix/components.py
@@ -28,7 +28,9 @@ _VERSIONED_NAME_RE = re.compile(
 )
 
 
-def recursive_derivations_to_dataframe(paths, derivations, include_cpe=True):
+def recursive_derivations_to_dataframe(
+    paths, derivations, include_cpe=True, require_cpe_dictionary=False
+):
     """Return component rows from an already-loaded derivation closure."""
     drvs = []
     for path in sorted(paths):
@@ -37,11 +39,20 @@ def recursive_derivations_to_dataframe(paths, derivations, include_cpe=True):
             LOG.debug("Recursive buildtime closure missing path: %s", path)
             continue
         drvs.append(drv)
-    return _derivations_to_dataframe(drvs, CPE(include_cpe=include_cpe))
+    return _derivations_to_dataframe(
+        drvs,
+        CPE(
+            include_cpe=include_cpe,
+            require_dictionary=require_cpe_dictionary,
+        ),
+    )
 
 
 def runtime_derivations_to_dataframe(
-    paths, output_paths_by_load_path, include_cpe=True
+    paths,
+    output_paths_by_load_path,
+    include_cpe=True,
+    require_cpe_dictionary=False,
 ):
     """Return component rows from runtime output-to-load-path mappings."""
     filtered_outputs_by_load_path = filter_runtime_outputs_by_load_path(
@@ -56,7 +67,10 @@ def runtime_derivations_to_dataframe(
             ignore_missing=True,
         ).values()
     )
-    cpe_generator = CPE(include_cpe=include_cpe)
+    cpe_generator = CPE(
+        include_cpe=include_cpe,
+        require_dictionary=require_cpe_dictionary,
+    )
     df_derivations = _derivations_to_dataframe(derivations, cpe_generator)
     rows = _inferred_component_rows(
         load_paths,

--- a/src/sbomnix/cpe.py
+++ b/src/sbomnix/cpe.py
@@ -10,7 +10,7 @@ import string
 from requests import RequestException, Session
 
 from common.df import df_from_csv_file, df_log
-from common.errors import InvalidCpeDictionaryError
+from common.errors import CsvLoadError, InvalidCpeDictionaryError
 from common.http import mount_retries
 from common.log import LOG, LOG_SPAM
 from sbomnix.dfcache import LockedDfCache
@@ -64,6 +64,7 @@ class CPE:
     def __init__(
         self,
         include_cpe=True,
+        require_dictionary=False,
     ):
         self.include_cpe = include_cpe
         self._product_vendor = {}
@@ -79,6 +80,7 @@ class CPE:
             LOG.debug("read CPE dictionary from cache")
         else:
             LOG.debug("CPE cache miss, downloading: %s", _CPE_CSV_URL)
+            download_error = None
             try:
                 with mount_retries(Session()) as session:
                     response = session.get(_CPE_CSV_URL, timeout=30)
@@ -89,7 +91,13 @@ class CPE:
             except RequestException as error:
                 LOG.debug("Error downloading cpedict: %s", error)
                 self.df_cpedict = None
+                download_error = error
             if self.df_cpedict is None or self.df_cpedict.empty:
+                if require_dictionary:
+                    raise CsvLoadError(
+                        _CPE_CSV_URL,
+                        download_error or "CPE dictionary is empty",
+                    )
                 LOG.warning(
                     "Failed downloading cpedict: CPE information might not be accurate"
                 )

--- a/src/sbomnix/main.py
+++ b/src/sbomnix/main.py
@@ -51,9 +51,14 @@ def getargs(args=None):
     parser.add_argument(
         "--exclude-meta", help=helps, action="store_true", default=False
     )
+    cpe_options = parser.add_mutually_exclusive_group()
     helps = "Exclude heuristic CPE matching; keep exact nixpkgs metadata CPEs"
-    parser.add_argument(
+    cpe_options.add_argument(
         "--exclude-cpe-matching", help=helps, action="store_true", default=False
+    )
+    helps = "Fail if the CPE dictionary cannot be loaded"
+    cpe_options.add_argument(
+        "--require-cpe-dictionary", help=helps, action="store_true", default=False
     )
 
     group = parser.add_argument_group("output arguments")
@@ -107,6 +112,7 @@ def _run(args):
         include_meta=not args.exclude_meta,
         include_vulns=args.include_vulns,
         include_cpe=not args.exclude_cpe_matching,
+        require_cpe_dictionary=args.require_cpe_dictionary,
     )
     LOG.verbose(
         "Constructed SBOM model in %.3fs",

--- a/src/vulnxscan/vulnxscan_cli.py
+++ b/src/vulnxscan/vulnxscan_cli.py
@@ -44,6 +44,10 @@ def getargs(args=None):
         "has no impact if the scan target is SBOM (ref: --sbom)."
     )
     parser.add_argument("--buildtime", help=helps, action="store_true")
+    helps = "Fail if the generated SBOM's CPE dictionary cannot be loaded"
+    parser.add_argument(
+        "--require-cpe-dictionary", help=helps, action="store_true", default=False
+    )
     helps = (
         "Indicate that TARGET is a cdx SBOM instead of path to nix artifact. "
         "This allows running vulnxscan using input SBOMs from any tool "
@@ -131,6 +135,7 @@ def _run(args):
             prefix="vulnxscan_",
             cdx_suffix=".json",
             include_csv=True,
+            require_cpe_dictionary=args.require_cpe_dictionary,
         )
         sbom_cdx_path = sbom_artifact.cdx_path
         sbom_csv_path = sbom_artifact.csv_path

--- a/tests/test_builder_runtime.py
+++ b/tests/test_builder_runtime.py
@@ -29,6 +29,7 @@ def _builder_double():
     builder.target_deriver = TARGET_DERIVER
     builder.target_component_ref = None
     builder.include_cpe = False
+    builder.require_cpe_dictionary = False
     builder.depth = None
     builder.df_deps = None
     builder._runtime_output_paths_by_load_path = None

--- a/tests/test_cli_conventions.py
+++ b/tests/test_cli_conventions.py
@@ -72,6 +72,27 @@ def test_cli_verbose_default_is_normal_info(getargs, base_argv):
 
 
 @pytest.mark.parametrize(
+    ("getargs", "target"),
+    [
+        (sbomnix_main.getargs, ".#pkg"),
+        (vulnxscan_cli.getargs, ".#pkg"),
+    ],
+)
+def test_require_cpe_dictionary_is_opt_in(getargs, target):
+    assert getargs([target]).require_cpe_dictionary is False
+    assert getargs(["--require-cpe-dictionary", target]).require_cpe_dictionary is True
+
+
+def test_sbomnix_cpe_matching_options_are_mutually_exclusive():
+    with pytest.raises(SystemExit) as excinfo:
+        sbomnix_main.getargs(
+            ["--exclude-cpe-matching", "--require-cpe-dictionary", ".#pkg"]
+        )
+
+    assert excinfo.value.code == 2
+
+
+@pytest.mark.parametrize(
     ("getargs", "base_argv"),
     CLI_ARG_CASES,
 )

--- a/tests/test_cpe.py
+++ b/tests/test_cpe.py
@@ -6,8 +6,10 @@
 """Focused tests for CPE generation."""
 
 import pandas as pd
+import pytest
 from requests import HTTPError
 
+from common.errors import CsvLoadError
 from sbomnix import cpe
 
 
@@ -52,6 +54,30 @@ def test_cpe_download_uses_retries_before_fallback(monkeypatch):
 
     assert mounted == [session]
     assert generated == "cpe:2.3:a:openssl:openssl:3.0.0:*:*:*:*:*:*:*"
+
+
+def test_cpe_required_dictionary_fails_after_download_retries(monkeypatch):
+    class FailingResponse:
+        def raise_for_status(self):
+            raise HTTPError("503 Server Error")
+
+    class FailingSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def get(self, _url, timeout):
+            assert timeout == 30
+            return FailingResponse()
+
+    monkeypatch.setattr(cpe, "LockedDfCache", lambda: FakeCache(None))
+    monkeypatch.setattr(cpe, "Session", FailingSession)
+    monkeypatch.setattr(cpe, "mount_retries", lambda session: session)
+
+    with pytest.raises(CsvLoadError, match="503 Server Error"):
+        cpe.CPE(require_dictionary=True)
 
 
 def test_cpe_uses_indexed_unique_product_vendor(monkeypatch):

--- a/tests/test_sbom_vuln_enrichment.py
+++ b/tests/test_sbom_vuln_enrichment.py
@@ -32,7 +32,10 @@ class CapturingLogger:
         self.records.append(("fatal", msg, args))
 
 
-def test_sbomnix_main_enriches_cdx_explicitly_when_include_vulns_is_set(monkeypatch):
+@pytest.mark.parametrize("require_cpe_dictionary", [False, True])
+def test_sbomnix_main_enriches_cdx_explicitly_when_include_vulns_is_set(
+    monkeypatch, require_cpe_dictionary
+):
     args = SimpleNamespace(
         NIXREF=".#target",
         buildtime=False,
@@ -41,6 +44,7 @@ def test_sbomnix_main_enriches_cdx_explicitly_when_include_vulns_is_set(monkeypa
         include_vulns=True,
         exclude_meta=False,
         exclude_cpe_matching=False,
+        require_cpe_dictionary=require_cpe_dictionary,
         csv=None,
         cdx="sbom.cdx.json",
         spdx=None,
@@ -96,6 +100,7 @@ def test_sbomnix_main_enriches_cdx_explicitly_when_include_vulns_is_set(monkeypa
                 "include_meta": True,
                 "include_vulns": True,
                 "include_cpe": True,
+                "require_cpe_dictionary": require_cpe_dictionary,
             },
         ),
         ("to_cdx_data",),
@@ -118,6 +123,7 @@ def test_sbomnix_main_logs_generation_before_initializing_builder(monkeypatch):
         include_vulns=False,
         exclude_meta=False,
         exclude_cpe_matching=False,
+        require_cpe_dictionary=False,
         csv=None,
         cdx=None,
         spdx=None,
@@ -159,6 +165,7 @@ def test_sbomnix_main_logs_generation_before_initializing_builder(monkeypatch):
                 "include_meta": True,
                 "include_vulns": False,
                 "include_cpe": True,
+                "require_cpe_dictionary": False,
             },
         )
     ]

--- a/tests/test_temp_sbom_generation.py
+++ b/tests/test_temp_sbom_generation.py
@@ -14,17 +14,22 @@ from sbomnix import cli_utils as sbomnix_cli_utils
 from vulnxscan import vulnxscan_cli
 
 
-def test_vulnxscan_cleans_generated_tempfiles_on_failure(tmp_path, monkeypatch):
+@pytest.mark.parametrize("require_cpe_dictionary", [False, True])
+def test_vulnxscan_cleans_generated_tempfiles_on_failure(
+    tmp_path, monkeypatch, require_cpe_dictionary
+):
     sbom_cdx_path = tmp_path / "generated.cdx.json"
     sbom_csv_path = tmp_path / "generated.csv"
     sbom_cdx_path.write_text("{}", encoding="utf-8")
     sbom_csv_path.write_text("", encoding="utf-8")
+    generated_kwargs = {}
 
     args = SimpleNamespace(
         TARGET="target",
         verbose=0,
         out="vulns.csv",
         buildtime=False,
+        require_cpe_dictionary=require_cpe_dictionary,
         sbom=False,
         whitelist=None,
         triage=False,
@@ -56,14 +61,15 @@ def test_vulnxscan_cleans_generated_tempfiles_on_failure(tmp_path, monkeypatch):
             path="/nix/store/target"
         ),
     )
-    monkeypatch.setattr(
-        vulnxscan_cli,
-        "generate_temp_sbom",
-        lambda _target_path, _buildtime, **_kwargs: sbomnix_cli_utils.GeneratedSbom(
+
+    def fake_generate_temp_sbom(_target_path, _buildtime, **kwargs):
+        generated_kwargs.update(kwargs)
+        return sbomnix_cli_utils.GeneratedSbom(
             cdx_path=sbom_cdx_path,
             csv_path=sbom_csv_path,
-        ),
-    )
+        )
+
+    monkeypatch.setattr(vulnxscan_cli, "generate_temp_sbom", fake_generate_temp_sbom)
     monkeypatch.setattr(vulnxscan_cli, "VulnScan", FailingScanner)
 
     with pytest.raises(RuntimeError, match="scan failed"):
@@ -71,6 +77,7 @@ def test_vulnxscan_cleans_generated_tempfiles_on_failure(tmp_path, monkeypatch):
 
     assert not sbom_cdx_path.exists()
     assert not sbom_csv_path.exists()
+    assert generated_kwargs["require_cpe_dictionary"] is require_cpe_dictionary
 
 
 def test_generate_temp_sbom_without_csv_returns_only_cdx_path(tmp_path, monkeypatch):
@@ -88,8 +95,15 @@ def test_generate_temp_sbom_without_csv_returns_only_cdx_path(tmp_path, monkeypa
             return False
 
     class DummySbomBuilder:
-        def __init__(self, _target_path, _buildtime, include_meta=False):
+        def __init__(
+            self,
+            _target_path,
+            _buildtime,
+            include_meta=False,
+            require_cpe_dictionary=False,
+        ):
             assert include_meta is False
+            assert require_cpe_dictionary is False
 
         def to_cdx(self, sbom_path, printinfo=False):
             Path(sbom_path).write_text("{}", encoding="utf-8")
@@ -139,8 +153,15 @@ def test_generate_temp_sbom_cleans_tempfiles_on_generation_failure(
             return False
 
     class FailingSbomBuilder:
-        def __init__(self, _target_path, _buildtime, include_meta=False):
+        def __init__(
+            self,
+            _target_path,
+            _buildtime,
+            include_meta=False,
+            require_cpe_dictionary=False,
+        ):
             assert include_meta is False
+            assert require_cpe_dictionary is False
 
         def to_cdx(self, sbom_path, printinfo=False):
             Path(sbom_path).write_text("{}", encoding="utf-8")
@@ -190,8 +211,15 @@ def test_generate_temp_sbom_cleans_first_tempfile_if_second_creation_fails(
             return False
 
     class DummySbomBuilder:
-        def __init__(self, _target_path, _buildtime, include_meta=False):
+        def __init__(
+            self,
+            _target_path,
+            _buildtime,
+            include_meta=False,
+            require_cpe_dictionary=False,
+        ):
             assert include_meta is False
+            assert require_cpe_dictionary is False
 
         def to_cdx(self, _sbom_path, printinfo=False):
             raise AssertionError("to_cdx should not run if csv tempfile creation fails")


### PR DESCRIPTION
Add --require-cpe-dictionary to sbomnix and vulnxscan so callers can make an unavailable CPE dictionary fatal after retries are exhausted. Reject the contradictory combination with --exclude-cpe-matching.

Both commands keep their warning and heuristic fallback by default, so this does not change existing failure behavior.

The prior [retry change](https://github.com/tiiuae/sbomnix/pull/315) improved transient download reliability without changing fallback behavior. The opt-in strict mode lets CI reject degraded CPE vendor mappings that could otherwise make vulnerability results incomplete. 

Sometimes non-failing retries hide things and strict mode is preferred, especially when comparing cached old results with new results where silent continuing causes bigger unexpected diffs in the findings. Observed that during GitHub outages in the last days.