### PR TITLE
Prefer explicit PURLs from derivation metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ $ sbomnix github:NixOS/nixpkgs/nixos-unstable#wget --buildtime
 ```bash
 $ sbomnix /path/to/result
 ```
-Note: store paths carry no record of which nixpkgs version produced them, so nixpkgs metadata enrichment is skipped. Use a flakeref target when nixpkgs metadata is required.
+Note: store paths carry no record of which nixpkgs version produced them, so nixpkgs metadata enrichment is skipped. Use a flakeref target when nixpkgs metadata enrichment is required. Explicit PURLs embedded in derivation JSON can still be used, as described below.
 
 #### Nixpkgs Metadata Source Selection
 `sbomnix` enriches packages with nixpkgs metadata, such as descriptions,
@@ -149,7 +149,7 @@ toplevel flakerefs are handled through the selected NixOS package set, so
 overlays, package overrides, nixpkgs config, and system-specific package-set
 changes can be represented.
 
-Store-path targets skip nixpkgs metadata because the store path does not
+Store-path targets skip nixpkgs metadata enrichment because the store path does not
 identify the nixpkgs source that produced it. `--exclude-meta` disables metadata
 enrichment.
 
@@ -157,7 +157,8 @@ When nixpkgs metadata is available, `sbomnix` prefers exact CPE identifiers
 from nixpkgs metadata and falls back to heuristic CPE matching only when no
 exact nixpkgs CPE is present. `--exclude-cpe-matching` disables only the
 heuristic fallback, while `--exclude-meta` disables nixpkgs metadata entirely,
-including metadata-derived CPEs. Using both flags results in no CPE output.
+including metadata-derived CPEs and embedded derivation PURLs. PURLs then use
+the existing name-and-version fallback. Using both flags results in no CPE output.
 Store-path targets have no nixpkgs metadata source, so `--exclude-cpe-matching`
 usually removes all CPEs for store-path targets.
 
@@ -172,6 +173,33 @@ metadata, including fields such as `nixpkgs:metadata_source_method`,
 
 See [sbomnix metadata enrichment](./doc/sbomnix_metadata.md) for a short
 overview of source selection, component matching, and metadata caching.
+
+#### PURLs from Derivation Metadata
+
+Experimental [Nix #16285](https://github.com/NixOS/nix/pull/16285), together with
+[nixpkgs #466932](https://github.com/NixOS/nixpkgs/pull/466932), exposes package
+identifiers in `nix derivation show` JSON. When available, `sbomnix` prefers
+`meta.identifiers.purl` over its generated name-and-version PURL, including for
+store-path targets without a nixpkgs enrichment source. The value is normalized
+using `packageurl-python`'s package-type rules before export to CycloneDX or SPDX.
+
+`--exclude-meta` disables this override for both runtime and build-time SBOMs.
+Missing, empty or malformed metadata also retains the existing generated PURL;
+ordinary Nix installations do not need the experimental changes. A generic
+`source` derivation has no generated fallback, but can have an explicit PURL
+when metadata is enabled.
+
+Only the singular `purl` is read. A populated `identifiers.purls` list without a
+usable singular value still falls back to the heuristic; selecting a primary
+identifier from that list is not implemented.
+
+Parsing and normalization do not verify package identity. Explicit identifiers
+take precedence even when their version is absent or is a tag or commit that
+differs from the derivation's version; `sbomnix` does not insert or replace it.
+Qualifiers such as `output=out` are retained, but do not split or filter a
+component's grouped outputs. Output-specific identity for multi-output components
+remains a limitation: retaining a qualifier does not establish that the PURL
+describes every grouped output.
 
 #### Visualize Package Dependencies
 `sbomnix` uses structured Nix JSON to find package dependencies where

--- a/src/sbomnix/builder.py
+++ b/src/sbomnix/builder.py
@@ -122,6 +122,7 @@ class SbomBuilder:
         self.uid = cols.STORE_PATH
         self.nix_path = nix_path
         self.buildtime = buildtime
+        self.include_meta = include_meta
         self.target_deriver = self._resolve_target_deriver(nix_path)
         self.target_component_ref = None
         self._recursive_buildtime_derivations = None
@@ -219,7 +220,9 @@ class SbomBuilder:
             raise MissingNixDeriverError(self.nix_path)
         started = time.perf_counter()
         LOG.verbose("Loading build-time closure for '%s'", self.target_deriver)
-        derivations, drv_infos = load_recursive(self.target_deriver)
+        derivations, drv_infos = load_recursive(
+            self.target_deriver, include_meta=self.include_meta
+        )
         LOG.verbose(
             "Loaded %d recursive derivation record(s) in %.3fs",
             len(drv_infos),
@@ -293,6 +296,7 @@ class SbomBuilder:
         df_components = runtime_derivations_to_dataframe(
             paths,
             self._runtime_output_paths_by_load_path,
+            include_meta=self.include_meta,
             include_cpe=self.include_cpe,
             require_cpe_dictionary=self.require_cpe_dictionary,
         )

--- a/src/sbomnix/components.py
+++ b/src/sbomnix/components.py
@@ -53,6 +53,8 @@ def runtime_derivations_to_dataframe(
     output_paths_by_load_path,
     include_cpe=True,
     require_cpe_dictionary=False,
+    *,
+    include_meta=True,
 ):
     """Return component rows from runtime output-to-load-path mappings."""
     filtered_outputs_by_load_path = filter_runtime_outputs_by_load_path(
@@ -65,6 +67,7 @@ def runtime_derivations_to_dataframe(
             load_paths,
             output_paths_by_drv=filtered_outputs_by_load_path,
             ignore_missing=True,
+            include_meta=include_meta,
         ).values()
     )
     cpe_generator = CPE(

--- a/src/sbomnix/derivation.py
+++ b/src/sbomnix/derivation.py
@@ -410,7 +410,7 @@ def _metadata_purl(meta):
     try:
         return str(PackageURL.from_string(purl))
     except ValueError:
-        LOG.warning("Ignoring invalid derivation meta.identifiers.purl: %r", purl)
+        LOG.warning("Ignoring invalid derivation meta.identifiers.purl")
         return ""
 
 

--- a/src/sbomnix/derivation.py
+++ b/src/sbomnix/derivation.py
@@ -338,6 +338,9 @@ class Derive:
             or _coerce_derivation_string(structured_attrs.get("out"))
         )
         drv._refresh_purl()
+        # Experimental Nix derivation-meta exposes nixpkgs identifiers here.
+        # Keep the existing heuristic only when no usable explicit PURL exists.
+        drv.purl = _metadata_purl(drv_info.get("meta")) or drv.purl
         drv.outputs = []
         _set_derivation_output_paths(drv, outputs, env_vars)
         drv.init(path, outpath)
@@ -377,6 +380,24 @@ class Derive:
         for attr in vars(self):
             ret[attr] = getattr(self, attr)
         return ret
+
+
+def _metadata_purl(meta):
+    """Read the primary PURL without rewriting its ecosystem or qualifiers."""
+    if not isinstance(meta, dict):
+        return ""
+    identifiers = meta.get("identifiers")
+    if not isinstance(identifiers, dict):
+        return ""
+    purl = identifiers.get("purl")
+    if not isinstance(purl, str) or not purl:
+        return ""
+    try:
+        PackageURL.from_string(purl)
+    except ValueError:
+        LOG.warning("Ignoring invalid derivation meta.identifiers.purl: %r", purl)
+        return ""
+    return purl
 
 
 def nix_purl(pname, version):

--- a/src/sbomnix/derivation.py
+++ b/src/sbomnix/derivation.py
@@ -27,7 +27,7 @@ def _batched(iterable, size):
         yield batch
 
 
-def load(path, outpath):
+def load(path, outpath, *, include_meta=True):
     """Load derivation from path"""
     cmd = nix_cmd("derivation", "show", path)
     drv_infos = parse_nix_derivation_show(
@@ -45,13 +45,22 @@ def load(path, outpath):
         )
     if outpath is None and path != drv_path and not path.endswith(".drv"):
         outpath = path
-    d_obj = Derive.from_nix_derivation_info(drv_path, drv_info, outpath)
+    d_obj = Derive.from_nix_derivation_info(
+        drv_path, drv_info, outpath, include_meta=include_meta
+    )
     LOG.log(LOG_SPAM, "load derivation: %s", d_obj)
     LOG.log(LOG_SPAM, "derivation attrs: %s", d_obj.to_dict())
     return d_obj
 
 
-def load_many(paths, output_paths_by_drv=None, batch_size=200, ignore_missing=False):
+def load_many(
+    paths,
+    output_paths_by_drv=None,
+    batch_size=200,
+    ignore_missing=False,
+    *,
+    include_meta=True,
+):
     """Load many derivations with batched `nix derivation show` calls."""
     if not paths:
         return {}
@@ -84,6 +93,7 @@ def load_many(paths, output_paths_by_drv=None, batch_size=200, ignore_missing=Fa
                 drv_path,
                 drv_info,
                 sorted_output_paths[0] if sorted_output_paths else None,
+                include_meta=include_meta,
             )
             for outpath in sorted_output_paths[1:]:
                 drv.add_output_path(outpath)
@@ -98,6 +108,7 @@ def load_many(paths, output_paths_by_drv=None, batch_size=200, ignore_missing=Fa
             loaded[path] = load(
                 path,
                 next(iter(output_paths_by_drv.get(path, ())), None),
+                include_meta=include_meta,
             )
     return loaded
 
@@ -172,7 +183,7 @@ def _derivation_output_paths(drv_info):
     return output_paths
 
 
-def load_recursive(path):
+def load_recursive(path, *, include_meta=True):
     """Load a derivation and its recursive build-time closure."""
     cmd = nix_cmd("derivation", "show", "--recursive", path)
     drv_infos = parse_nix_derivation_show(
@@ -186,7 +197,9 @@ def load_recursive(path):
         )
     loaded = {}
     for drv_path, drv_info in drv_infos.items():
-        drv = Derive.from_nix_derivation_info(drv_path, drv_info)
+        drv = Derive.from_nix_derivation_info(
+            drv_path, drv_info, include_meta=include_meta
+        )
         LOG.log(LOG_SPAM, "load derivation: %s", drv)
         LOG.log(LOG_SPAM, "derivation attrs: %s", drv.to_dict())
         loaded[drv_path] = drv
@@ -291,17 +304,18 @@ class Derive:
             path = envVars.get(output, None) or structured_env.get(output)
             self.add_output_path(path)
         LOG.log(LOG_SPAM, "%s outputs: %s", self, self.outputs)
-        # pname 'source' in Nix has special meaning - it is the default name
-        # for all fetchFromGitHub derivations. As such, it should not be used
-        # to construct cpe or purl, rather, cpe and purl should be empty
-        # for such packages.
+        # The generic name 'source' does not identify a package, so do not
+        # generate CPEs or PURLs from it. An explicit metadata PURL can still
+        # identify the source when metadata is enabled.
         self.cpe = ""
         self.purl = ""
         self._refresh_purl()
         self.urls = envVars.get("urls", "")
 
     @classmethod
-    def from_nix_derivation_info(cls, path, drv_info, outpath=None):
+    def from_nix_derivation_info(
+        cls, path, drv_info, outpath=None, *, include_meta=True
+    ):
         """Create a derivation from normalized `nix derivation show` JSON."""
         env_vars = dict(drv_info.get("env", {}))
         structured_attrs = _structured_attr_map(drv_info.get("structuredAttrs"))
@@ -339,8 +353,9 @@ class Derive:
         )
         drv._refresh_purl()
         # Experimental Nix derivation-meta exposes nixpkgs identifiers here.
-        # Keep the existing heuristic only when no usable explicit PURL exists.
-        drv.purl = _metadata_purl(drv_info.get("meta")) or drv.purl
+        # Keep the heuristic if metadata is disabled or has no usable PURL.
+        if include_meta:
+            drv.purl = _metadata_purl(drv_info.get("meta")) or drv.purl
         drv.outputs = []
         _set_derivation_output_paths(drv, outputs, env_vars)
         drv.init(path, outpath)
@@ -383,7 +398,7 @@ class Derive:
 
 
 def _metadata_purl(meta):
-    """Read the primary PURL without rewriting its ecosystem or qualifiers."""
+    """Read and normalize the primary PURL using package-type rules."""
     if not isinstance(meta, dict):
         return ""
     identifiers = meta.get("identifiers")
@@ -393,11 +408,10 @@ def _metadata_purl(meta):
     if not isinstance(purl, str) or not purl:
         return ""
     try:
-        PackageURL.from_string(purl)
+        return str(PackageURL.from_string(purl))
     except ValueError:
         LOG.warning("Ignoring invalid derivation meta.identifiers.purl: %r", purl)
         return ""
-    return purl
 
 
 def nix_purl(pname, version):

--- a/src/sbomnix/main.py
+++ b/src/sbomnix/main.py
@@ -47,7 +47,10 @@ def getargs(args=None):
     add_verbose_argument(parser)
     helps = "Include vulnerabilities in the output of CyloneDX SBOM"
     parser.add_argument("--include-vulns", help=helps, action="store_true")
-    helps = "Exclude nixpkgs metadata enrichment, including metadata-derived CPEs"
+    helps = (
+        "Exclude nixpkgs metadata enrichment (including metadata-derived CPEs) "
+        "and embedded derivation PURLs"
+    )
     parser.add_argument(
         "--exclude-meta", help=helps, action="store_true", default=False
     )

--- a/tests/test_builder_runtime.py
+++ b/tests/test_builder_runtime.py
@@ -29,6 +29,7 @@ def _builder_double():
     builder.target_deriver = TARGET_DERIVER
     builder.target_component_ref = None
     builder.include_cpe = False
+    builder.include_meta = True
     builder.require_cpe_dictionary = False
     builder.depth = None
     builder.df_deps = None

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -68,7 +68,9 @@ def test_recursive_derivations_to_dataframe_skips_missing_paths():
 def test_runtime_derivations_to_dataframe_filters_outputs_before_loading(monkeypatch):
     load_calls = []
 
-    def fake_load_many(paths, output_paths_by_drv=None, ignore_missing=False):
+    def fake_load_many(
+        paths, output_paths_by_drv=None, ignore_missing=False, *, include_meta=True
+    ):
         load_calls.append((paths, output_paths_by_drv, ignore_missing))
         return {
             "/nix/store/first.drv": FakeDrv("/nix/store/first.drv", "first"),
@@ -136,7 +138,9 @@ def test_runtime_derivations_to_dataframe_infers_missing_runtime_components(
     }
     output_paths = set().union(*output_paths_by_load_path.values())
 
-    def fake_load_many(paths, output_paths_by_drv=None, ignore_missing=False):
+    def fake_load_many(
+        paths, output_paths_by_drv=None, ignore_missing=False, *, include_meta=True
+    ):
         assert paths == sorted(output_paths_by_load_path)
         assert output_paths_by_drv == output_paths_by_load_path
         assert ignore_missing is True

--- a/tests/test_derivation_purl_metadata.py
+++ b/tests/test_derivation_purl_metadata.py
@@ -4,33 +4,117 @@
 """Explicit derivation identifiers must take precedence over name heuristics."""
 
 import json
+import subprocess
 
 import pytest
 
 from common.nix_utils import parse_nix_derivation_show
+from sbomnix import builder as builder_module
+from sbomnix import derivation as derivation_module
+from sbomnix.builder import SbomBuilder
+from sbomnix.closure import dependency_rows_to_dataframe
 from sbomnix.derivation import Derive
-from sbomnix.exporters import _drv_to_spdx_extrefs
+from sbomnix.exporters import (
+    _drv_to_spdx_extrefs,
+    build_cdx_document,
+    build_spdx_document,
+)
+from sbomnix.runtime import RuntimeClosure
+
+DRV_PATH = "/nix/store/0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-test.drv"
+OUT_PATH = "/nix/store/1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-test"
 
 
-def load_component(meta, name="bash-5.3p9", pname="bash", version="5.3p9"):
-    """Exercise the real JSON normalization and component reader together."""
-    path = "/nix/store/0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-test.drv"
-    payload = {
+def derivation_payload(meta, name="bash-5.3p9", pname="bash", version="5.3p9"):
+    """Return modern derivation JSON with an offline, dependency-free target."""
+    return {
         "version": 4,
         "derivations": {
-            path: {
+            DRV_PATH: {
                 "name": name,
                 "system": "aarch64-darwin",
-                "outputs": {
-                    "out": {"path": "/nix/store/1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-test"}
-                },
+                "outputs": {"out": {"path": OUT_PATH}},
+                "inputs": {"drvs": {}, "srcs": []},
                 "structuredAttrs": {"pname": pname, "version": version},
                 "meta": meta,
             }
         },
     }
-    info = parse_nix_derivation_show(json.dumps(payload))[path]
-    return Derive.from_nix_derivation_info(path, info)
+
+
+def load_component(meta, name="bash-5.3p9", pname="bash", version="5.3p9"):
+    """Exercise the real JSON normalization and component reader together."""
+    payload = derivation_payload(meta, name, pname, version)
+    info = parse_nix_derivation_show(json.dumps(payload))[DRV_PATH]
+    return Derive.from_nix_derivation_info(DRV_PATH, info)
+
+
+@pytest.mark.parametrize(
+    ("purl", "expected"),
+    [
+        ("pkg:github/NixOS/nixpkgs@v1.0", "pkg:github/nixos/nixpkgs@v1.0"),
+        (
+            "pkg:generic/repo?vcs_url=https://host/owner/repo@rev",
+            "pkg:generic/repo?vcs_url=https://host/owner/repo%40rev",
+        ),
+        (
+            "pkg:maven/org.Example/MyLibrary@ReleaseA",
+            "pkg:maven/org.Example/MyLibrary@ReleaseA",
+        ),
+    ],
+)
+def test_metadata_purl_is_normalized_by_package_type(purl, expected):
+    assert load_component({"identifiers": {"purl": purl}}).purl == expected
+
+
+@pytest.mark.parametrize("buildtime", [True, False])
+@pytest.mark.parametrize("include_meta", [True, False])
+@pytest.mark.parametrize("pname", ["bash", "source"])
+def test_metadata_policy_reaches_both_exporters(
+    monkeypatch, buildtime, include_meta, pname
+):
+    """Catch ignored opt-outs and PURLs lost in the production dataframe path."""
+    payload = derivation_payload(
+        {"identifiers": {"purl": "pkg:github/NixOS/nixpkgs@v1.0"}},
+        name="source" if pname == "source" else "bash-5.3p9",
+        pname=pname,
+    )
+    # Replace only external Nix operations; keep parsing, component assembly,
+    # metadata-source selection and both document exporters real.
+    monkeypatch.setattr(
+        derivation_module,
+        "exec_cmd",
+        lambda cmd, **_kwargs: subprocess.CompletedProcess(
+            cmd, 0, stdout=json.dumps(payload)
+        ),
+    )
+    monkeypatch.setattr(builder_module, "require_deriver", lambda _path: DRV_PATH)
+    monkeypatch.setattr(builder_module, "find_deriver", lambda _path: DRV_PATH)
+    monkeypatch.setattr(builder_module, "is_loadable_deriver_path", lambda _path: True)
+    monkeypatch.setattr(
+        builder_module,
+        "load_runtime_closure",
+        lambda _path: RuntimeClosure(
+            df_deps=dependency_rows_to_dataframe([]),
+            output_paths_by_drv={DRV_PATH: {OUT_PATH}},
+        ),
+    )
+    builder = SbomBuilder(
+        OUT_PATH,
+        buildtime=buildtime,
+        include_meta=include_meta,
+        include_cpe=False,
+    )
+    expected = "pkg:github/nixos/nixpkgs@v1.0"
+    if not include_meta:
+        expected = "" if pname == "source" else "pkg:nix/bash@5.3p9"
+    assert builder.df_sbomdb.iloc[0]["purl"] == expected
+    cdx = build_cdx_document(builder)
+    spdx = build_spdx_document(builder)
+    assert cdx["metadata"]["component"].get("purl", "") == expected
+    refs = spdx["packages"][0].get("externalRefs", [])
+    purls = [ref["referenceLocator"] for ref in refs if ref["referenceType"] == "purl"]
+    assert purls == ([expected] if expected else [])
 
 
 def test_explicit_attribute_identifier_overrides_reconstructed_name():
@@ -82,3 +166,42 @@ def test_missing_or_invalid_metadata_retains_existing_fallback(meta):
 
 def test_source_without_identifier_still_has_no_invented_purl():
     assert load_component({}, name="source", pname="source", version="").purl == ""
+
+
+@pytest.mark.parametrize(
+    "purl", ["pkg:github/example/project", "pkg:github/example/project@release-tag"]
+)
+def test_explicit_identifier_version_is_not_replaced_with_derivation_version(purl):
+    drv = load_component({"identifiers": {"purl": purl}})
+    assert drv.purl == purl
+    assert drv.version == "5.3p9"
+
+
+def test_plural_identifiers_alone_retain_existing_fallback():
+    drv = load_component(
+        {"identifiers": {"purls": ["pkg:github/example/project@release-tag"]}}
+    )
+    assert drv.purl == "pkg:nix/bash@5.3p9"
+
+
+@pytest.mark.parametrize("batch_fallback", [False, True])
+def test_single_derivation_load_honors_metadata_opt_out(monkeypatch, batch_fallback):
+    payload = derivation_payload(
+        {"identifiers": {"purl": "pkg:github/example/project@release-tag"}}
+    )
+    replies = [json.dumps(payload)]
+    if batch_fallback:
+        replies.insert(0, json.dumps({"version": 4, "derivations": {}}))
+    responses = iter(replies)
+    monkeypatch.setattr(
+        derivation_module,
+        "exec_cmd",
+        lambda cmd, **_kwargs: subprocess.CompletedProcess(
+            cmd, 0, stdout=next(responses)
+        ),
+    )
+    if batch_fallback:
+        drv = derivation_module.load_many([DRV_PATH], include_meta=False)[DRV_PATH]
+    else:
+        drv = derivation_module.load(DRV_PATH, None, include_meta=False)
+    assert drv.purl == "pkg:nix/bash@5.3p9"

--- a/tests/test_derivation_purl_metadata.py
+++ b/tests/test_derivation_purl_metadata.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2026 Tanishq Palandurkar
+# SPDX-License-Identifier: Apache-2.0
+
+"""Explicit derivation identifiers must take precedence over name heuristics."""
+
+import json
+
+import pytest
+
+from common.nix_utils import parse_nix_derivation_show
+from sbomnix.derivation import Derive
+from sbomnix.exporters import _drv_to_spdx_extrefs
+
+
+def load_component(meta, name="bash-5.3p9", pname="bash", version="5.3p9"):
+    """Exercise the real JSON normalization and component reader together."""
+    path = "/nix/store/0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-test.drv"
+    payload = {
+        "version": 4,
+        "derivations": {
+            path: {
+                "name": name,
+                "system": "aarch64-darwin",
+                "outputs": {
+                    "out": {"path": "/nix/store/1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-test"}
+                },
+                "structuredAttrs": {"pname": pname, "version": version},
+                "meta": meta,
+            }
+        },
+    }
+    info = parse_nix_derivation_show(json.dumps(payload))[path]
+    return Derive.from_nix_derivation_info(path, info)
+
+
+def test_explicit_attribute_identifier_overrides_reconstructed_name():
+    purl = "pkg:nix/nixpkgs/bashNonInteractive@5.3p9?output=out"
+    drv = load_component({"identifiers": {"purl": purl}})
+    assert drv.purl == purl
+    assert drv.pname == "bash"
+    assert drv.version == "5.3p9"
+
+
+def test_explicit_source_identifier_is_not_suppressed():
+    drv = load_component(
+        {"identifiers": {"purl": "pkg:github/example/project@v1.0"}},
+        name="source",
+        pname="source",
+        version="",
+    )
+    assert drv.purl == "pkg:github/example/project@v1.0"
+
+
+def test_spdx_reference_preserves_explicit_purl():
+    drv = load_component({"identifiers": {"purl": "pkg:nix/nixpkgs/bash@5.3p9"}})
+    assert _drv_to_spdx_extrefs(drv) == [
+        {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:nix/nixpkgs/bash@5.3p9",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "meta",
+    [
+        None,
+        {},
+        "bad",
+        {"identifiers": None},
+        {"identifiers": {}},
+        {"identifiers": {"purl": None}},
+        {"identifiers": {"purl": ""}},
+        {"identifiers": {"purl": 123}},
+        {"identifiers": {"purl": "not-a-purl"}},
+    ],
+)
+def test_missing_or_invalid_metadata_retains_existing_fallback(meta):
+    assert load_component(meta).purl == "pkg:nix/bash@5.3p9"
+
+
+def test_source_without_identifier_still_has_no_invented_purl():
+    assert load_component({}, name="source", pname="source", version="").purl == ""

--- a/tests/test_derivation_purl_metadata.py
+++ b/tests/test_derivation_purl_metadata.py
@@ -164,6 +164,21 @@ def test_missing_or_invalid_metadata_retains_existing_fallback(meta):
     assert load_component(meta).purl == "pkg:nix/bash@5.3p9"
 
 
+def test_invalid_metadata_purl_is_not_disclosed_in_logs(caplog):
+    marker = "example-private-marker"
+    purl = f"pkg:generic/?vcs_url=https://example.invalid/repo?token={marker}"
+    with caplog.at_level(derivation_module.LOG_SPAM, logger=derivation_module.LOG.name):
+        result = derivation_module._metadata_purl({"identifiers": {"purl": purl}})
+
+    assert result == ""
+    assert any(
+        record.levelname == "WARNING" and "meta.identifiers.purl" in record.message
+        for record in caplog.records
+    )
+    assert purl not in caplog.text
+    assert marker not in caplog.text
+
+
 def test_source_without_identifier_still_has_no_invented_purl():
     assert load_component({}, name="source", pname="source", version="").purl == ""
 


### PR DESCRIPTION
### Background

As part of GSoC, I'm adding Package URLs (PURLs) to nixpkgs package metadata. The aim is to let package authors declare identifiers alongside package definitions, rather than leave SBOM tools to reconstruct them from names and versions.

Robert Hensing's experimental [Nix #16285](https://github.com/NixOS/nix/pull/16285) and [nixpkgs #466932](https://github.com/NixOS/nixpkgs/pull/466932) make this metadata available through `nix derivation show` JSON. sbomnix's derivation reader currently ignores it and generates a PURL from the package name and version, losing details such as the declared namespace. For example, in our local coreutils experiment:

```text
Derivation metadata: pkg:nix/nixpkgs/coreutils@9.11
Current sbomnix:     pkg:nix/coreutils@9.11
With this patch:    pkg:nix/nixpkgs/coreutils@9.11
```

### Change and compatibility

Prefer `meta.identifiers.purl` when present and parseable, normalized using `packageurl-python`'s package-type rules. Missing or malformed metadata falls back to the existing heuristic, so ordinary Nix users retain today's behavior. `--exclude-meta` disables the override for both runtime and build-time SBOMs, retaining the same fallback. Dependency discovery and the exporters are unchanged.

This trusts the metadata author for package identity: parsing checks the PURL's syntax, not whether it identifies the right package. A parseable but incorrect PURL will still be accepted. The improvement is preserving declared identifiers, not guaranteeing their correctness.

### Verification

- `./scripts/check-fast.sh` passed on `aarch64-darwin`: **493 tests passed, 1 skipped** (opt-in real-vulnix test), including all 29 PURL cases. These cover normalization, metadata opt-out in both closure modes, and the production dataframe path into both exporters. Code-quality checks and flake evaluation passed.
- Commit message passes the project's `gitlint` rules; DCO sign-off retained.
- Real `aarch64-darwin` stdenv build-time SBOM: exact metadata matches improve from **0/14 to 14/14**.
- Both SPDX 2.3 documents validate against the JSON schema, with **495 packages and 2,483 dependency relationships unchanged**.
- Review follow-up: replaying the captured real derivation JSON through the updated builder and both exporters preserves those counts. Metadata enabled matches the normalized explicit identifiers; metadata excluded matches the original heuristic SBOM. Both replayed SPDX documents validate. This is a saved-graph replay, not a fresh Nix evaluation.
- The 14 common-PATH output paths and stdenv output path are unchanged with metadata transport enabled. This metadata comparison required no package builds.

### Draft scope

The SBOM experiment used Robert's Nix build, a backport of his nixpkgs patch, and my 14 common-PATH PURL additions. This remains draft while the metadata interface is experimental. Only the primary `purl` is read, not the full `purls` list. Full CI and end-to-end stdenv runtime-closure verification remain pending.

AI assistance: Codex helped implement the patch, tests, and local verification.
